### PR TITLE
feat(system): graceful power controls; scope privileged ops through dtk-system-helper

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import re
 import shutil
@@ -15,6 +16,8 @@ from app.api.deps import get_db_dependency
 from app.models.system_log import SystemLog
 from app.models.user import User
 from app.schemas.system_log import SystemLogOut
+
+logger = logging.getLogger(__name__)
 
 allow_read_only = RoleChecker(["admin", "operator", "reviewer"])
 allow_admin     = RoleChecker(["admin"])
@@ -361,14 +364,23 @@ def _run_power_action(action: str) -> None:
     """Invoke the privileged helper to power off or reboot the appliance.
 
     Runs in a background task after the HTTP response has been sent, so the
-    reply isn't lost when the system goes down. Failures are logged; there is
-    no client left to inform by the time this runs.
+    reply isn't lost when the system goes down. Failures are logged (there is
+    no client left to inform by the time this runs); stdin is closed so a
+    misconfigured sudoers can never sit waiting for a password until the
+    timeout.
     """
     try:
-        subprocess.run(["sudo", HELPER, action], timeout=30)
+        result = subprocess.run(
+            ["sudo", HELPER, action],
+            capture_output=True, text=True, timeout=30,
+            stdin=subprocess.DEVNULL,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "sin salida"
+            logger.error("Power action %s failed (rc=%s): %s",
+                         action, result.returncode, detail)
     except Exception:
-        import logging
-        logging.getLogger(__name__).exception("Power action %s failed", action)
+        logger.exception("Power action %s failed", action)
 
 
 @router.post("/power")

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -188,6 +188,10 @@ def mount_device(
     passwordless sudo for /usr/local/bin/dtk-system-helper. The helper adds the
     uid/gid options for vfat/exfat itself and always mounts nosuid,nodev. This
     is set up by the superproject installer.
+
+    The mounts root is root-owned and the helper is its only writer: the backend
+    just decides the mountpoint *name*; the helper creates the directory and
+    removes it again if the mount fails.
     """
     if not _DEVICE_RE.match(body.device):
         raise HTTPException(status_code=400, detail="Ruta de dispositivo no válida.")
@@ -200,11 +204,12 @@ def mount_device(
     if dev_info.get("mountpoint"):
         return {"mountpoint": dev_info["mountpoint"], "message": "El dispositivo ya está montado."}
 
-    # Build a safe mount point directory under the dtk data tree
+    # Build a safe mount point name under the dtk data tree. The mounts root is
+    # root-owned; the helper creates the directory itself (and removes it if the
+    # mount fails), so we don't mkdir here.
     label = dev_info.get("label") or dev_info["name"]
     safe  = re.sub(r"[^a-zA-Z0-9_\-]", "_", label)[:32]
     mountpoint = _MOUNT_BASE / safe
-    mountpoint.mkdir(parents=True, exist_ok=True)
 
     # Mount through the privileged helper. It handles fstype-specific options
     # (uid/gid for vfat/exfat) and always mounts nosuid,nodev, so we don't build
@@ -213,11 +218,6 @@ def mount_device(
 
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
     if result.returncode != 0:
-        # Clean up the (empty) directory we just created
-        try:
-            mountpoint.rmdir()
-        except OSError:
-            pass
         detail = result.stderr.strip() or result.stdout.strip() or "Error desconocido al montar."
         raise HTTPException(status_code=500, detail=detail)
 
@@ -243,6 +243,9 @@ def unmount_device(
 
     If the unmounted path is currently the active storage override, the override
     is cleared automatically so the backend falls back to its default path.
+
+    The helper removes the (root-owned) mountpoint directory after a successful
+    umount, so no cleanup happens here.
     """
     from app.core.storage_override import get_storage_override, clear_storage_override
     from app.core.audit import log_event
@@ -274,12 +277,6 @@ def unmount_device(
             set_storage_override(override)
         detail = result.stderr.strip() or result.stdout.strip() or "Error desconocido al desmontar."
         raise HTTPException(status_code=500, detail=detail)
-
-    # Remove the now-empty mount directory so it doesn't clutter the listing
-    try:
-        target.rmdir()
-    except OSError:
-        pass  # non-empty or already gone — not fatal
 
     log_event(db, level="INFO", category="system", action="storage_unmount",
               actor=current_user.username, subject=str(target))

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -4,13 +4,13 @@ import re
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from app.api.auth import RoleChecker
+from app.api.auth import RoleChecker, get_current_user
 from app.api.deps import get_db_dependency
 from app.models.system_log import SystemLog
 from app.models.user import User
@@ -350,3 +350,63 @@ def reset_storage(
 
     from app.core.storage_override import get_storage_override  # should be None now
     return {"projects_path": str(settings.projects_dir), "message": "Restaurado al almacenamiento predeterminado."}
+
+
+# ---------------------------------------------------------------------------
+# Power management
+# ---------------------------------------------------------------------------
+
+class PowerRequest(BaseModel):
+    action: Literal["poweroff", "reboot"]
+
+
+def _run_power_action(action: str) -> None:
+    """Invoke the privileged helper to power off or reboot the appliance.
+
+    Runs in a background task after the HTTP response has been sent, so the
+    reply isn't lost when the system goes down. Failures are logged; there is
+    no client left to inform by the time this runs.
+    """
+    try:
+        subprocess.run(["sudo", HELPER, action], timeout=30)
+    except Exception:
+        import logging
+        logging.getLogger(__name__).exception("Power action %s failed", action)
+
+
+@router.post("/power")
+def power_control(
+    body: PowerRequest,
+    background_tasks: BackgroundTasks,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db_dependency),
+):
+    """Power off or reboot the appliance. Any authenticated user may call this.
+
+    This is intentionally NOT admin-only: the operators who run the toolkit are
+    often non-technical staff, and anyone with physical access can already pull
+    the plug — a graceful shutdown from the UI is strictly safer than that.
+
+    The action is audit-logged and committed *before* it is triggered (the DB is
+    about to go down), then dispatched via a BackgroundTask so the HTTP response
+    is sent before the machine powers off.
+    """
+    # Refuse honestly on machines without the helper (dev Docker, non-Pi hosts)
+    # rather than pretending we scheduled a shutdown that will never happen.
+    if shutil.which("sudo") is None or not os.path.exists(HELPER):
+        raise HTTPException(
+            status_code=501,
+            detail="Control de energía no disponible en este equipo.",
+        )
+
+    from app.core.audit import log_event
+    log_event(db, level="INFO", category="system", action="power_" + body.action,
+              actor=current_user.username)
+
+    background_tasks.add_task(_run_power_action, body.action)
+
+    if body.action == "poweroff":
+        message = "El equipo se apagará en unos segundos."
+    else:
+        message = "El equipo se reiniciará en unos segundos."
+    return {"action": body.action, "message": message}

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -19,6 +19,11 @@ from app.schemas.system_log import SystemLogOut
 allow_read_only = RoleChecker(["admin", "operator", "reviewer"])
 allow_admin     = RoleChecker(["admin"])
 
+# Single root-privileged entry point installed (root-owned, sudoers-whitelisted)
+# by the superproject setup. All privileged shell-outs go through this helper
+# rather than raw mount/umount/mkdir/chown; see /etc/sudoers.d/dtk-system-helper.
+HELPER = "/usr/local/bin/dtk-system-helper"
+
 router = APIRouter()
 
 
@@ -177,10 +182,12 @@ def mount_device(
     current_user: User = Depends(allow_admin),
     db: Session = Depends(get_db_dependency),
 ):
-    """Mount an unmounted partition via sudo mount (no polkit/D-Bus required).
+    """Mount an unmounted partition via the dtk-system-helper (no polkit/D-Bus).
 
-    Requires /etc/sudoers.d/dtk-storage to grant the service user passwordless
-    sudo for /usr/bin/mount and /usr/bin/umount.  This is set up by setup.sh.
+    Requires /etc/sudoers.d/dtk-system-helper to grant the service user
+    passwordless sudo for /usr/local/bin/dtk-system-helper. The helper adds the
+    uid/gid options for vfat/exfat itself and always mounts nosuid,nodev. This
+    is set up by the superproject installer.
     """
     if not _DEVICE_RE.match(body.device):
         raise HTTPException(status_code=400, detail="Ruta de dispositivo no válida.")
@@ -199,15 +206,10 @@ def mount_device(
     mountpoint = _MOUNT_BASE / safe
     mountpoint.mkdir(parents=True, exist_ok=True)
 
-    # Build mount command.
-    # FAT-based filesystems (exfat, vfat) don't store Unix ownership in the
-    # filesystem — ownership is controlled entirely by mount options.
-    # Pass uid/gid so all files appear owned by the running user (pi).
-    fstype = dev_info.get("fstype") or ""
-    cmd = ["sudo", "mount"]
-    if fstype in ("vfat", "exfat"):
-        cmd += ["-o", f"uid={os.getuid()},gid={os.getgid()}"]
-    cmd += [body.device, str(mountpoint)]
+    # Mount through the privileged helper. It handles fstype-specific options
+    # (uid/gid for vfat/exfat) and always mounts nosuid,nodev, so we don't build
+    # -o options here.
+    cmd = ["sudo", HELPER, "mount", body.device, str(mountpoint)]
 
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
     if result.returncode != 0:
@@ -262,7 +264,7 @@ def unmount_device(
         override_cleared = True
 
     result = subprocess.run(
-        ["sudo", "umount", str(target)],
+        ["sudo", HELPER, "umount", str(target)],
         capture_output=True, text=True, timeout=30,
     )
     if result.returncode != 0:
@@ -313,18 +315,15 @@ def activate_storage(
         projects_path.mkdir(parents=True, exist_ok=True)
     except PermissionError:
         # ext4 / ext2 partitions freshly formatted have a root-owned filesystem root.
-        # Use sudo to create the directory, then hand ownership to pi.
+        # The helper does mkdir -p and hands ownership to the invoking user in one
+        # step (the path must end in dtk-projects, which it does).
         r1 = subprocess.run(
-            ["sudo", "mkdir", "-p", str(projects_path)],
+            ["sudo", HELPER, "prepare-projects", str(projects_path)],
             capture_output=True, text=True, timeout=10,
         )
         if r1.returncode != 0:
             detail = r1.stderr.strip() or "Error al crear el directorio."
             raise HTTPException(status_code=500, detail=f"No se puede crear el directorio: {detail}")
-        subprocess.run(
-            ["sudo", "chown", "pi:pi", str(projects_path)],
-            capture_output=True, text=True, timeout=10,
-        )
 
     set_storage_override(str(projects_path))
 

--- a/tests/unit/test_system_power.py
+++ b/tests/unit/test_system_power.py
@@ -58,18 +58,31 @@ def test_power_returns_501_when_helper_missing(power_client, monkeypatch):
     assert "no disponible" in resp.json()["detail"].lower()
 
 
+class _Result:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
 @pytest.mark.unit
 def test_power_poweroff_success(power_client, monkeypatch):
     """When the helper is present: 200, Spanish message, audit logged, helper
-    dispatched via subprocess in the background task (not synchronously)."""
+    dispatched via subprocess in the background task (not synchronously),
+    with stdin closed so sudo can never sit waiting for a password."""
+    import subprocess as real_subprocess
     import app.api.system as system
 
     monkeypatch.setattr(system.shutil, "which", lambda name: "/usr/bin/sudo")
     monkeypatch.setattr(system.os.path, "exists", lambda p: True)
 
     calls = []
-    monkeypatch.setattr(system.subprocess, "run",
-                        lambda *a, **k: calls.append(a[0]))
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return _Result(0)
+
+    monkeypatch.setattr(system.subprocess, "run", fake_run)
 
     logged = {}
 
@@ -93,7 +106,9 @@ def test_power_poweroff_success(power_client, monkeypatch):
 
     # TestClient runs background tasks after the response; the helper was called.
     assert calls, "background task should have invoked the helper"
-    assert calls[-1] == ["sudo", system.HELPER, "poweroff"]
+    cmd, kwargs = calls[-1]
+    assert cmd == ["sudo", system.HELPER, "poweroff"]
+    assert kwargs.get("stdin") == real_subprocess.DEVNULL
 
 
 @pytest.mark.unit
@@ -106,7 +121,7 @@ def test_power_reboot_success(power_client, monkeypatch):
 
     calls = []
     monkeypatch.setattr(system.subprocess, "run",
-                        lambda *a, **k: calls.append(a[0]))
+                        lambda cmd, **k: calls.append(cmd) or _Result(0))
 
     import app.core.audit as audit
     monkeypatch.setattr(audit, "log_event", lambda db, **k: None)
@@ -116,6 +131,37 @@ def test_power_reboot_success(power_client, monkeypatch):
     assert resp.status_code == 200
     assert "se reiniciará" in resp.json()["message"]
     assert calls[-1] == ["sudo", system.HELPER, "reboot"]
+
+
+@pytest.mark.unit
+def test_power_helper_failure_is_logged(power_client, monkeypatch):
+    """A non-zero exit from the helper is not silent: the background task logs
+    the return code and stderr via logger.error (there is no client left to
+    inform, so logging is the only diagnostic channel)."""
+    import app.api.system as system
+
+    monkeypatch.setattr(system.shutil, "which", lambda name: "/usr/bin/sudo")
+    monkeypatch.setattr(system.os.path, "exists", lambda p: True)
+    monkeypatch.setattr(
+        system.subprocess, "run",
+        lambda cmd, **k: _Result(1, stderr="sudo: not permitted by sudoers"),
+    )
+
+    import app.core.audit as audit
+    monkeypatch.setattr(audit, "log_event", lambda db, **k: None)
+
+    errors = []
+    monkeypatch.setattr(system.logger, "error",
+                        lambda msg, *args: errors.append(msg % args))
+
+    resp = power_client.post("/system/power", json={"action": "poweroff"})
+
+    # The endpoint itself still returns 200 — the failure happens post-response.
+    assert resp.status_code == 200
+    assert errors, "helper failure should have been logged"
+    assert "poweroff" in errors[-1]
+    assert "rc=1" in errors[-1]
+    assert "not permitted by sudoers" in errors[-1]
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_system_power.py
+++ b/tests/unit/test_system_power.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the /system/power endpoint (NEH-98).
+
+These exercise the endpoint through the FastAPI TestClient with the auth and
+DB dependencies overridden, and the privileged helper / subprocess mocked so
+nothing is ever actually powered off. Run with:
+    python -m pytest tests/unit/test_system_power.py
+"""
+
+import pytest
+
+
+def _make_user(role="reviewer", username="operator1"):
+    """Build a lightweight stand-in for an authenticated User row."""
+    from app.models.user import User
+    return User(username=username, email=f"{username}@example.com",
+                hashed_password="x", role=role, is_active=True)
+
+
+@pytest.fixture
+def power_client(client, db_session):
+    """TestClient with get_current_user overridden to a plain authenticated user.
+
+    Uses the `client` fixture (which already overrides the DB dependency) and
+    additionally overrides get_current_user so no real token is needed.
+    """
+    from app.main import app
+    from app.api.auth import get_current_user
+
+    app.dependency_overrides[get_current_user] = lambda: _make_user()
+    yield client
+    # `client` fixture clears overrides on teardown
+
+
+@pytest.mark.unit
+def test_power_requires_authentication(client):
+    """With no auth override and no token, the endpoint rejects the request."""
+    resp = client.post("/system/power", json={"action": "poweroff"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.unit
+def test_power_rejects_invalid_action(power_client):
+    """The Literal in the request model rejects anything but poweroff/reboot."""
+    resp = power_client.post("/system/power", json={"action": "explode"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.unit
+def test_power_returns_501_when_helper_missing(power_client, monkeypatch):
+    """On a host without the helper we refuse honestly with 501, not a fake 200."""
+    import app.api.system as system
+    monkeypatch.setattr(system.os.path, "exists", lambda p: False)
+
+    resp = power_client.post("/system/power", json={"action": "poweroff"})
+    assert resp.status_code == 501
+    assert "no disponible" in resp.json()["detail"].lower()
+
+
+@pytest.mark.unit
+def test_power_poweroff_success(power_client, monkeypatch):
+    """When the helper is present: 200, Spanish message, audit logged, helper
+    dispatched via subprocess in the background task (not synchronously)."""
+    import app.api.system as system
+
+    monkeypatch.setattr(system.shutil, "which", lambda name: "/usr/bin/sudo")
+    monkeypatch.setattr(system.os.path, "exists", lambda p: True)
+
+    calls = []
+    monkeypatch.setattr(system.subprocess, "run",
+                        lambda *a, **k: calls.append(a[0]))
+
+    logged = {}
+
+    def fake_log_event(db, **kwargs):
+        logged.update(kwargs)
+
+    import app.core.audit as audit
+    monkeypatch.setattr(audit, "log_event", fake_log_event)
+
+    resp = power_client.post("/system/power", json={"action": "poweroff"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["action"] == "poweroff"
+    assert "se apagará" in body["message"]
+
+    # Audit fired before the action, with the right category/action/actor.
+    assert logged.get("category") == "system"
+    assert logged.get("action") == "power_poweroff"
+    assert logged.get("actor") == "operator1"
+
+    # TestClient runs background tasks after the response; the helper was called.
+    assert calls, "background task should have invoked the helper"
+    assert calls[-1] == ["sudo", system.HELPER, "poweroff"]
+
+
+@pytest.mark.unit
+def test_power_reboot_success(power_client, monkeypatch):
+    """Reboot path returns the reboot message and dispatches `reboot`."""
+    import app.api.system as system
+
+    monkeypatch.setattr(system.shutil, "which", lambda name: "/usr/bin/sudo")
+    monkeypatch.setattr(system.os.path, "exists", lambda p: True)
+
+    calls = []
+    monkeypatch.setattr(system.subprocess, "run",
+                        lambda *a, **k: calls.append(a[0]))
+
+    import app.core.audit as audit
+    monkeypatch.setattr(audit, "log_event", lambda db, **k: None)
+
+    resp = power_client.post("/system/power", json={"action": "reboot"})
+
+    assert resp.status_code == 200
+    assert "se reiniciará" in resp.json()["message"]
+    assert calls[-1] == ["sudo", system.HELPER, "reboot"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_system_storage_helper.py
+++ b/tests/unit/test_system_storage_helper.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the NEH-69 refactor: storage mount/umount/activate now shell out
+through the single privileged helper /usr/local/bin/dtk-system-helper instead of
+raw sudo mount/umount/mkdir/chown.
+
+These assert the exact argv passed to subprocess.run so a future regression that
+reintroduces raw sudo calls (or the hardcoded pi:pi chown) is caught. Run with:
+    python -m pytest tests/unit/test_system_storage_helper.py
+"""
+
+import pytest
+
+
+def _admin():
+    from app.models.user import User
+    return User(username="admin1", email="a@example.com",
+                hashed_password="x", role="admin", is_active=True)
+
+
+@pytest.fixture
+def admin_client(client, db_session):
+    from app.main import app
+    # system.py binds its own allow_admin = RoleChecker(["admin"]) instance, so
+    # override that exact object (not the one re-exported from app.api.auth).
+    import app.api.system as system
+    app.dependency_overrides[system.allow_admin] = lambda: _admin()
+    yield client
+
+
+class _Result:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+@pytest.mark.unit
+def test_mount_uses_helper(admin_client, monkeypatch):
+    import app.api.system as system
+
+    # One unmounted vfat partition available.
+    monkeypatch.setattr(system, "_parse_lsblk", lambda: [{
+        "name": "sda1", "path": "/dev/sda1", "size": "1G",
+        "fstype": "vfat", "mountpoint": None, "label": "USB",
+        "removable": True, "type": "part",
+    }])
+    # Don't touch the real /var/lib/dtk/mounts tree.
+    monkeypatch.setattr(system.Path, "mkdir", lambda self, **k: None)
+
+    calls = []
+    monkeypatch.setattr(system.subprocess, "run",
+                        lambda cmd, **k: calls.append(cmd) or _Result(0))
+    import app.core.audit as audit
+    monkeypatch.setattr(audit, "log_event", lambda *a, **k: None)
+
+    resp = admin_client.post("/system/storage/mount", json={"device": "/dev/sda1"})
+    assert resp.status_code == 200, resp.text
+
+    cmd = calls[-1]
+    # Routed through the helper; no raw `mount`, no -o uid/gid built here.
+    assert cmd[:3] == ["sudo", system.HELPER, "mount"]
+    assert cmd[3] == "/dev/sda1"
+    assert "-o" not in cmd
+
+
+@pytest.mark.unit
+def test_unmount_uses_helper(admin_client, monkeypatch):
+    import app.api.system as system
+    import app.core.storage_override as so
+
+    # The endpoint imports these lazily from app.core.storage_override.
+    monkeypatch.setattr(so, "get_storage_override", lambda: None)
+
+    target = str(system._MOUNT_BASE / "USB")
+
+    calls = []
+    monkeypatch.setattr(system.subprocess, "run",
+                        lambda cmd, **k: calls.append(cmd) or _Result(0))
+    monkeypatch.setattr(system.Path, "rmdir", lambda self: None)
+    import app.core.audit as audit
+    monkeypatch.setattr(audit, "log_event", lambda *a, **k: None)
+
+    resp = admin_client.request("DELETE", "/system/storage/mount",
+                                json={"mountpoint": target})
+    assert resp.status_code == 200, resp.text
+
+    cmd = calls[-1]
+    # Routed through the helper, not a bare `sudo umount`.
+    assert cmd == ["sudo", system.HELPER, "umount", target]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_system_storage_helper.py
+++ b/tests/unit/test_system_storage_helper.py
@@ -5,7 +5,9 @@ through the single privileged helper /usr/local/bin/dtk-system-helper instead of
 raw sudo mount/umount/mkdir/chown.
 
 These assert the exact argv passed to subprocess.run so a future regression that
-reintroduces raw sudo calls (or the hardcoded pi:pi chown) is caught. Run with:
+reintroduces raw sudo calls (or the hardcoded pi:pi chown) is caught. They also
+assert the backend never mkdirs/rmdirs under the mounts root — the root is
+root-owned and the helper is its only writer. Run with:
     python -m pytest tests/unit/test_system_storage_helper.py
 """
 
@@ -28,6 +30,22 @@ def admin_client(client, db_session):
     yield client
 
 
+@pytest.fixture
+def dir_op_recorder(monkeypatch):
+    """Record any Path.mkdir / Path.rmdir the endpoints attempt.
+
+    The mounts root is root-owned and the helper is its only writer, so the
+    endpoints must not touch the filesystem there at all.
+    """
+    from pathlib import Path
+    ops = []
+    monkeypatch.setattr(Path, "mkdir",
+                        lambda self, **k: ops.append(("mkdir", str(self))))
+    monkeypatch.setattr(Path, "rmdir",
+                        lambda self: ops.append(("rmdir", str(self))))
+    return ops
+
+
 class _Result:
     def __init__(self, returncode=0, stdout="", stderr=""):
         self.returncode = returncode
@@ -35,18 +53,19 @@ class _Result:
         self.stderr = stderr
 
 
-@pytest.mark.unit
-def test_mount_uses_helper(admin_client, monkeypatch):
-    import app.api.system as system
-
-    # One unmounted vfat partition available.
-    monkeypatch.setattr(system, "_parse_lsblk", lambda: [{
+def _one_vfat_partition():
+    return [{
         "name": "sda1", "path": "/dev/sda1", "size": "1G",
         "fstype": "vfat", "mountpoint": None, "label": "USB",
         "removable": True, "type": "part",
-    }])
-    # Don't touch the real /var/lib/dtk/mounts tree.
-    monkeypatch.setattr(system.Path, "mkdir", lambda self, **k: None)
+    }]
+
+
+@pytest.mark.unit
+def test_mount_uses_helper_and_does_not_mkdir(admin_client, monkeypatch, dir_op_recorder):
+    import app.api.system as system
+
+    monkeypatch.setattr(system, "_parse_lsblk", _one_vfat_partition)
 
     calls = []
     monkeypatch.setattr(system.subprocess, "run",
@@ -63,9 +82,30 @@ def test_mount_uses_helper(admin_client, monkeypatch):
     assert cmd[3] == "/dev/sda1"
     assert "-o" not in cmd
 
+    # Creating the mountpoint directory is the helper's job now.
+    assert dir_op_recorder == []
+
 
 @pytest.mark.unit
-def test_unmount_uses_helper(admin_client, monkeypatch):
+def test_mount_failure_returns_500_without_cleanup(admin_client, monkeypatch, dir_op_recorder):
+    """When the helper fails, surface its stderr as a 500 and do NOT try to
+    rmdir the mountpoint — the helper cleans up its own directory."""
+    import app.api.system as system
+
+    monkeypatch.setattr(system, "_parse_lsblk", _one_vfat_partition)
+    monkeypatch.setattr(system.subprocess, "run",
+                        lambda cmd, **k: _Result(32, stderr="mount: wrong fs type"))
+    import app.core.audit as audit
+    monkeypatch.setattr(audit, "log_event", lambda *a, **k: None)
+
+    resp = admin_client.post("/system/storage/mount", json={"device": "/dev/sda1"})
+    assert resp.status_code == 500
+    assert "wrong fs type" in resp.json()["detail"]
+    assert dir_op_recorder == []
+
+
+@pytest.mark.unit
+def test_unmount_uses_helper_and_does_not_rmdir(admin_client, monkeypatch, dir_op_recorder):
     import app.api.system as system
     import app.core.storage_override as so
 
@@ -77,7 +117,6 @@ def test_unmount_uses_helper(admin_client, monkeypatch):
     calls = []
     monkeypatch.setattr(system.subprocess, "run",
                         lambda cmd, **k: calls.append(cmd) or _Result(0))
-    monkeypatch.setattr(system.Path, "rmdir", lambda self: None)
     import app.core.audit as audit
     monkeypatch.setattr(audit, "log_event", lambda *a, **k: None)
 
@@ -88,6 +127,9 @@ def test_unmount_uses_helper(admin_client, monkeypatch):
     cmd = calls[-1]
     # Routed through the helper, not a bare `sudo umount`.
     assert cmd == ["sudo", system.HELPER, "umount", target]
+
+    # Removing the mountpoint directory after umount is the helper's job now.
+    assert dir_op_recorder == []
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two related changes to `app/api/system.py`:

1. **NEH-69** (superproject #87): route all privileged storage shell-outs through the new single, sudoers-whitelisted helper `/usr/local/bin/dtk-system-helper` instead of raw `sudo mount` / `sudo umount` / `sudo mkdir` / `sudo chown pi:pi`.
2. **NEH-98** (superproject #116): add a graceful power-off / reboot endpoint driven by the same helper.

The helper path lives in one module-level constant, `HELPER`.

## New endpoint contract (frontend codes against this)

- **Path:** `POST /system/power` (the system router is mounted at prefix `/system` in `app/main.py`).
- **Request body:** `{ "action": "poweroff" | "reboot" }` — Pydantic model with a `Literal`; any other value returns **422**.
- **Background task hardening** (Copilot follow-up): the helper call runs with `stdin=subprocess.DEVNULL` (a misconfigured sudoers can never sit waiting for a password) and non-zero exits are logged via `logger.error` with rc + stderr — the task runs post-response, so logging is the diagnostic channel.
- **Responses:**
  - **200** — `{ "action": "poweroff", "message": "El equipo se apagará en unos segundos." }` or `{ "action": "reboot", "message": "El equipo se reiniciará en unos segundos." }`. The action is dispatched **after** the response is sent, via `BackgroundTasks`, so the reply is never lost to the shutdown.
  - **401** — not authenticated.
  - **501** — `{ "detail": "Control de energía no disponible en este equipo." }` when the helper is absent (dev Docker / non-Pi host). The endpoint pre-checks `shutil.which("sudo")` and `os.path.exists(HELPER)` and refuses honestly rather than pretending it scheduled a shutdown.

## Auth-level decision — PLEASE REVIEW

`POST /system/power` requires **any authenticated user** (`Depends(get_current_user)`), **not** admin. Rationale: the operators who need this are non-technical staff, and anyone with physical access can already pull the plug — a graceful UI shutdown is strictly safer than the alternative. This is deliberately more permissive than the storage endpoints (which stay `allow_admin`). If the team wants this restricted to `admin`/`operator`, it's a one-line change to the dependency. Roles in the codebase: `admin`, `operator`, `reviewer` (`RoleChecker` in `app/api/auth.py`).

The action is **audit-logged before it is triggered** (`log_event(..., category="system", action="power_poweroff"|"power_reboot", actor=<username>)`). `log_event` commits immediately, so the entry lands before the DB goes down — no extra commit needed.

## NEH-69 refactor details

- **mount:** `["sudo", HELPER, "mount", device, mountpoint]`. The `-o uid/gid` branch for vfat/exfat is **deleted** — the helper adds those itself and always mounts `nosuid,nodev`. All existing request validation (`_DEVICE_RE`, lsblk lookup, protected-mountpoint checks) is **kept** as defense-in-depth and for friendlier errors than the helper's stderr.
- **umount:** `["sudo", HELPER, "umount", mountpoint]`.
- **Mountpoint directory lifecycle is now the helper's** (follow-up, coordinated with the helper PR): the mounts root `/var/lib/dtk/mounts` goes root-owned to close a symlink TOCTOU, and the helper is its only writer. The backend still decides the mountpoint *name* (label sanitization unchanged) but no longer mkdirs it, cleans it up on mount failure, or rmdirs it after umount.
- **activate (PermissionError fallback):** the two calls (`sudo mkdir -p` + `sudo chown pi:pi`) collapse to a single `["sudo", HELPER, "prepare-projects", projects_path]`. This also **removes the hardcoded `pi:pi`** — the helper chowns to the invoking user. The path already ends in `dtk-projects`, which the helper requires.
- Docstrings updated to describe the `dtk-system-helper` sudoers arrangement (they previously named raw mount/umount and `/etc/sudoers.d/dtk-storage`).

## ⚠️ COORDINATION REQUIRED — do not merge to `main` in isolation

This backend depends on the superproject PR (#116 / #87) that provisions `/usr/local/bin/dtk-system-helper` and the `/etc/sudoers.d/dtk-system-helper` entry on the host. **Running this backend against the OLD sudoers (raw `sudo mount`/`umount` whitelist, no helper) breaks storage mounting**, because the backend now only ever calls the helper. Therefore:

- Land the backend pointer bump and the superproject helper install **together**.
- **Hardware-test on a Pi** (mount a USB stick, activate storage on a fresh ext4 partition, power-off, reboot) before promoting `dev` → `main`.
- Until the helper is present, `POST /system/power` returns 501 (safe) and storage mount/umount/activate fail at the helper call (expected).

## Testing — what ran, what didn't

- **Ran locally (macOS, Python 3.14, venv with core deps + `psycopg[binary]`; SQLite via the existing `db_session` fixture):**
  - `tests/unit/test_system_power.py` — 6 tests: 401 without auth, 422 on bad action, **501 when helper missing**, poweroff success (200 + Spanish message + audit call asserted + helper dispatched via background task), reboot success, and **helper-failure logging** (rc + stderr reach `logger.error`). **All pass.**
  - `tests/unit/test_system_storage_helper.py` — 3 tests asserting mount/umount argv now go through `HELPER` (no bare `sudo mount`/`umount`, no `-o` built in the endpoint), that the backend performs **no mkdir/rmdir** under the mounts root, and that a helper mount failure returns 500 without local cleanup. **All pass.**
  - Full `tests/unit/` suite: **18 passed, 5 skipped** (the 5 skips are pre-existing Linux/Pi-only route/model/DB tests).
- **Did NOT run:** `tests/integration/` (camera hardware), and the Linux-only tests in `test_api.py` (they skip on macOS by design). `picamera2`/`gphoto2`/`rawpy` do not install on macOS — not fought, per plan. `python3 -m py_compile` passes on all touched files.

## Files touched

- `app/api/system.py` — refactor + new endpoint
- `tests/unit/test_system_power.py` — new
- `tests/unit/test_system_storage_helper.py` — new
