### PR TITLE
fix(capture): resolve projects root at call time so drive activation takes effect

### DIFF
--- a/capture/project_manager.py
+++ b/capture/project_manager.py
@@ -16,7 +16,6 @@ from .camera_registry import CameraRegistry
 
 from app.core.config import settings
 
-PROJECTS_ROOT = settings.projects_dir
 LOG_FILE = settings.log_dir / "project_manager.log"
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 
@@ -31,11 +30,23 @@ def secure_project_filename(project_name):
     return project_name.lstrip('.').lower()
 
 
+def _projects_root() -> Path:
+    """Resolve the active projects root at call time.
+
+    Read from settings on every call (rather than a module-level constant
+    captured at import) so a runtime storage-drive switch — POST
+    /system/storage/activate flips the storage override in
+    app.core.config.Settings.projects_dir — takes effect immediately for new
+    captures, keeping writes and reads on the same disk.
+    """
+    return settings.projects_dir
+
+
 def project_capture_root(project_name: str) -> Path:
     """Project-level directory holding the manifest and all image subdirs.
     Args:
         project_name: Name of the project"""
-    return Path(PROJECTS_ROOT, secure_project_filename(project_name))
+    return Path(_projects_root(), secure_project_filename(project_name))
 
 
 def collection_capture_root(project_name: str, collection_name: str) -> Path:

--- a/capture/service.py
+++ b/capture/service.py
@@ -37,7 +37,6 @@ from .project_manager import project_capture_root, image_output_dir
 
 from app.core.config import settings
 
-PROJECTS_ROOT = settings.projects_dir
 LOG_FILE = settings.log_dir / "capture_service.log"
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 

--- a/tests/unit/test_projects_root_live.py
+++ b/tests/unit/test_projects_root_live.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Regression test for NEH-125: the capture write path must resolve the active
+projects root at call time so a runtime storage-drive switch (POST
+/system/storage/activate, which flips the storage override consulted by
+Settings.projects_dir) takes effect immediately for new captures.
+
+Before the fix, capture/project_manager.py captured
+``PROJECTS_ROOT = settings.projects_dir`` as a module-level constant at import
+time, so after an operator activated an external drive new captures kept
+writing to the OLD root while the registry/delete/export/storage-panel readers
+followed the NEW root — splitting a project across two disks.
+
+Run with: python -m pytest tests/unit/test_projects_root_live.py
+"""
+
+from pathlib import Path
+
+import capture.project_manager as pm
+
+
+def test_project_capture_root_follows_runtime_override(tmp_path, monkeypatch):
+    """Activating a drive at runtime must move new captures to the new root
+    without re-importing the capture modules."""
+    new_root = tmp_path / "external-drive" / "dtk-projects"
+    new_root.mkdir(parents=True, exist_ok=True)
+
+    # Simulate what POST /system/storage/activate does: set the storage
+    # override that Settings.projects_dir consults on every access. We patch
+    # get_storage_override where projects_dir imports it (inside the property).
+    monkeypatch.setattr(
+        "app.core.storage_override.get_storage_override",
+        lambda: str(new_root),
+    )
+
+    # No re-import of pm — the module has been imported once already, exactly
+    # as it is in the long-running backend process when the drive is switched.
+    resolved = pm.project_capture_root("My Project")
+
+    assert resolved == new_root / "my_project"
+    # And the manifest/image helpers built on top of it follow the same root.
+    assert pm.image_output_dir("My Project").is_relative_to(new_root)
+
+
+def test_projects_root_reflects_override_change_between_calls(tmp_path, monkeypatch):
+    """Two successive resolutions with different overrides must land on
+    different disks — proving the root is read per call, not cached."""
+    root_a = tmp_path / "disk-a"
+    root_b = tmp_path / "disk-b"
+    root_a.mkdir()
+    root_b.mkdir()
+
+    monkeypatch.setattr(
+        "app.core.storage_override.get_storage_override", lambda: str(root_a)
+    )
+    first = pm.project_capture_root("proj")
+
+    monkeypatch.setattr(
+        "app.core.storage_override.get_storage_override", lambda: str(root_b)
+    )
+    second = pm.project_capture_root("proj")
+
+    assert first == root_a / "proj"
+    assert second == root_b / "proj"
+    assert first != second

--- a/tests/unit/test_projects_root_live.py
+++ b/tests/unit/test_projects_root_live.py
@@ -14,9 +14,19 @@ followed the NEW root — splitting a project across two disks.
 Run with: python -m pytest tests/unit/test_projects_root_live.py
 """
 
+import tempfile
 from pathlib import Path
 
-import capture.project_manager as pm
+# Importing capture.project_manager runs LOG_FILE.parent.mkdir(...) at module
+# import time, with settings.log_dir defaulting to /var/log/dtk — not writable
+# on dev machines. Point the already-instantiated settings at a writable temp
+# dir BEFORE the capture import so this test is hermetic.
+from app.core.config import settings
+
+_TEST_LOG_DIR = Path(tempfile.mkdtemp(prefix="dtk-test-logs-"))
+settings.DTK_LOG_DIR = str(_TEST_LOG_DIR)
+
+import capture.project_manager as pm  # noqa: E402
 
 
 def test_project_capture_root_follows_runtime_override(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem (NEH-125 · UCSB-AMPLab/digitization-toolkit-software#143)

The runtime storage-drive switch silently split a project's write path across two disks.

`app/core/config.py` defines `Settings.projects_dir` as a **property** that consults the storage override on every access, and `POST /system/storage/activate` (`app/api/system.py`) flips that override at runtime via `set_storage_override(...)` with **no restart**.

But `capture/project_manager.py` captured `PROJECTS_ROOT = settings.projects_dir` as a **module-level constant at import time**, and `project_capture_root()` — the single function every capture write funnels through (`capture/service.py` `single_capture_image` / `dual_capture_image`, plus the `image_output_dir`/`collection_capture_root` helpers built on it) — used that frozen constant.

Result: after an operator activates an external drive, new captures kept writing images and manifest records to the **OLD** root, while the live readers — camera registry (`capture/camera_registry.py`, `Path(settings.projects_dir) / "cameras.json"` at call time), delete/export/move (`app/api/projects.py`, `app/api/collections.py`), and the storage/free-space panel (`app/api/system.py`) — all followed the **NEW** root. Fresh scans vanished from review/export, the free-space panel watched the wrong disk, `cameras.json` calibration lookups broke (slow-autofocus fallback), and after reboot a project was split across two physical disks.

## Fix — mechanism

Resolve the projects root **at call time** instead of caching it at import, matching the existing live-reader idiom (`camera_registry.py` already reads `settings.projects_dir` inside `__init__`).

- `capture/project_manager.py`: removed the module-level `PROJECTS_ROOT = settings.projects_dir` constant; added a tiny `_projects_root() -> Path` that returns `settings.projects_dir`, and `project_capture_root()` now calls it. Every downstream helper (`collection_capture_root`, `image_output_dir`, `project_init`) and every API caller of these funnels through the property, so they now all resolve the same active disk.
- `capture/service.py`: removed the `PROJECTS_ROOT = settings.projects_dir` module constant. It was **dead** — defined at import but never read (all writes go through `project_capture_root`/`image_output_dir`). Removed so no stale root lingers.

Smallest diff that fixes the split; no drive-by refactors.

### Use sites changed
- `capture/project_manager.py:19` — deleted stale `PROJECTS_ROOT` constant.
- `capture/project_manager.py` `project_capture_root()` — now `Path(_projects_root(), ...)` (new `_projects_root()` helper reads `settings.projects_dir` per call).
- `capture/service.py:40` — deleted dead `PROJECTS_ROOT` constant.

## In-flight capture semantics

No capture-session object caches a projects-root `Path` across the switch — each capture call re-resolves the root at the moment of capture. Within a single `dual_capture_image` call the image dir and the manifest root each resolve `_projects_root()` independently, but there is no switch mid-call, so both land on the same disk (the two images + their manifest record stay together). A single in-progress capture completing on the old root is atomic and acceptable; the bug this fixes is **new** captures after activation going to the old root.

## Other import-time settings captures found (reported, left unchanged)

While sweeping `capture/` for `= settings.<...>` module-level captures I found the `LOG_FILE` siblings: `capture/project_manager.py` and `capture/service.py` both capture `LOG_FILE = settings.log_dir / "..."` (and `capture/manifestHandler.py`). These derive from `DTK_LOG_DIR`, which has **no runtime override** (unlike `projects_dir`), so they are not part of this write-path split. Left unchanged to keep the diff scoped.

## Testing — what ran vs. what could not

This was developed on macOS with no camera hardware and no pixi; picamera2 cannot install here, so the full hardware suite could not run. **This should be hardware-tested on a Pi before release.**

- **Ran:** `python -m py_compile` on both touched files — clean.
- **Ran:** a new regression test (`tests/unit/test_projects_root_live.py`, in the repo's plain-pytest + monkeypatch style) in a minimal venv (pydantic, pydantic-settings, pillow, pytest). It monkeypatches `app.core.storage_override.get_storage_override` to simulate a runtime drive activation and asserts `project_capture_root` / `image_output_dir` resolve the **new** root **without re-import**, and that two successive calls with different overrides land on different disks. **2 passed** against the fix; both **fail** against the pre-fix code (confirmed by stashing the fix) — so it genuinely catches the regression.
- **Could not run:** the existing `tests/unit/test_api.py` auth/token cases and anything importing `fastapi`/`psycopg`/`picamera2` — those deps are absent on this Mac (2 pre-existing `test_api.py` failures are purely `No module named 'fastapi'`, unrelated to this change; route/model/db tests self-skip off-Linux).
