### PR TITLE
fix(deps): bump typing-inspection to 0.4.2 to satisfy fastapi 0.139

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ SQLAlchemy==2.0.25
 psycopg[binary]==3.2.12
 alembic==1.14.0
 starlette==1.3.1
-typing-inspection==0.4.1
+typing-inspection==0.4.2
 typing_extensions==4.15.0
 uvicorn==0.35.0
 watchfiles==1.1.0


### PR DESCRIPTION
## Summary

Bumps `typing-inspection` from `==0.4.1` to `==0.4.2` in `requirements.txt`. The old pin conflicts with `fastapi==0.139.0`, which requires `typing-inspection>=0.4.2`, so any clean install from requirements.txt — including the `Dockerfile.dev` build — fails at pip's resolver before installing anything.

## The failure (dev HEAD, verbatim)

Discovered while empirically testing the NEH-107 x86 build claim (see #23). A clean `docker build --platform linux/amd64 -f Dockerfile.dev .` against `dev` HEAD fails at ~45s:

```
#9 44.69 ERROR: Cannot install -r requirements.txt (line 4) and typing-inspection==0.4.1 because these package versions have conflicting dependencies.
#9 44.69
#9 44.69 The conflict is caused by:
#9 44.69     The user requested typing-inspection==0.4.1
#9 44.69     fastapi 0.139.0 depends on typing-inspection>=0.4.2
#9 44.69
#9 44.69 To fix this you could try to:
#9 44.69 1. loosen the range of package versions you've specified
#9 44.69 2. remove package versions to allow pip attempt to solve the dependency conflict
#9 44.69
#9 44.70 ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
#9 ERROR: process "/bin/sh -c pip install --no-cache-dir -r requirements.txt" did not complete successfully: exit code: 1
```

## The fix and its verification

`typing-inspection==0.4.1` → `typing-inspection==0.4.2`. The strict `==` form matches the lockfile-style block this entry lives in (lines 1–24 of requirements.txt are all `==` pins), and 0.4.2 is exactly the version the resolver selects and installs once the constraint is satisfiable.

Re-ran the identical build against this branch — green end-to-end in ~2m48s wall clock (155s for the pip layer under qemu amd64 emulation):

```
#9 90.89 Successfully built PiDNG python-prctl
#9 153.1 Successfully installed ... fastapi-0.139.0 ... typing-inspection-0.4.2 ... picamera2-0.3.36 ...
#9 DONE 155.8s
#11 naming to docker.io/library/neh107-fix-test:latest done
```

## Scope

One-line pin bump only. Independent of #23 (piexif/bagit manifest additions); the two PRs touch different lines of requirements.txt and can land in either order.
