### PR TITLE
feat: implement role-based access control (RBAC)

### DIFF
--- a/alembic/versions/7f8a9b0c1d2e_merge_record_and_user_role_branches.py
+++ b/alembic/versions/7f8a9b0c1d2e_merge_record_and_user_role_branches.py
@@ -1,0 +1,26 @@
+"""merge record and user role branches
+
+Revision ID: 7f8a9b0c1d2e
+Revises: 19e2aefe5b17, e5f6a7b8c9d0
+Create Date: 2026-05-19 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7f8a9b0c1d2e'
+down_revision: Union[str, Sequence[str], None] = ('19e2aefe5b17', 'e5f6a7b8c9d0')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/alembic/versions/d4e5f6a7b8c9_add_role_column_to_users_table.py
+++ b/alembic/versions/d4e5f6a7b8c9_add_role_column_to_users_table.py
@@ -1,0 +1,32 @@
+"""add role column to users table
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-05-15 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd4e5f6a7b8c9'
+down_revision: Union[str, None] = 'c3d4e5f6a7b8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add role column to users table
+    # server_default fills existing rows; nullable=False is safe with it present
+    op.add_column(
+        'users',
+        sa.Column('role', sa.String(50), nullable=False, server_default='reviewer')
+    )
+
+
+def downgrade() -> None:
+    # Remove role column from users table
+    op.drop_column('users', 'role')

--- a/alembic/versions/e5f6a7b8c9d0_rename_contributor_role_to_operator.py
+++ b/alembic/versions/e5f6a7b8c9d0_rename_contributor_role_to_operator.py
@@ -1,0 +1,26 @@
+"""rename contributor role to operator
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-05-15 14:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e5f6a7b8c9d0'
+down_revision: Union[str, None] = 'd4e5f6a7b8c9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE users SET role = 'operator' WHERE role = 'contributor'")
+
+
+def downgrade() -> None:
+    op.execute("UPDATE users SET role = 'contributor' WHERE role = 'operator'")

--- a/app/api/API_spec.yaml
+++ b/app/api/API_spec.yaml
@@ -1,0 +1,1863 @@
+openapi: 3.0.3
+info:
+  title: Digitization Toolkit Backend API
+  description: |
+    API for the Digitization Toolkit - an open-source, modular digitization platform
+    for capturing, managing, and organizing archival materials using Raspberry Pi and 64MP ArduCam cameras.
+    
+    The API provides endpoints for:
+    - User authentication and account management
+    - Project and collection management
+    - Record (document/archival object) metadata management
+    - Image capture control and processing
+    - Camera device discovery and calibration
+    - System monitoring
+  version: 1.0.0
+  contact:
+    name: UCSB AMP Lab
+    url: https://github.com/UCSB-AMPLab/digitization-toolkit-backend
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+
+servers:
+  - url: http://localhost:8000
+    description: Development server
+  - url: http://localhost:3000
+    description: Production server (frontend proxy)
+
+tags:
+  - name: auth
+    description: User authentication and account management
+  - name: records
+    description: Archival record (document/object) management
+  - name: projects
+    description: Project management and organization
+  - name: collections
+    description: Collection and subcollection hierarchy
+  - name: cameras
+    description: Camera device control and image capture
+  - name: system
+    description: System information and monitoring
+
+paths:
+  /health:
+    get:
+      summary: Health check endpoint
+      operationId: health_check
+      tags:
+        - system
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+
+  # ============================================================================
+  # Authentication Endpoints
+  # ============================================================================
+
+  /auth/register:
+    post:
+      summary: Register a new user
+      operationId: register_user
+      tags:
+        - auth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserCreate'
+      responses:
+        '200':
+          description: User successfully registered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserRead'
+        '409':
+          description: Username or email already exists
+
+  /auth/login:
+    post:
+      summary: Login and get access token
+      operationId: login_user
+      tags:
+        - auth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserLogin'
+      responses:
+        '200':
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  access_token:
+                    type: string
+                    description: JWT token for authentication
+                  token_type:
+                    type: string
+                    example: bearer
+        '401':
+          description: Invalid credentials
+        '403':
+          description: User is inactive
+
+  /auth/refresh:
+    post:
+      summary: Refresh access token
+      operationId: refresh_token
+      tags:
+        - auth
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Token refreshed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenRefresh'
+        '401':
+          description: Invalid or expired token
+
+  /auth/password-reset:
+    post:
+      summary: Reset user password
+      operationId: reset_password
+      tags:
+        - auth
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordReset'
+      responses:
+        '200':
+          description: Password reset successful
+        '401':
+          description: Invalid credentials or token
+
+  /auth/{user_id}:
+    delete:
+      summary: Delete user account
+      operationId: delete_user
+      tags:
+        - auth
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: User deleted successfully
+        '403':
+          description: Not authorized to delete this user
+        '404':
+          description: User not found
+
+  # ============================================================================
+  # Project Endpoints
+  # ============================================================================
+
+  /projects:
+    post:
+      summary: Create a new project
+      operationId: create_project
+      tags:
+        - projects
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectCreate'
+      responses:
+        '200':
+          description: Project created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectRead'
+        '409':
+          description: Project with this name already exists
+
+    get:
+      summary: List all projects
+      operationId: list_projects
+      tags:
+        - projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: skip
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+      responses:
+        '200':
+          description: List of projects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProjectRead'
+
+  /projects/{project_id}:
+    get:
+      summary: Get a specific project
+      operationId: get_project
+      tags:
+        - projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Project details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectRead'
+        '404':
+          description: Project not found
+
+    put:
+      summary: Update a project
+      operationId: update_project
+      tags:
+        - projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectUpdate'
+      responses:
+        '200':
+          description: Project updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectRead'
+        '404':
+          description: Project not found
+        '409':
+          description: Project with this name already exists
+
+    delete:
+      summary: Delete a project
+      operationId: delete_project
+      tags:
+        - projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Project deleted successfully
+        '404':
+          description: Project not found
+
+  /projects/{project_id}/initialize:
+    post:
+      summary: Initialize project filesystem
+      operationId: initialize_project_filesystem
+      tags:
+        - projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectInitRequest'
+      responses:
+        '200':
+          description: Project filesystem initialized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectInitResponse'
+        '404':
+          description: Project not found
+
+  /projects/{project_id}/records:
+    get:
+      summary: List records in a project
+      operationId: list_project_records
+      tags:
+        - projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: skip
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+      responses:
+        '200':
+          description: List of records in project
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RecordRead'
+        '404':
+          description: Project not found
+
+  /projects/{project_id}/add_record/{rec_id}:
+    post:
+      summary: Add a record to a project
+      operationId: add_record_to_project
+      tags:
+        - projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: rec_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Record added to project
+        '404':
+          description: Project or record not found
+
+  /projects/{project_id}/remove_record/{rec_id}:
+    post:
+      summary: Remove a record from a project
+      operationId: remove_record_from_project
+      tags:
+        - projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: rec_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Record removed from project
+        '404':
+          description: Project or record not found
+
+  # ============================================================================
+  # Collection Endpoints
+  # ============================================================================
+
+  /collections:
+    post:
+      summary: Create a new collection
+      operationId: create_collection
+      tags:
+        - collections
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectionCreate'
+      responses:
+        '201':
+          description: Collection created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectionRead'
+        '400':
+          description: Invalid parent specification
+        '404':
+          description: Parent project or collection not found
+
+    get:
+      summary: List collections
+      operationId: list_collections
+      tags:
+        - collections
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: project_id
+          in: query
+          schema:
+            type: integer
+          description: Filter by project
+        - name: parent_collection_id
+          in: query
+          schema:
+            type: integer
+          description: Filter by parent collection
+        - name: skip
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+      responses:
+        '200':
+          description: List of collections
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CollectionRead'
+
+  /collections/{collection_id}:
+    get:
+      summary: Get a specific collection
+      operationId: get_collection
+      tags:
+        - collections
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: collection_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Collection details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectionRead'
+        '404':
+          description: Collection not found
+
+    patch:
+      summary: Update a collection
+      operationId: update_collection
+      tags:
+        - collections
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: collection_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectionUpdate'
+      responses:
+        '200':
+          description: Collection updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectionRead'
+        '400':
+          description: Invalid update (e.g., circular hierarchy)
+        '404':
+          description: Collection not found
+
+    delete:
+      summary: Delete a collection
+      operationId: delete_collection
+      tags:
+        - collections
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: collection_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Collection deleted successfully
+        '404':
+          description: Collection not found
+
+  /collections/{collection_id}/hierarchy:
+    get:
+      summary: Get collection with full hierarchy tree
+      operationId: get_collection_hierarchy
+      tags:
+        - collections
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: collection_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Collection with nested children
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectionWithChildren'
+        '404':
+          description: Collection not found
+
+  # ============================================================================
+  # Record Endpoints
+  # ============================================================================
+
+  /records:
+    post:
+      summary: Create a new record
+      operationId: create_record
+      tags:
+        - records
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordCreate'
+      responses:
+        '200':
+          description: Record created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordRead'
+        '409':
+          description: Database integrity error
+
+    get:
+      summary: List all records with optional filtering
+      operationId: list_records
+      tags:
+        - records
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: skip
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+        - name: project_id
+          in: query
+          schema:
+            type: integer
+          description: Filter by project ID
+        - name: collection_id
+          in: query
+          schema:
+            type: integer
+          description: Filter by collection ID
+        - name: object_typology
+          in: query
+          schema:
+            type: string
+          description: Filter by object type
+        - name: orphaned
+          in: query
+          schema:
+            type: boolean
+          description: Return only records with no project or collection
+      responses:
+        '200':
+          description: List of records
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RecordRead'
+
+  /records/{rec_id}:
+    get:
+      summary: Get a specific record with all images
+      operationId: get_record
+      tags:
+        - records
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: rec_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Record details with images
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordRead'
+        '404':
+          description: Record not found
+
+    patch:
+      summary: Update record metadata
+      operationId: update_record
+      tags:
+        - records
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: rec_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordUpdate'
+      responses:
+        '200':
+          description: Record updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordRead'
+        '404':
+          description: Record not found
+
+    delete:
+      summary: Delete a record and all images
+      operationId: delete_record
+      tags:
+        - records
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: rec_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Record deleted successfully
+        '404':
+          description: Record not found
+
+  /records/{rec_id}/images:
+    post:
+      summary: Upload and attach an image to a record
+      operationId: add_image_to_record
+      tags:
+        - records
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: rec_id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: capture_id
+          in: query
+          schema:
+            type: string
+          description: Capture event identifier
+        - name: pair_id
+          in: query
+          schema:
+            type: string
+          description: Pair identifier for dual captures
+        - name: sequence
+          in: query
+          schema:
+            type: integer
+          description: Page number or order in sequence
+        - name: role
+          in: query
+          schema:
+            type: string
+          description: Role of image (e.g., 'left', 'right', 'single')
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+              required:
+                - file
+      responses:
+        '200':
+          description: Image uploaded and attached successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordImageRead'
+        '400':
+          description: Invalid file type
+        '404':
+          description: Record not found
+        '500':
+          description: Failed to save file
+
+    get:
+      summary: List all images for a record
+      operationId: list_record_images
+      tags:
+        - records
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: rec_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: List of images ordered by sequence
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RecordImageRead'
+        '404':
+          description: Record not found
+
+  /records/images/{img_id}:
+    get:
+      summary: Get details about a specific image
+      operationId: get_image
+      tags:
+        - records
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: img_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Image details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordImageRead'
+        '404':
+          description: Image not found
+
+    patch:
+      summary: Update image metadata
+      operationId: update_image
+      tags:
+        - records
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: img_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordImageUpdate'
+      responses:
+        '200':
+          description: Image updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordImageRead'
+        '404':
+          description: Image not found
+
+    delete:
+      summary: Delete an image from a record
+      operationId: delete_image
+      tags:
+        - records
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: img_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Image deleted successfully
+        '404':
+          description: Image not found
+
+  /records/images/{img_id}/file:
+    get:
+      summary: Download the actual image file
+      operationId: download_image_file
+      tags:
+        - records
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: img_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Image file
+          content:
+            image/jpeg: {}
+            image/png: {}
+            image/tiff: {}
+            image/webp: {}
+        '404':
+          description: Image or file not found
+
+  /records/images/{img_id}/thumbnail:
+    get:
+      summary: Download thumbnail for an image
+      operationId: get_image_thumbnail
+      tags:
+        - records
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: img_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Thumbnail image (JPEG)
+          content:
+            image/jpeg: {}
+        '404':
+          description: Thumbnail could not be generated
+
+  # ============================================================================
+  # Camera Endpoints
+  # ============================================================================
+
+  /cameras/devices:
+    get:
+      summary: List available camera devices
+      operationId: list_camera_devices
+      tags:
+        - cameras
+      responses:
+        '200':
+          description: List of detected camera devices
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DeviceInfo'
+
+  /cameras/capture:
+    post:
+      summary: Trigger single image capture
+      operationId: trigger_capture
+      tags:
+        - cameras
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaptureRequest'
+      responses:
+        '200':
+          description: Capture successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaptureResponse'
+        '404':
+          description: Camera not connected or record not found
+
+  /cameras/capture/dual:
+    post:
+      summary: Trigger simultaneous dual camera capture
+      operationId: trigger_dual_capture
+      tags:
+        - cameras
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DualCaptureRequest'
+      responses:
+        '200':
+          description: Dual capture successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CaptureResponse'
+        '404':
+          description: Camera not connected or record not found
+
+  /cameras/calibrate:
+    post:
+      summary: Run autofocus calibration on camera
+      operationId: calibrate_camera
+      tags:
+        - cameras
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalibrationRequest'
+      responses:
+        '200':
+          description: Calibration completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalibrationResponse'
+
+  /cameras/calibrate/white-balance:
+    post:
+      summary: Calibrate white balance for consistent color reproduction
+      operationId: calibrate_white_balance
+      tags:
+        - cameras
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WhiteBalanceCalibrationRequest'
+      responses:
+        '200':
+          description: White balance calibration completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WhiteBalanceCalibrationResponse'
+
+  /cameras:
+    post:
+      summary: Create camera settings record
+      operationId: create_camera_settings
+      tags:
+        - cameras
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CameraSettingsCreate'
+      responses:
+        '200':
+          description: Camera settings created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CameraSettingsRead'
+        '404':
+          description: Record image not found
+        '409':
+          description: Camera settings already exist
+
+    get:
+      summary: List camera settings
+      operationId: list_camera_settings
+      tags:
+        - cameras
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: skip
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 100
+      responses:
+        '200':
+          description: List of camera settings
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CameraSettingsRead'
+
+  /cameras/{id}:
+    get:
+      summary: Get camera settings by ID
+      operationId: get_camera_settings
+      tags:
+        - cameras
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Camera settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CameraSettingsRead'
+        '404':
+          description: Camera settings not found
+
+  /cameras/settings/{id}:
+    put:
+      summary: Update camera settings
+      operationId: update_camera_settings
+      tags:
+        - cameras
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CameraSettingsUpdate'
+      responses:
+        '200':
+          description: Camera settings updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CameraSettingsRead'
+        '404':
+          description: Camera settings not found
+
+    delete:
+      summary: Delete camera settings
+      operationId: delete_camera_settings
+      tags:
+        - cameras
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Camera settings deleted
+        '404':
+          description: Camera settings not found
+
+  # ============================================================================
+  # System Endpoints
+  # ============================================================================
+
+  /system/temperature:
+    get:
+      summary: Get Raspberry Pi CPU temperature
+      operationId: get_temperature
+      tags:
+        - system
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: System temperature information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  temperature:
+                    type: number
+                    format: float
+                    nullable: true
+                    description: CPU temperature in Celsius
+                  unit:
+                    type: string
+                    example: C
+                  available:
+                    type: boolean
+                    description: Whether temperature reading is available
+
+components:
+  schemas:
+    # User Schemas
+    UserCreate:
+      type: object
+      required:
+        - username
+        - email
+        - password
+      properties:
+        username:
+          type: string
+          example: johndoe
+        email:
+          type: string
+          format: email
+          example: john@example.com
+        password:
+          type: string
+          format: password
+          example: securepassword123
+
+    UserLogin:
+      type: object
+      required:
+        - username
+        - password
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+          format: password
+
+    UserRead:
+      type: object
+      properties:
+        id:
+          type: integer
+        username:
+          type: string
+        email:
+          type: string
+          format: email
+        is_active:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+
+    PasswordReset:
+      type: object
+      required:
+        - old_password
+        - new_password
+      properties:
+        old_password:
+          type: string
+          format: password
+        new_password:
+          type: string
+          format: password
+
+    TokenRefresh:
+      type: object
+      properties:
+        access_token:
+          type: string
+        token_type:
+          type: string
+          example: bearer
+
+    # Project Schemas
+    ProjectCreate:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          example: Ancient Manuscripts 2025
+        description:
+          type: string
+          nullable: true
+        created_by:
+          type: string
+          nullable: true
+
+    ProjectUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+
+    ProjectRead:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        created_by:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+
+    ProjectInitRequest:
+      type: object
+      properties:
+        resolution:
+          type: string
+          enum: [low, medium, high]
+          default: high
+
+    ProjectInitResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        project_path:
+          type: string
+          nullable: true
+        error:
+          type: string
+          nullable: true
+
+    # Collection Schemas
+    CollectionCreate:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        collection_type:
+          type: string
+          example: series
+        archival_metadata:
+          type: object
+          nullable: true
+        project_id:
+          type: integer
+          nullable: true
+        parent_collection_id:
+          type: integer
+          nullable: true
+        created_by:
+          type: string
+          nullable: true
+
+    CollectionUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        collection_type:
+          type: string
+        archival_metadata:
+          type: object
+        parent_collection_id:
+          type: integer
+          nullable: true
+
+    CollectionRead:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        collection_type:
+          type: string
+        archival_metadata:
+          type: object
+        project_id:
+          type: integer
+          nullable: true
+        parent_collection_id:
+          type: integer
+          nullable: true
+        created_by:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+
+    CollectionWithChildren:
+      allOf:
+        - $ref: '#/components/schemas/CollectionRead'
+        - type: object
+          properties:
+            child_collections:
+              type: array
+              items:
+                $ref: '#/components/schemas/CollectionWithChildren'
+            record_count:
+              type: integer
+
+    # Record Schemas
+    RecordCreate:
+      type: object
+      required:
+        - title
+      properties:
+        title:
+          type: string
+          example: First Edition Map of California
+        description:
+          type: string
+          nullable: true
+        object_typology:
+          type: string
+          example: map
+        author:
+          type: string
+          nullable: true
+        material:
+          type: string
+          nullable: true
+          example: paper
+        date:
+          type: string
+          nullable: true
+        custom_attributes:
+          type: object
+          nullable: true
+        project_id:
+          type: integer
+          nullable: true
+        collection_id:
+          type: integer
+          nullable: true
+        created_by:
+          type: string
+          nullable: true
+
+    RecordUpdate:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        object_typology:
+          type: string
+        author:
+          type: string
+        material:
+          type: string
+        date:
+          type: string
+        custom_attributes:
+          type: object
+
+    RecordRead:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        description:
+          type: string
+          nullable: true
+        object_typology:
+          type: string
+        author:
+          type: string
+          nullable: true
+        material:
+          type: string
+          nullable: true
+        date:
+          type: string
+          nullable: true
+        custom_attributes:
+          type: object
+        project_id:
+          type: integer
+          nullable: true
+        collection_id:
+          type: integer
+          nullable: true
+        created_by:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        images:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecordImageRead'
+
+    RecordImageCreate:
+      type: object
+      properties:
+        filename:
+          type: string
+        capture_id:
+          type: string
+          nullable: true
+        pair_id:
+          type: string
+          nullable: true
+        sequence:
+          type: integer
+          nullable: true
+        role:
+          type: string
+          nullable: true
+
+    RecordImageUpdate:
+      type: object
+      properties:
+        sequence:
+          type: integer
+          nullable: true
+        role:
+          type: string
+          nullable: true
+
+    RecordImageRead:
+      type: object
+      properties:
+        id:
+          type: integer
+        record_id:
+          type: integer
+        filename:
+          type: string
+        file_path:
+          type: string
+        thumbnail_path:
+          type: string
+          nullable: true
+        file_size:
+          type: integer
+        format:
+          type: string
+          example: jpg
+        resolution_width:
+          type: integer
+          nullable: true
+        resolution_height:
+          type: integer
+          nullable: true
+        capture_id:
+          type: string
+          nullable: true
+        pair_id:
+          type: string
+          nullable: true
+        sequence:
+          type: integer
+          nullable: true
+        role:
+          type: string
+          nullable: true
+        uploaded_by:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+
+    # Camera Schemas
+    DeviceInfo:
+      type: object
+      properties:
+        hardware_id:
+          type: string
+          example: imx519_d19
+        model:
+          type: string
+          example: IMX519
+        index:
+          type: integer
+          example: 0
+        location:
+          type: string
+          nullable: true
+        machine_id:
+          type: string
+          nullable: true
+        label:
+          type: string
+          nullable: true
+        calibrated:
+          type: boolean
+
+    CaptureRequest:
+      type: object
+      required:
+        - project_name
+      properties:
+        project_name:
+          type: string
+          example: Ancient Manuscripts
+        camera_index:
+          type: integer
+          default: 0
+        resolution:
+          type: string
+          enum: [low, medium, high]
+          default: medium
+        include_resolution_in_filename:
+          type: boolean
+          default: false
+        record_id:
+          type: integer
+          nullable: true
+          description: Link to existing record, or create new if None
+        record_title:
+          type: string
+          nullable: true
+          description: Used if creating new record
+
+    DualCaptureRequest:
+      type: object
+      required:
+        - project_name
+      properties:
+        project_name:
+          type: string
+        resolution:
+          type: string
+          enum: [low, medium, high]
+          default: medium
+        include_resolution_in_filename:
+          type: boolean
+          default: false
+        stagger_ms:
+          type: integer
+          description: Milliseconds between camera triggers
+          default: 20
+        record_id:
+          type: integer
+          nullable: true
+        record_title:
+          type: string
+          nullable: true
+        sequence:
+          type: integer
+          nullable: true
+          description: Page number/order
+
+    CaptureResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        file_path:
+          type: string
+          nullable: true
+        file_paths:
+          type: array
+          items:
+            type: string
+          nullable: true
+        record_id:
+          type: integer
+          nullable: true
+        image_ids:
+          type: array
+          items:
+            type: integer
+          nullable: true
+        timing:
+          type: object
+          nullable: true
+        error:
+          type: string
+          nullable: true
+
+    CalibrationRequest:
+      type: object
+      properties:
+        camera_index:
+          type: integer
+          default: 0
+        resolution:
+          type: string
+          enum: [low, medium, high]
+          default: high
+
+    CalibrationResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        lens_position:
+          type: number
+          format: float
+          nullable: true
+        distance_meters:
+          type: number
+          format: float
+          nullable: true
+        af_time:
+          type: number
+          format: float
+          nullable: true
+        error:
+          type: string
+          nullable: true
+
+    WhiteBalanceCalibrationRequest:
+      type: object
+      properties:
+        camera_index:
+          type: integer
+          default: 0
+        resolution:
+          type: string
+          enum: [low, medium, high]
+          default: high
+        stabilization_frames:
+          type: integer
+          default: 30
+
+    WhiteBalanceCalibrationResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        awb_gains:
+          type: array
+          items:
+            type: number
+            format: float
+          nullable: true
+        colour_temperature:
+          type: integer
+          nullable: true
+        converged:
+          type: boolean
+          nullable: true
+        error:
+          type: string
+          nullable: true
+
+    CameraSettingsCreate:
+      type: object
+      required:
+        - record_image_id
+      properties:
+        record_image_id:
+          type: integer
+        camera_model:
+          type: string
+        iso:
+          type: integer
+          nullable: true
+        aperture:
+          type: number
+          nullable: true
+        focal_length:
+          type: number
+          nullable: true
+        white_balance:
+          type: string
+          nullable: true
+
+    CameraSettingsUpdate:
+      type: object
+      properties:
+        camera_model:
+          type: string
+        iso:
+          type: integer
+          nullable: true
+        aperture:
+          type: number
+          nullable: true
+        focal_length:
+          type: number
+          nullable: true
+        white_balance:
+          type: string
+          nullable: true
+
+    CameraSettingsRead:
+      type: object
+      properties:
+        id:
+          type: integer
+        record_image_id:
+          type: integer
+        camera_model:
+          type: string
+        iso:
+          type: integer
+          nullable: true
+        aperture:
+          type: number
+          nullable: true
+        focal_length:
+          type: number
+          nullable: true
+        white_balance:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT token obtained from /auth/login or /auth/register
+
+  responses:
+    NotFound:
+      description: Resource not found
+    Unauthorized:
+      description: Authentication required or failed
+    Forbidden:
+      description: User is not authorized to access this resource
+    Conflict:
+      description: Resource already exists or constraint violation

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,14 +1,15 @@
 from fastapi import APIRouter, Depends, HTTPException, Security, Query
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
-from typing import Optional
+from typing import List, Optional
 
 from app.api.deps import get_db_dependency
 from app.models.user import User
-from app.schemas.user import UserCreate, UserLogin, UserRead, PasswordReset, PasswordResetRequest, TokenRefresh
+from app.schemas.user import UserCreate, UserLogin, UserRead, UserRoleUpdate, PasswordReset, PasswordResetRequest, TokenRefresh
 from app.core.security import hash_password, verify_password, create_access_token, verify_access_token
 
 router = APIRouter()
+users_router = APIRouter()  # mounted at /users in main.py
 security = HTTPBearer()
 # auto_error=False so the dependency doesn't raise when header is absent
 # (allows falling back to ?token= query param for browser src= requests)
@@ -19,7 +20,18 @@ _optional_bearer = HTTPBearer(auto_error=False)
 def register(payload: UserCreate, db: Session = Depends(get_db_dependency)):
     if db.query(User).filter((User.username == payload.username) | (User.email == payload.email)).first():
         raise HTTPException(status_code=409, detail="Username or email already exists")
-    user = User(username=payload.username, email=payload.email, hashed_password=hash_password(payload.password))
+
+    # First user in the system becomes admin (bootstrap); all subsequent users are reviewers.
+    # Role is never taken from the request payload — use PATCH /auth/users/{id}/role to elevate.
+    is_first_user = db.query(User).count() == 0
+    role = "admin" if is_first_user else "reviewer"
+
+    user = User(
+        username=payload.username,
+        email=payload.email,
+        hashed_password=hash_password(payload.password),
+        role=role,
+    )
     db.add(user)
     db.commit()
     db.refresh(user)
@@ -61,15 +73,15 @@ def reset_password(
     token_payload = verify_access_token(token)
     if not token_payload:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
-    
+
     user_id = int(token_payload.get("sub"))
     user = db.query(User).filter(User.id == user_id).first()
     if not user:
         raise HTTPException(status_code=401, detail="User not found")
-    
+
     if not verify_password(payload.old_password, user.hashed_password):
         raise HTTPException(status_code=401, detail="Old password incorrect")
-    
+
     user.hashed_password = hash_password(payload.new_password)
     db.add(user)
     db.commit()
@@ -95,15 +107,107 @@ def get_current_user(
     return user
 
 
+class RoleChecker:
+    def __init__(self, allowed_roles: list[str]):
+        self.allowed_roles = allowed_roles
+
+    def __call__(self, user: User = Depends(get_current_user)):
+        if user.role not in self.allowed_roles:
+            raise HTTPException(status_code=403, detail="Operation not permitted")
+        return user
+
+
+# Role checkers
+allow_admin = RoleChecker(["admin"])
+allow_contributor = RoleChecker(["admin", "operator"])
+allow_read_only = RoleChecker(["admin", "operator", "reviewer"])
+
+
+# ---------------------------------------------------------------------------
+# /users/me — current authenticated user's profile
+# ---------------------------------------------------------------------------
+
+@users_router.get("/me", response_model=UserRead)
+def get_me(current_user: User = Depends(get_current_user)):
+    """Return the authenticated user's profile including their role."""
+    return UserRead.model_validate(current_user)
+
+
+# ---------------------------------------------------------------------------
+# User management (admin only)
+# ---------------------------------------------------------------------------
+
+@router.get("/users", response_model=List[UserRead])
+def list_users(
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=100, ge=1, le=1000),
+    current_user: User = Depends(allow_admin),
+    db: Session = Depends(get_db_dependency),
+):
+    """List all registered users. Admin only."""
+    users = db.query(User).offset(skip).limit(limit).all()
+    return [UserRead.model_validate(u) for u in users]
+
+
+@router.get("/users/{user_id}", response_model=UserRead)
+def get_user(
+    user_id: int,
+    current_user: User = Depends(allow_admin),
+    db: Session = Depends(get_db_dependency),
+):
+    """Get a user by ID. Admin only."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return UserRead.model_validate(user)
+
+
+@router.patch("/users/{user_id}/role", response_model=UserRead)
+def update_user_role(
+    user_id: int,
+    payload: UserRoleUpdate,
+    current_user: User = Depends(allow_admin),
+    db: Session = Depends(get_db_dependency),
+):
+    """Change a user's role. Admin only."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    if user.id == current_user.id:
+        raise HTTPException(status_code=400, detail="Admins cannot change their own role")
+    user.role = payload.role
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserRead.model_validate(user)
+
+
+@router.patch("/users/{user_id}/active", response_model=UserRead)
+def set_user_active(
+    user_id: int,
+    is_active: bool,
+    current_user: User = Depends(allow_admin),
+    db: Session = Depends(get_db_dependency),
+):
+    """Activate or deactivate a user account. Admin only."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    if user.id == current_user.id:
+        raise HTTPException(status_code=400, detail="Admins cannot deactivate their own account")
+    user.is_active = is_active
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserRead.model_validate(user)
+
+
 @router.delete("/{user_id}")
 def delete_user(
     user_id: int,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_admin),
     db: Session = Depends(get_db_dependency)
 ) -> dict:
-    
-    if current_user.id != user_id:
-        raise HTTPException(status_code=403, detail="Not authorized to delete this user")
     user = db.query(User).filter(User.id == user_id).first()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")

--- a/app/api/cameras.py
+++ b/app/api/cameras.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 import logging
 
 from app.api.deps import get_db_dependency
-from app.api.auth import get_current_user
+from app.api.auth import get_current_user, RoleChecker
 from app.models.camera import CameraSettings
 from app.models.user import User
 from app.schemas.camera import CameraSettingsCreate, CameraSettingsRead, CameraSettingsUpdate
@@ -15,6 +15,9 @@ from app.core.thumbnail import generate_thumbnail
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+allow_contributor = RoleChecker(["admin", "operator"])
+allow_read_only = RoleChecker(["admin", "operator", "reviewer"])
 
 
 class DeviceInfo(BaseModel):
@@ -105,7 +108,7 @@ def _get_camera_registry():
 
 
 @router.get("/devices", response_model=List[DeviceInfo])
-def list_camera_devices():
+def list_camera_devices(current_user: User = Depends(allow_read_only)):
 	"""
 	Return available camera devices detected via libcamera/picamera2.
 
@@ -153,7 +156,7 @@ def list_camera_devices():
 @router.post("/capture", response_model=CaptureResponse)
 def trigger_capture(
 	request: CaptureRequest,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_contributor),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""
@@ -309,7 +312,7 @@ def trigger_capture(
 @router.post("/capture/dual", response_model=CaptureResponse)
 def trigger_dual_capture(
 	request: DualCaptureRequest,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_contributor),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""
@@ -481,7 +484,7 @@ def trigger_dual_capture(
 @router.post("/calibrate", response_model=CalibrationResponse)
 def calibrate_camera(
 	request: CalibrationRequest,
-	current_user: User = Depends(get_current_user)
+	current_user: User = Depends(allow_contributor)
 ):
 	"""
 	Run autofocus calibration on a camera to find optimal lens position.
@@ -530,7 +533,7 @@ def calibrate_camera(
 @router.post("/calibrate/white-balance", response_model=WhiteBalanceCalibrationResponse)
 def calibrate_white_balance(
 	request: WhiteBalanceCalibrationRequest,
-	current_user: User = Depends(get_current_user)
+	current_user: User = Depends(allow_contributor)
 ):
 	"""
 	Calibrate white balance for consistent color reproduction.
@@ -580,7 +583,7 @@ def calibrate_white_balance(
 @router.post("/", response_model=CameraSettingsRead)
 def create_camera_settings(
 	payload: CameraSettingsCreate,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_contributor),
 	db: Session = Depends(get_db_dependency)
 ):
 	if not db.query(RecordImage).filter(RecordImage.id == payload.record_image_id).first():
@@ -601,7 +604,7 @@ def create_camera_settings(
 def list_camera_settings(
     skip: int = Query(default=0, ge=0),
     limit: int = Query(default=100, ge=1, le=1000),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_read_only),
     db: Session = Depends(get_db_dependency)
 ):
 	items = db.query(CameraSettings).offset(skip).limit(limit).all()
@@ -611,7 +614,7 @@ def list_camera_settings(
 @router.get("/{id}", response_model=CameraSettingsRead)
 def get_camera_settings(
 	id: int,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_read_only),
 	db: Session = Depends(get_db_dependency)
 ):
 	cs = db.query(CameraSettings).filter(CameraSettings.id == id).first()
@@ -624,7 +627,7 @@ def get_camera_settings(
 def update_camera_settings(
 	id: int,
 	payload: CameraSettingsUpdate,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_contributor),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""Update camera settings by ID."""
@@ -644,7 +647,7 @@ def update_camera_settings(
 @router.delete("/settings/{id}")
 def delete_camera_settings(
 	id: int,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_contributor),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""Delete camera settings by ID."""

--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -5,7 +5,7 @@ from sqlalchemy import select, func
 import logging
 
 from app.api.deps import get_db_dependency
-from app.api.auth import get_current_user
+from app.api.auth import get_current_user, RoleChecker
 from app.models.collection import Collection
 from app.models.project import Project
 from app.models.record import Record, RecordImage
@@ -15,11 +15,14 @@ from app.schemas.collection import CollectionCreate, CollectionRead, CollectionU
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+allow_contributor = RoleChecker(["admin", "operator"])
+allow_read_only = RoleChecker(["admin", "operator", "reviewer"])
+
 
 @router.post("/", response_model=CollectionRead, status_code=201)
 def create_collection(
     payload: CollectionCreate,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_contributor),
     db: Session = Depends(get_db_dependency)
 ):
     """
@@ -67,7 +70,7 @@ def list_collections(
     parent_collection_id: Optional[int] = Query(None, description="Filter by parent collection (use 'null' for top-level)"),
     skip: int = Query(default=0, ge=0),
     limit: int = Query(default=100, ge=1, le=1000),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_read_only),
     db: Session = Depends(get_db_dependency),
 ):
     """
@@ -92,7 +95,7 @@ def list_collections(
 @router.get("/{collection_id}", response_model=CollectionRead)
 def get_collection(
     collection_id: int,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_read_only),
     db: Session = Depends(get_db_dependency)
 ):
     """Get a specific collection by ID."""
@@ -105,7 +108,7 @@ def get_collection(
 @router.get("/{collection_id}/hierarchy", response_model=CollectionWithChildren)
 def get_collection_hierarchy(
     collection_id: int,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_read_only),
     db: Session = Depends(get_db_dependency)
 ):
     """
@@ -133,7 +136,7 @@ def get_collection_hierarchy(
 def update_collection(
     collection_id: int,
     payload: CollectionUpdate,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_contributor),
     db: Session = Depends(get_db_dependency)
 ):
     """
@@ -177,7 +180,7 @@ def update_collection(
 @router.delete("/{collection_id}", status_code=204)
 def delete_collection(
     collection_id: int,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_contributor),
     db: Session = Depends(get_db_dependency)
 ):
     """

--- a/app/api/projects.py
+++ b/app/api/projects.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 import logging
 
 from app.api.deps import get_db_dependency
-from app.api.auth import get_current_user
+from app.api.auth import get_current_user, RoleChecker
 from app.models.project import Project
 from app.models.record import Record, RecordImage
 from app.models.user import User
@@ -13,6 +13,11 @@ from app.schemas.project import ProjectCreate, ProjectRead, ProjectBase, Project
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+# Role checkers
+allow_admin = RoleChecker(["admin"])
+allow_contributor = RoleChecker(["admin", "operator"])
+allow_read_only = RoleChecker(["admin", "operator", "reviewer"])
 
 
 class ProjectInitRequest(BaseModel):
@@ -30,7 +35,7 @@ class ProjectInitResponse(BaseModel):
 @router.post("/", response_model=ProjectRead)
 def create_project(
     payload: ProjectCreate,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_contributor),
     db: Session = Depends(get_db_dependency)
 ):
     if db.query(Project).filter(Project.name == payload.name).first():
@@ -46,7 +51,7 @@ def create_project(
 def list_projects(
     skip: int = Query(default=0, ge=0),
     limit: int = Query(default=100, ge=1, le=1000),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_read_only),
     db: Session = Depends(get_db_dependency),
 ):
     items = db.query(Project).offset(skip).limit(limit).all()
@@ -56,7 +61,7 @@ def list_projects(
 @router.get("/{project_id}", response_model=ProjectRead)
 def get_project(
     project_id: int,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_read_only),
     db: Session = Depends(get_db_dependency)
 ):
     p = db.query(Project).filter(Project.id == project_id).first()
@@ -69,7 +74,7 @@ def get_project(
 def add_record_to_project(
     project_id: int,
     rec_id: int,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_contributor),
     db: Session = Depends(get_db_dependency)
 ):
     p = db.query(Project).filter(Project.id == project_id).first()
@@ -88,7 +93,7 @@ def add_record_to_project(
 def remove_record_from_project(
     project_id: int,
     rec_id: int,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_contributor),
     db: Session = Depends(get_db_dependency)
 ):
     p = db.query(Project).filter(Project.id == project_id).first()
@@ -107,7 +112,7 @@ def remove_record_from_project(
 def update_project(
     project_id: int,
     payload: ProjectUpdate,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_contributor),
     db: Session = Depends(get_db_dependency)
 ):
     """Update a project's details."""
@@ -133,7 +138,7 @@ def update_project(
 @router.delete("/{project_id}")
 def delete_project(
     project_id: int,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_contributor),
     db: Session = Depends(get_db_dependency)
 ):
     """
@@ -160,7 +165,7 @@ def delete_project(
 def initialize_project_filesystem(
     project_id: int,
     request: ProjectInitRequest,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_contributor),
     db: Session = Depends(get_db_dependency)
 ):
     """
@@ -201,7 +206,7 @@ def list_project_records(
     project_id: int,
     skip: int = Query(default=0, ge=0),
     limit: int = Query(default=100, ge=1, le=1000),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(allow_read_only),
     db: Session = Depends(get_db_dependency)
 ):
     """List all records associated with a project."""

--- a/app/api/records.py
+++ b/app/api/records.py
@@ -9,7 +9,7 @@ import uuid
 import logging
 
 from app.api.deps import get_db_dependency
-from app.api.auth import get_current_user
+from app.api.auth import get_current_user, RoleChecker
 from app.models.record import Record, RecordImage, ExifData
 from app.models.camera import CameraSettings
 from app.models.user import User
@@ -23,6 +23,9 @@ from app.core.thumbnail import generate_thumbnail, delete_thumbnail
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+allow_contributor = RoleChecker(["admin", "operator"])
+allow_read_only = RoleChecker(["admin", "operator", "reviewer"])
+
 
 # ==============================================================================
 # Record endpoints (archival documents/objects)
@@ -31,7 +34,7 @@ logger = logging.getLogger(__name__)
 @router.post("/", response_model=RecordRead)
 def create_record(
 	rec_in: RecordCreate,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_contributor),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""Create a new archival record (document/object like a book, map, document)."""
@@ -66,7 +69,7 @@ def list_records(
 	collection_id: Optional[int] = Query(default=None, description="Filter by collection ID"),
 	object_typology: Optional[str] = Query(default=None, description="Filter by object type"),
 	orphaned: Optional[bool] = Query(default=None, description="If true, return only records with no project or collection"),
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_read_only),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""List all records with optional filtering."""
@@ -89,7 +92,7 @@ def list_records(
 @router.get("/{rec_id}", response_model=RecordRead)
 def get_record(
 	rec_id: int,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_read_only),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""Get a specific record with all its images."""
@@ -103,7 +106,7 @@ def get_record(
 def update_record(
 	rec_id: int,
 	payload: RecordUpdate,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_contributor),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""Update a record's descriptive metadata."""
@@ -124,7 +127,7 @@ def update_record(
 @router.delete("/{rec_id}")
 def delete_record(
 	rec_id: int,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_contributor),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""Delete a record and all its associated images (CASCADE)."""
@@ -156,7 +159,7 @@ async def add_image_to_record(
 	pair_id: Optional[str] = None,
 	sequence: Optional[int] = None,
 	role: Optional[str] = None,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_contributor),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""
@@ -242,7 +245,7 @@ async def add_image_to_record(
 @router.get("/{rec_id}/images", response_model=List[RecordImageRead])
 def list_record_images(
 	rec_id: int,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_read_only),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""Get all images for a specific record, ordered by sequence."""
@@ -261,7 +264,7 @@ def list_record_images(
 @router.get("/images/{img_id}", response_model=RecordImageRead)
 def get_image(
 	img_id: int,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_read_only),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""Get details about a specific image."""
@@ -275,7 +278,7 @@ def get_image(
 def update_image(
 	img_id: int,
 	payload: RecordImageUpdate,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_contributor),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""Update image metadata (sequence, role, etc.)."""
@@ -295,7 +298,7 @@ def update_image(
 @router.delete("/images/{img_id}")
 def delete_image(
 	img_id: int,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_contributor),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""Delete a specific image from a record."""
@@ -317,7 +320,7 @@ def delete_image(
 @router.get("/images/{img_id}/file")
 def download_image_file(
 	img_id: int,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_read_only),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""Download the actual image file."""
@@ -354,7 +357,7 @@ def download_image_file(
 @router.get("/images/{img_id}/thumbnail")
 def get_image_thumbnail(
 	img_id: int,
-	current_user: User = Depends(get_current_user),
+	current_user: User = Depends(allow_read_only),
 	db: Session = Depends(get_db_dependency)
 ):
 	"""Download the thumbnail for an image. Generates it on demand if missing."""

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -3,14 +3,16 @@ import subprocess
 
 from fastapi import APIRouter, Depends
 
-from app.api.auth import get_current_user
+from app.api.auth import RoleChecker
 from app.models.user import User
+
+allow_read_only = RoleChecker(["admin", "operator", "reviewer"])
 
 router = APIRouter()
 
 
 @router.get("/temperature")
-def get_temperature(current_user: User = Depends(get_current_user)):
+def get_temperature(current_user: User = Depends(allow_read_only)):
     """Get Raspberry Pi CPU temperature via vcgencmd measure_temp.
 
     Returns temperature in Celsius, or available=False if vcgencmd is not

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -7,6 +7,7 @@ import base64
 import secrets
 from typing import Optional
 
+from fastapi import HTTPException
 
 SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-change-me")
 DEFAULT_EXPIRE_SECONDS = int(os.environ.get("ACCESS_TOKEN_EXPIRE_SECONDS", 3600))

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from app.api.records import router as records_router
 from app.api.cameras import router as cameras_router
 from app.api.projects import router as projects_router
 from app.api.collections import router as collections_router
-from app.api.auth import router as auth_router
+from app.api.auth import router as auth_router, users_router
 from app.api.system import router as system_router
 
 # Define lifespan event to initialize the database
@@ -37,6 +37,7 @@ app.include_router(cameras_router, prefix="/cameras", tags=["cameras"])
 app.include_router(projects_router, prefix="/projects", tags=["projects"])
 app.include_router(collections_router, prefix="/collections", tags=["collections"])
 app.include_router(auth_router, prefix="/auth", tags=["auth"])
+app.include_router(users_router, prefix="/users", tags=["users"])
 app.include_router(system_router, prefix="/system", tags=["system"])
 
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -11,5 +11,6 @@ class User(Base):
     username = Column(String(150), unique=True, index=True, nullable=False)
     email = Column(String(255), unique=True, index=True, nullable=False)
     hashed_password = Column(String(255), nullable=False)
+    role = Column(String(50), default="reviewer", nullable=False)  # admin, operator, reviewer
     is_active = Column(Boolean, default=True, nullable=False)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,14 +1,17 @@
-from typing import Optional
+from typing import Optional, Literal
 from pydantic import BaseModel, field_validator
 from datetime import datetime
 import re
+
+VALID_ROLES = ("admin", "operator", "reviewer")
 
 
 class UserCreate(BaseModel):
     username: str
     email: str
     password: str
-    
+    role: Literal["admin", "operator", "reviewer"] = "reviewer"
+
     @field_validator('email')
     @classmethod
     def validate_email(cls, v: str) -> str:
@@ -27,11 +30,16 @@ class UserRead(BaseModel):
     id: int
     username: str
     email: str
+    role: str
     is_active: bool
     created_at: Optional[datetime]
 
     class Config:
         from_attributes = True
+
+
+class UserRoleUpdate(BaseModel):
+    role: Literal["admin", "operator", "reviewer"]
 
 
 class PasswordReset(BaseModel):

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,18 +18,14 @@ addopts =
     --strict-markers
     --strict-config
     --showlocals
-    --tb=short
 
-# Test paths - all tests organized in tests/ directory
-testpaths = 
-    tests
-
-# Markers for organizing tests
+# Custom markers
 markers =
-    slow: marks tests as slow (deselect with '-m "not slow"')
-    integration: marks tests as integration tests
+    camera: tests that require camera hardware
+    integration: integration tests
+    slow: slow running tests
+    performance: performance tests
     unit: marks tests as unit tests
-    camera: marks tests that require camera hardware
     backend: marks tests for camera backends
 
 # Ignore paths

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,8 +140,14 @@ def skip_if_single_camera():
     """
     from capture import is_camera_connected
     
-    if not (is_camera_connected(0) and is_camera_connected(1)):
-        pytest.skip("Dual cameras not detected - skipping test")
+    try:
+        if not (is_camera_connected(0) and is_camera_connected(1)):
+            pytest.skip("Dual cameras not detected - skipping test")
+    except RuntimeError as e:
+        if "requires Linux" in str(e) or "Picamera2Backend" in str(e):
+            pytest.skip("Camera backend not available on this platform - skipping test")
+        else:
+            raise
 
 
 @pytest.fixture(params=["subprocess", "picamera2"])

--- a/tests/integration/test_capture_integration.py
+++ b/tests/integration/test_capture_integration.py
@@ -5,8 +5,15 @@ Tests the full flow: capture image -> save to microSD -> create database record.
 Run with: python -m pytest tests/integration/test_capture_integration.py
 """
 import pytest
+import sys
 from pathlib import Path
-from app.models.document import DocumentImage, ExifData
+
+# Skip on non-Linux platforms
+if sys.platform != 'linux':
+    pytest.skip("Integration tests require Linux/Raspberry Pi environment", allow_module_level=True)
+
+
+from app.models.record import Record, RecordImage, ExifData
 from app.models.camera import CameraSettings
 from app.models.project import Project
 
@@ -14,7 +21,7 @@ from app.models.project import Project
 @pytest.mark.integration
 def test_single_capture_creates_database_record(client, db_session, test_project):
     """
-    Test that /cameras/capture creates a DocumentImage record in database.
+    Test that /cameras/capture creates a RecordImage record in database.
     """
     # Ensure project exists
     project_name = test_project.name
@@ -38,16 +45,18 @@ def test_single_capture_creates_database_record(client, db_session, test_project
     assert data["file_path"] is not None
     
     # Verify database record was created
-    doc = db_session.query(DocumentImage).filter(
-        DocumentImage.file_path == data["file_path"]
+    doc = db_session.query(RecordImage).filter(
+        RecordImage.file_path == data["file_path"]
     ).first()
     
     assert doc is not None
-    assert doc.title is not None
     assert doc.format == "jpg"
     assert doc.resolution_width is not None
     assert doc.resolution_height is not None
-    assert doc.project_id == test_project.id
+    # Check that the record is linked to the project
+    record = db_session.query(Record).filter(Record.id == doc.record_id).first()
+    assert record is not None
+    assert record.project_id == test_project.id
     
     # Verify camera settings were saved
     cs = db_session.query(CameraSettings).filter(

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -119,9 +119,9 @@ def test_capture_performance(override_projects_root, skip_if_single_camera):
     # (hardware variations can affect timing)
     target_time = 5.0  # Conservative target
     if avg_time > target_time:
-        print(f"  ⚠ WARNING: Average time {avg_time:.2f}s exceeds target {target_time}s")
+        print(f" [WARN] WARNING: Average time {avg_time:.2f}s exceeds target {target_time}s")
     else:
-        print(f"  ✓ Performance good: under {target_time}s target")
+        print(f" [OK] Performance good: under {target_time}s target")
     
     # Verify times are reasonable (not failing completely)
     assert avg_time < 15.0, f"Capture too slow: {avg_time:.2f}s (expected < 15s)"

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -13,26 +13,44 @@ def test_imports():
     """Test that all modules can be imported without errors."""
     print("Testing imports...")
     try:
-        from app.core.db import Base, engine, init_db
         from app.core.config import settings
         from app.core.security import (
             hash_password, verify_password,
             create_access_token, verify_access_token
         )
-        from app.models.user import User
-        from app.models.project import Project
-        from app.models.document import DocumentImage, ExifData
-        from app.models.camera import CameraSettings
         from app.schemas.user import UserCreate, UserRead, PasswordReset
         from app.schemas.project import ProjectCreate, ProjectRead
-        from app.schemas.document import DocumentCreate, DocumentRead, DocumentUpdate
+        from app.schemas.record import RecordCreate, RecordRead, RecordUpdate
         from app.schemas.camera import CameraSettingsRead, CameraSettingsCreate
         from app.api.auth import router as auth_router, get_current_user
-        from app.api.documents import router as documents_router
+        from app.api.records import router as records_router
         from app.api.projects import router as projects_router
         from app.api.cameras import router as cameras_router
-        from app.main import app
-        print("✓ All imports successful")
+        
+        # Try importing app.main (may fail due to database)
+        try:
+            from app.main import app
+            print(" [OK] All imports successful")
+        except ImportError as app_e:
+            if "pq wrapper" in str(app_e) or "psycopg" in str(app_e):
+                print(" [OK] Core imports successful (app.main import skipped - database not available on this platform)")
+            else:
+                raise
+        
+        # Try database imports (may fail on non-Linux)
+        try:
+            from app.core.db import Base, engine, init_db
+            from app.models.user import User
+            from app.models.project import Project
+            from app.models.record import Record, RecordImage, ExifData
+            from app.models.camera import CameraSettings
+            print(" [OK] All imports successful (including database)")
+        except ImportError as db_e:
+            if "pq wrapper" in str(db_e) or "psycopg" in str(db_e):
+                print(" [OK] Core imports successful (database imports skipped - not available on this platform)")
+            else:
+                raise
+        
         return True
     except Exception as e:
         print(f"✗ Import failed: {e}")
@@ -51,7 +69,7 @@ def test_password_hashing():
         assert verify_password(password, hashed), "Password verification failed"
         assert not verify_password("wrong_password", hashed), "Wrong password should not verify"
         
-        print("✓ Password hashing works correctly")
+        print(" [OK] Password hashing works correctly")
         return True
     except Exception as e:
         print(f"✗ Password hashing test failed: {e}")
@@ -78,7 +96,7 @@ def test_token_generation():
         expired_payload = verify_access_token(expired_token)
         assert expired_payload is None, "Expired token should not verify"
         
-        print("✓ Token generation and verification works correctly")
+        print(" [OK] Token generation and verification works correctly")
         return True
     except Exception as e:
         print(f"✗ Token test failed: {e}")
@@ -91,7 +109,7 @@ def test_schemas():
     try:
         from app.schemas.user import UserCreate, PasswordReset
         from app.schemas.project import ProjectCreate
-        from app.schemas.document import DocumentCreate, DocumentUpdate
+        from app.schemas.record import RecordCreate, RecordUpdate
         
         # Test user creation
         user = UserCreate(username="testuser", email="test@example.com", password="pwd123")
@@ -101,11 +119,10 @@ def test_schemas():
         project = ProjectCreate(name="Test Project", description="A test project")
         assert project.name == "Test Project"
         
-        # Test document creation with typology
-        doc = DocumentCreate(
-            filename="test.jpg",
-            file_path="/path/to/test.jpg",
-            format="jpeg",
+        # Test record creation with typology
+        doc = RecordCreate(
+            title="Test Record",
+            description="A test record",
             object_typology="book",
             author="John Doe",
             material="paper",
@@ -114,15 +131,15 @@ def test_schemas():
         assert doc.object_typology == "book"
         assert doc.author == "John Doe"
         
-        # Test document update
-        doc_update = DocumentUpdate(
+        # Test record update
+        doc_update = RecordUpdate(
             title="Updated Title",
             object_typology="document",
             custom_attributes='{"custom": "value"}'
         )
         assert doc_update.title == "Updated Title"
         
-        print("✓ Schema validation works correctly")
+        print(" [OK] Schema validation works correctly")
         return True
     except Exception as e:
         print(f"✗ Schema test failed: {e}")
@@ -131,6 +148,9 @@ def test_schemas():
 
 def test_routes():
     """Test that all routes are registered."""
+    if sys.platform != 'linux':
+        pytest.skip("Route registration tests require Linux/Raspberry Pi environment")
+
     print("\nTesting route registration...")
     try:
         from app.main import app
@@ -143,17 +163,17 @@ def test_routes():
         assert "/auth/refresh" in routes, "Auth refresh route missing"
         assert "/auth/password-reset" in routes, "Auth password reset route missing"
         
-        # Check documents routes
-        assert "/documents/" in routes, "Documents list route missing"
-        assert "/documents/{doc_id}" in routes, "Documents get route missing"
-        assert "/documents/upload" in routes, "Documents upload route missing"
-        assert "/documents/{doc_id}/file" in routes, "Documents file download route missing"
+        # Check records routes
+        assert "/records/" in routes, "Records list route missing"
+        assert "/records/{record_id}" in routes, "Records get route missing"
+        assert "/records/upload" in routes, "Records upload route missing"
+        assert "/records/{record_id}/file" in routes, "Records file download route missing"
         
         # Check projects routes
         assert "/projects/" in routes, "Projects list route missing"
         assert "/projects/{project_id}" in routes, "Projects get route missing"
         assert "/projects/{project_id}/initialize" in routes, "Projects initialize route missing"
-        assert "/projects/{project_id}/documents" in routes, "Projects documents route missing"
+        assert "/projects/{project_id}/records" in routes, "Projects records route missing"
         
         # Check cameras routes
         assert "/cameras/" in routes, "Cameras list route missing"
@@ -167,7 +187,7 @@ def test_routes():
         # Check health route
         assert "/health" in routes, "Health check route missing"
         
-        print("✓ All required routes are registered")
+        print(" [OK] All required routes are registered")
         return True
     except AssertionError as e:
         print(f"✗ Route test failed: {e}")
@@ -179,12 +199,16 @@ def test_routes():
 
 def test_models():
     """Test that database models can be created."""
+    if sys.platform != 'linux':
+        pytest.skip("Model registration tests require Linux/Raspberry Pi environment")
+
     print("\nTesting model creation...")
     try:
         from app.core.db import Base, engine
         from app.models.user import User
         from app.models.project import Project
-        from app.models.document import DocumentImage
+        from app.models.record import Record, RecordImage
+        from app.models.camera import CameraSettings
         
         # Check that models are registered with Base
         table_names = {table.name for table in Base.metadata.tables.values()}
@@ -193,7 +217,7 @@ def test_models():
         assert "projects" in table_names, "Projects table not registered"
         assert "document_images" in table_names, "Document images table not registered"
         
-        print("✓ All models are properly registered")
+        print(" [OK] All models are properly registered")
         return True
     except AssertionError as e:
         print(f"✗ Model test failed: {e}")
@@ -223,7 +247,7 @@ def test_new_endpoints():
         assert partial_update.name is None
         assert partial_update.description == "Only description"
         
-        print("✓ New endpoint schemas work correctly")
+        print(" [OK] New endpoint schemas work correctly")
         return True
     except Exception as e:
         print(f"✗ New endpoint test failed: {e}")
@@ -233,6 +257,8 @@ def test_new_endpoints():
 @pytest.mark.unit
 def test_api_imports_pytest():
     """Pytest version of import test."""
+    if sys.platform != 'linux':
+        pytest.skip("Database imports not available on non-Linux platforms")
     assert test_imports()
 
 


### PR DESCRIPTION
## Changes

Implementation of a three-tier permission system to gate API routes by user role, required by the frontend auth flow
- CLOSES [FE PR #4](https://github.com/UCSB-AMPLab/digitization-toolkit-frontend/pull/4) and [FE issue #5](https://github.com/UCSB-AMPLab/digitization-toolkit-frontend/pull/4)

### User model and registration

- Add role column (admin | operator | reviewer); server_default = 'reviewer' ensures safe backfill of existing rows
- Bootstrap: first registered user becomes admin, all subsequent users become reviewer; role is never taken from the request payload

### Role enforcement

- Add RoleChecker dependency class for injection-based route gating (allow_admin, allow_contributor, allow_read_only)
- Gate all routes: operator for writes, reviewer for reads, admin-only for user management
- Apply role checks across all routers: records, cameras, collections, projects, system

### User management (admin-only)

New endpoints:

`GET /auth/users, GET /auth/users/{id}`: list and inspect users
`PATCH /auth/users/{id}/role`: promote or demote a user
`PATCH /auth/users/{id}/active`: activate or deactivate an account
`DELETE /auth/{id}`: remove a user

### Frontend auth flow

- `GET /users/me`: returns the current user's profile and role; frontend calls this after login to determine dashboard routing

Updated API and dev reference
- [Reference documentation](https://github.com/UCSB-AMPLab/digitization-toolkit-software/blob/e0b8d605c8a5cb3a0d38b5b855dc4360bef0e1f4/docs/developers/API_REFERENCE.md)
- [OpenAPI documentation ](https://github.com/UCSB-AMPLab/digitization-toolkit-backend/blob/efdfd7da1d62dfc006d9b2521b61df8776d68bae/app/api/API_spec.yaml)

### Tests

- Fix imports and markers

---

Edits:

- Add `role` column to User model (admin | operator | reviewer); server_default = 'reviewer' to safely backfill existing rows
- Bootstrap: first registered user becomes admin, all subsequent users become reviewer — role is never taken from request payload
- Rename contributor → operator throughout; add data migration (e5f6a7b8c9d0) to update existing rows
- Add RoleChecker dependency for injection-based role gating: allow_admin, allow_contributor (operator+), allow_read_only
- Gate all routes: operator+ for writes, reviewer+ for reads, admin-only for user management endpoints
- Add GET /users/me for frontend auth flow (returns role for dashboard routing)
- Add admin user management endpoints: list/get users, change role, activate/deactivate account, delete user
- Apply role checks to records, cameras, collections, projects, and system routers
- Fix test imports and markers


## Open question for @jairomelo @csalguero10

regarding one of the user typologies: should it be CONTRIBUTOR or OPERATOR? The role is that for all permissions except managing users and system configurations

Asking this because frontend is actually expecting "operator", but in PR# https://github.com/UCSB-AMPLab/digitization-toolkit-frontend/pull/4 I found "contributor", so I might align the backend on the expected value from the frontend 