### PR TITLE
fix(deps): declare piexif and bagit explicitly (NEH-104); NEH-107 empirical check

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -26,6 +26,7 @@ pyyaml = ">=6.0.2"
 
 # Image processing
 pillow = ">=11.0.0"
+piexif = ">=1.1.3"
 
 # Testing
 pytest = ">=9.0.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,9 +25,13 @@ python-multipart==0.0.20
 
 # Image processing
 Pillow>=11.0.0
+piexif>=1.1.3
 
 # Image postprocessing
 rawpy>=0.23.0
+
+# Archival packaging
+bagit>=1.9.0
 
 # Camera backends
 picamera2>=0.3.33


### PR DESCRIPTION
## Summary

- Adds `piexif` and `bagit` explicitly to `requirements.txt` and `pixi.toml` (NEH-104). Both are used directly by application code but were previously either transitive-only (piexif, via picamera2 on the pip path) or present in one manifest but not the other (bagit, in pixi.toml but missing from requirements.txt).
- Empirically tests the NEH-107 claim that a clean x86 (`linux/amd64`) build of `Dockerfile.dev` fails because of `picamera2`/`python-prctl`. **That specific claim did not hold up.** See the empirical finding below.

## NEH-107 empirical finding

I ran `docker build --platform linux/amd64 -f Dockerfile.dev -t neh107-test .` against `dev` HEAD. The build **does fail**, but not for the reason NEH-107 hypothesized. It fails at the `pip install -r requirements.txt` step on a `pip` resolver conflict between the pinned `fastapi==0.139.0` and the pinned `typing-inspection==0.4.1`, unrelated to picamera2:

```
#9 44.69 ERROR: Cannot install -r requirements.txt (line 4) and typing-inspection==0.4.1 because these package versions have conflicting dependencies.
#9 44.69
#9 44.69 The conflict is caused by:
#9 44.69     The user requested typing-inspection==0.4.1
#9 44.69     fastapi 0.139.0 depends on typing-inspection>=0.4.2
#9 44.69
#9 44.69 ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
#9 ERROR: process "/bin/sh -c pip install --no-cache-dir -r requirements.txt" did not complete successfully: exit code: 1
```

This is a pre-existing pin conflict on `dev` HEAD, orthogonal to picamera2/python-prctl and to both NEH-104 and NEH-107. It is out of scope for this PR (neither issue is about it) and is not touched here — flagging it for a maintainer to pick up separately, since it currently breaks `Dockerfile.dev` outright regardless of this PR.

To isolate the actual picamera2/python-prctl question, I ran the identical build in a scratch copy with only `typing-inspection` bumped to satisfy fastapi (no other change). With that one unrelated conflict out of the way, the build **succeeded end to end**, including compiling `python-prctl` (picamera2's only wheel-less dependency) natively via the `build-essential`/`libcap-dev` already installed in `Dockerfile.dev`:

```
#9 90.48   Building wheel for PiDNG (setup.py): started
#9 103.4   Building wheel for PiDNG (setup.py): finished with status 'done'
#9 103.5   Building wheel for python-prctl (setup.py): started
#9 111.5   Building wheel for python-prctl (setup.py): finished with status 'done'
#9 111.6 Successfully built PiDNG python-prctl
...
#9 188.7 Successfully installed ... picamera2-0.3.36 piexif-1.1.3 python-prctl-1.8.1 ...
#11 naming to docker.io/library/neh107-isolate-test:latest done
```

Wall clock for the successful isolated build: ~3.5 min (192s for the pip install layer). The `dev` HEAD failing build fails fast, at ~45s, before it ever reaches picamera2/python-prctl compilation.

**Conclusion: the counter-hypothesis in NEH-107 is correct.** `build-essential` and `libcap-dev` are sufficient for python-prctl to build on x86, and picamera2 installs and builds cleanly with no platform marker needed. The picamera2 platform-marker fix proposed in NEH-107 would not have addressed the actual build failure on `dev` HEAD (the `typing-inspection`/`fastapi` conflict) and is not applied here. Per NEH-107's own framing, the issue reduces to image-slimming (excluding an ARM-only camera stack from x86 dev images), which is a scope/maintainer decision, not a build-breakage fix — so no platform marker was added to `picamera2` in this PR.

## What this PR does

- `requirements.txt`: add `piexif>=1.1.3` and `bagit>=1.9.0`, matching the existing `>=`-pinned style used by the other hand-added entries (`Pillow`, `rawpy`, `picamera2`) in that section of the file.
- `pixi.toml`: add `piexif = ">=1.1.3"` next to `pillow` in the Image processing section, matching the existing `bagit` entry's style. Verified `piexif` is available on conda-forge (`noarch`, latest `1.1.3`), so it resolves on both `linux-64` and `linux-aarch64`.
- No platform marker added to `picamera2` — see empirical finding above.
- Re-ran the build once against this branch to confirm the two additions introduce no new failure: it reproduces the identical pre-existing `typing-inspection`/`fastapi` conflict, at the same point, with no new errors from piexif or bagit.

Relates to UCSB-AMPLab/digitization-toolkit-software#125
Relates to UCSB-AMPLab/digitization-toolkit-software#122
