### PR TITLE
fix: write capture manifest to the same sanitized path as images (fix…

### DIFF
--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -248,18 +248,15 @@ def delete_collection(
     db.commit()
 
     # Remove the collection directory from disk (project/collection/images/).
-    # Try both raw and sanitized names to handle historic inconsistencies.
+    # Images and manifest share the sanitized path, so one candidate covers both.
     if project_name:
-        safe_col = secure_project_filename(collection_name)
-        for proj_dir in [settings.projects_dir / project_name, settings.projects_dir / secure_project_filename(project_name)]:
-            for col_dir in ([proj_dir / collection_name] + ([proj_dir / safe_col] if safe_col != collection_name else [])):
-                if col_dir.exists() and col_dir.is_dir():
-                    try:
-                        shutil.rmtree(col_dir)
-                        logger.info(f"Removed collection directory: {col_dir}")
-                    except Exception as e:
-                        logger.warning(f"Could not remove collection directory {col_dir}: {e}")
-                    break
+        col_dir = settings.projects_dir / secure_project_filename(project_name) / secure_project_filename(collection_name)
+        if col_dir.exists() and col_dir.is_dir():
+            try:
+                shutil.rmtree(col_dir)
+                logger.info(f"Removed collection directory: {col_dir}")
+            except Exception as e:
+                logger.warning(f"Could not remove collection directory {col_dir}: {e}")
 
     return None
 

--- a/app/api/projects.py
+++ b/app/api/projects.py
@@ -216,22 +216,14 @@ def delete_project(
     log_event(db, level="WARN", category="activity", action="project_deleted",
               actor=current_user.username, subject=project_name)
 
-    # Remove the project directory from disk.
-    # Two candidate paths are tried because project_init() sanitizes the name
-    # (spaces → underscores) while capture_image() uses the raw name directly.
-    safe_name = secure_project_filename(project_name)
-    candidates = [settings.projects_dir / project_name]
-    if safe_name != project_name:
-        candidates.append(settings.projects_dir / safe_name)
 
-    for candidate in candidates:
-        if candidate.exists() and candidate.is_dir():
-            try:
-                shutil.rmtree(candidate)
-                logger.info(f"Removed project directory: {candidate}")
-            except Exception as e:
-                logger.warning(f"Could not remove project directory {candidate}: {e}")
-            break
+    project_dir = settings.projects_dir / secure_project_filename(project_name)
+    if project_dir.exists() and project_dir.is_dir():
+        try:
+            shutil.rmtree(project_dir)
+            logger.info(f"Removed project directory: {project_dir}")
+        except Exception as e:
+            logger.warning(f"Could not remove project directory {project_dir}: {e}")
 
     return {"detail": "project deleted"}
 

--- a/capture/manifestHandler.py
+++ b/capture/manifestHandler.py
@@ -113,6 +113,21 @@ class CaptureRecord:
 
 #### Helper functions ####
 
+def _relative_capture_path(file_path: Union[str, Path], project_root: Optional[Path]) -> str:
+    """Path of a captured file relative to the project root.
+
+    Keeps the manifest's paths in the same tree as the images (including any
+    collection subdir). Falls back to images/main/<name> when the file is not
+    under project_root.
+    """
+    p = Path(file_path)
+    if project_root is not None:
+        try:
+            return str(p.relative_to(project_root))
+        except ValueError:
+            pass
+    return str(Path("images/main") / p.name)
+
 def generate_manifest_project(
     project_name: str,
     paths: Dict[str, str] = None,
@@ -145,7 +160,8 @@ def generate_manifest_record(
     pair_id: str = None,
     stagger: int = None,
     roles: list = None,
-    metadata_list: list = None) -> CaptureRecord:
+    metadata_list: list = None,
+    project_root: Optional[Path] = None) -> CaptureRecord:
     """
     Generate a manifest record for single or dual captures.
     
@@ -183,18 +199,18 @@ def generate_manifest_record(
             # Add JPEG file
             files.append(CaptureFile(
                 role=role,
-                relative_path=str(Path("images/main") / Path(jpeg_path).name),
+                relative_path=_relative_capture_path(jpeg_path, project_root),
                 bytes=os.path.getsize(jpeg_path),
                 mimetype=f"image/{config.encoding}",
                 sha256=compute_sha256(jpeg_path)
             ))
-            
+
             # Add raw sensor data file
             # Note: Using .raw extension due to picamera2 DNG save bug
             # Contains compressed raw sensor data (Pi 5) or packed pixels (Pi 4)
             files.append(CaptureFile(
                 role=f"{role}_raw",
-                relative_path=str(Path("images/main") / Path(raw_path).name),
+                relative_path=_relative_capture_path(raw_path, project_root),
                 bytes=os.path.getsize(raw_path),
                 mimetype="application/octet-stream",  # Binary raw sensor data
                 sha256=compute_sha256(raw_path)
@@ -203,7 +219,7 @@ def generate_manifest_record(
             # Single format
             files.append(CaptureFile(
                 role=role,
-                relative_path=str(Path("images/main") / Path(path).name),
+                relative_path=_relative_capture_path(path, project_root),
                 bytes=os.path.getsize(path),
                 mimetype=f"image/{config.encoding}",
                 sha256=compute_sha256(path)

--- a/capture/project_manager.py
+++ b/capture/project_manager.py
@@ -30,6 +30,21 @@ def secure_project_filename(project_name):
     project_name = re.sub(r'[^a-zA-Z0-9._-]', '_', project_name)
     return project_name.lstrip('.').lower()
 
+
+def project_capture_root(project_name: str) -> Path:
+    """Project-level directory holding the manifest and all image subdirs.
+    Args:
+        project_name: Name of the project"""
+    return Path(PROJECTS_ROOT, secure_project_filename(project_name))
+
+
+def image_output_dir(project_name: str, collection_name: Optional[str] = None) -> Path:
+    """Directory where captured images are written for a project/collection."""
+    root = project_capture_root(project_name)
+    if collection_name:
+        root = root / secure_project_filename(collection_name)
+    return root / "images" / "main"
+
 def load_calibration_profile(camera_index: int, calibration_dir: Path = None) -> dict:
     """
     Load calibration profile for a camera.
@@ -133,7 +148,7 @@ def project_init(
         Path to the created project directory
     """
         
-    project_path = Path(PROJECTS_ROOT, secure_project_filename(project_name))
+    project_path = project_capture_root(project_name)
     packages_dir = Path(project_path, "packages")
     
     for path in [packages_dir]:

--- a/capture/service.py
+++ b/capture/service.py
@@ -33,7 +33,7 @@ from .utils import setup_rotating_logger
 from .camera import CameraConfig
 from .manifestHandler import generate_manifest_record, append_manifest_record
 from .backends import CameraBackend, RpicamBackend, Picamera2Backend, GPhoto2Backend
-from .project_manager import secure_project_filename
+from .project_manager import project_capture_root, image_output_dir
 
 from app.core.config import settings
 
@@ -219,10 +219,7 @@ def capture_image(
     if check_camera and not is_camera_connected(camera_config.camera_index):
         raise RuntimeError(f"Camera {camera_config.camera_index} is not connected.")
     
-    if collection_name:
-        project_path = PROJECTS_ROOT / secure_project_filename(project_name) / secure_project_filename(collection_name) / "images" / "main"
-    else:
-        project_path = PROJECTS_ROOT / secure_project_filename(project_name) / "images" / "main"
+    project_path = image_output_dir(project_name, collection_name)
     project_path.mkdir(parents=True, exist_ok=True)
     
     if not output_filename:
@@ -293,15 +290,16 @@ def single_capture_image(
     )
     
     elapsed_time = time.time() - start_time
-    
-    project_root = PROJECTS_ROOT / project_name
-    
+
+    project_root = project_capture_root(project_name)
+
     record = generate_manifest_record(
         project_name=project_name,
         img_paths=[output_path],
         cam_configs=[camera_config],
         times=[elapsed_time],
-        metadata_list=[metadata] if metadata else None
+        metadata_list=[metadata] if metadata else None,
+        project_root=project_root
     )
     append_manifest_record(project_root, record)
     
@@ -391,11 +389,11 @@ def dual_capture_image(
         img1_path, time1, metadata1 = future1.result()
         img2_path, time2, metadata2 = future2.result()
         
-    project_root = PROJECTS_ROOT / project_name
-    
+    project_root = project_capture_root(project_name)
+
     # Prepare metadata list (filter out None values)
     metadata_list = [m for m in [metadata1, metadata2] if m is not None]
-    
+
     record = generate_manifest_record(
         project_name=project_name,
         pair_id=timestamp_index,
@@ -403,7 +401,8 @@ def dual_capture_image(
         cam_configs=[cam1_config, cam2_config],
         times=[time1, time2],
         stagger=stagger_ms,
-        metadata_list=metadata_list if metadata_list else None
+        metadata_list=metadata_list if metadata_list else None,
+        project_root=project_root
     )
     append_manifest_record(project_root, record)
     

--- a/tests/unit/test_capture_manifest_paths.py
+++ b/tests/unit/test_capture_manifest_paths.py
@@ -1,0 +1,116 @@
+"""
+Tests that captured images and their sha256 provenance manifest land in the
+same sanitized directory tree, even when the project/collection name has
+capitals, spaces, or accents.
+"""
+
+import json
+import pytest
+
+
+class _StubConfig:
+    """Minimal stand-in for CameraConfig used by generate_manifest_record."""
+    encoding = "jpg"
+    camera_index = 0
+
+    def to_dict(self):
+        return {"camera_index": self.camera_index, "encoding": self.encoding}
+
+
+@pytest.fixture
+def projects_root(tmp_path, monkeypatch):
+    """Point the capture layout helpers at a temporary projects root."""
+    from capture import project_manager as pm
+    monkeypatch.setattr(pm, "PROJECTS_ROOT", tmp_path)
+    return tmp_path
+
+
+# ==============================================================================
+# Path layout helpers
+# ==============================================================================
+
+class TestLayoutHelpers:
+    def test_project_root_is_sanitized(self, projects_root):
+        from capture.project_manager import project_capture_root
+        root = project_capture_root("Río Negro Ñandú")
+        assert root == projects_root / "rio_negro_nandu"
+
+    def test_image_dir_sanitizes_project_and_collection(self, projects_root):
+        from capture.project_manager import image_output_dir
+        img_dir = image_output_dir("Río Negro Ñandú", "Caja 1")
+        assert img_dir == projects_root / "rio_negro_nandu" / "caja_1" / "images" / "main"
+
+    def test_image_dir_without_collection(self, projects_root):
+        from capture.project_manager import image_output_dir
+        img_dir = image_output_dir("Rionegro")
+        assert img_dir == projects_root / "rionegro" / "images" / "main"
+
+
+# ==============================================================================
+# Manifest / image directory agreement
+# ==============================================================================
+
+def _write_fake_image(img_dir, name):
+    img_dir.mkdir(parents=True, exist_ok=True)
+    img_path = img_dir / name
+    img_path.write_bytes(b"fake-jpeg-bytes")
+    return img_path
+
+
+class TestManifestSharesImageDirectory:
+    @pytest.mark.parametrize("project_name,collection_name", [
+        ("Rionegro", None),                 # capital, no collection
+        ("Río Negro Ñandú", "Caja 1"),      # accents + spaces, with collection
+    ])
+    def test_manifest_paths_resolve_to_images(self, projects_root, project_name, collection_name):
+        from capture.project_manager import project_capture_root, image_output_dir
+        from capture.manifestHandler import generate_manifest_record, append_manifest_record
+
+        img_dir = image_output_dir(project_name, collection_name)
+        img_path = _write_fake_image(img_dir, "20260101_000000_000_c0.jpg")
+
+        project_root = project_capture_root(project_name)
+        record = generate_manifest_record(
+            project_name=project_name,
+            img_paths=[img_path],
+            cam_configs=[_StubConfig()],
+            times=[0.1],
+            project_root=project_root,
+        )
+        append_manifest_record(project_root, record)
+
+        # Manifest lands under the same sanitized project root as the images
+        manifest_path = project_root / "metadata" / "manifest.jsonl"
+        assert manifest_path.exists()
+
+        # Every file path in the manifest, resolved from project_root, is the real image
+        assert record.files, "expected at least one file in the manifest record"
+        for f in record.files:
+            resolved = (project_root / f.relative_path).resolve()
+            assert resolved == img_path.resolve()
+            assert resolved.exists()
+
+    def test_manifest_on_disk_matches_record(self, projects_root):
+        from capture.project_manager import project_capture_root, image_output_dir
+        from capture.manifestHandler import generate_manifest_record, append_manifest_record
+
+        project_name = "Río Negro Ñandú"
+        collection_name = "Caja 1"
+        img_dir = image_output_dir(project_name, collection_name)
+        img_path = _write_fake_image(img_dir, "20260101_000000_000_c0.jpg")
+
+        project_root = project_capture_root(project_name)
+        record = generate_manifest_record(
+            project_name=project_name,
+            img_paths=[img_path],
+            cam_configs=[_StubConfig()],
+            times=[0.1],
+            project_root=project_root,
+        )
+        append_manifest_record(project_root, record)
+
+        manifest_path = project_root / "metadata" / "manifest.jsonl"
+        entry = json.loads(manifest_path.read_text(encoding="utf-8").strip())
+        rel = entry["files"][0]["relative_path"]
+        # Relative path includes the collection subdir and resolves to the image
+        assert (project_root / rel).resolve() == img_path.resolve()


### PR DESCRIPTION
…es NEH-45)

single/dual capture built the manifest root from the raw, unsanitized project name and ignored the collection subdir, so images and their sha256 manifest landed in separate directory trees for any project with capitals, spaces, or accents (live at Rionegro).

- centralize the on-disk layout in project_manager (project_capture_root, image_output_dir) as the single source of truth

- derive manifest relative_paths from the real image paths so they always include the collection subdir

- remove the dual-path workarounds in projects/collections delete

- add regression tests for capitals/spaces/accents