### PR TITLE
fix(docker): pin base images by multi-arch digest

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,6 @@
-FROM python:3.11-slim
+# Pinned by multi-arch index digest for golden-card reproducibility;
+# refresh deliberately with `docker buildx imagetools inspect <image:tag>` when updating.
+FROM python:3.11-slim@sha256:e031123e3d85762b141ad1cbc56452ba69c6e722ebf2f042cc0dc86c47c0d8b3
 WORKDIR /app
 
 # System deps if you add any libs later


### PR DESCRIPTION
## Summary
- Pins `python:3.11-slim` in `Dockerfile.dev` to its multi-arch manifest-list digest, so two golden SD cards provisioned weeks apart build from the exact same base image on both x86 dev machines and the arm64 Pi.
- Part of NEH-149 (see UCSB-AMPLab/digitization-toolkit-software#167).

## Image → digest table

| Image | Digest (manifest-list / index) | File |
|---|---|---|
| `python:3.11-slim` | `sha256:e031123e3d85762b141ad1cbc56452ba69c6e722ebf2f042cc0dc86c47c0d8b3` | `Dockerfile.dev:1` |

## How verified
- Digest obtained live via `docker buildx imagetools inspect python:3.11-slim` (multi-arch index digest, not a single-platform manifest digest).
- Full build verified: `docker build --platform linux/amd64 -f Dockerfile.dev .` completes successfully with the pinned digest — pip install of all backend deps (fastapi, alembic, picamera2, etc.) succeeds.
- Independently re-verified the digest resolves via `docker manifest inspect python:3.11-slim@sha256:e031...`.

## Test plan
- [x] `docker build --platform linux/amd64 -f Dockerfile.dev .` succeeds
- [x] `docker manifest inspect` resolves the pinned digest
- [ ] CI build on merge

## Notes
Comment added at the pin: "refresh deliberately with `docker buildx imagetools inspect <image:tag>` when updating."