### PR TITLE
fix(db): pool_pre_ping and recycle so Postgres restarts do not 500

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -15,10 +15,18 @@ DATABASE_URL = (
 
 
 # Create engine
+# This is an unattended, offline-first appliance (Raspberry Pi): Postgres runs in a
+# Docker container that can restart under the backend (manual `docker restart`, or the
+# container restart policy), which leaves pooled connections stale. Without
+# pool_pre_ping, the next request to draw a stale connection raises OperationalError
+# and 500s the user before the pool discards it — unacceptable when no one is around
+# to retry. pool_recycle proactively retires connections before they go stale.
 engine = create_engine(
 	DATABASE_URL,
 	echo=False,
 	poolclass=QueuePool,
+	pool_pre_ping=True,
+	pool_recycle=1800,
 )
 
 # Session factory


### PR DESCRIPTION
## Problem

This is an offline-first, unattended appliance: Postgres runs in a Docker container that can restart under the backend (manual `docker restart`, or the container restart policy). When that happens, connections held in the SQLAlchemy engine's `QueuePool` (`app/core/db.py`) go stale. The next request that draws one of those stale pooled connections raises `OperationalError`, which surfaces as a 500 to the user — before the pool notices the connection is dead and discards it. On an unattended Pi with no one around to retry or restart the app, that's unacceptable.

## Fix

Add `pool_pre_ping=True` and `pool_recycle=1800` (30 min) to the `create_engine(...)` call in `app/core/db.py`:

- `pool_pre_ping=True` issues a lightweight liveness check before handing out a pooled connection, transparently reconnecting if the check fails, instead of surfacing the error to the request.
- `pool_recycle=1800` proactively retires connections older than 30 minutes so they don't go stale from sitting idle in the pool.

Diff is minimal and surgical — only the two new kwargs plus an explanatory comment; no other engine construction changes.

Refs NEH-142. Closes UCSB-AMPLab/digitization-toolkit-software#160.

## Testing

- `python3 -m py_compile app/core/db.py` — compiles clean.
- Ran the `tests/unit` suite (marker `unit`) in a fresh Python 3.12 venv with core deps + `psycopg[binary]` (no Pi hardware deps): 13 passed, 3 skipped (pre-existing platform gates for non-Linux/Pi environments, unrelated to this change), 9 deselected (non-unit-marked tests in the same directory).
- No existing test asserts on `app/core/db.py`'s engine construction/kwargs — `tests/conftest.py`'s `db_session` fixture builds its own separate SQLite `create_engine(...)` for tests and is unaffected by this change.
