### PR TITLE
fix(capture): fsync and atomically write image files before the manifest (NEH-46)

### DIFF
--- a/capture/backends/gphoto2_backend.py
+++ b/capture/backends/gphoto2_backend.py
@@ -39,6 +39,7 @@ except ImportError:
     _GP_AVAILABLE = False
 
 from .base import CameraBackend
+from ..utils import atomic_write
 
 # Image format mapping: CameraConfig.image_format → PTP imageformat widget value
 _IMAGE_FORMAT_MAP = {
@@ -253,7 +254,8 @@ class _PTPSession:
                 camera_file = self._cam.file_get(
                     file_path.folder, file_path.name, gp.GP_FILE_TYPE_NORMAL
                 )
-                camera_file.save(str(actual_outpath))
+                # Durable save: temp + fsync + atomic replace, so no partial master survives a crash
+                atomic_write(actual_outpath, lambda tmp: camera_file.save(tmp))
                 self._cam.file_delete(file_path.folder, file_path.name)
                 elapsed = time.perf_counter() - t0
 

--- a/capture/backends/picamera2_backend.py
+++ b/capture/backends/picamera2_backend.py
@@ -30,6 +30,7 @@ if sys.platform == "linux":
 
 
 from .base import CameraBackend
+from ..utils import atomic_write
 
 
 class Picamera2Backend(CameraBackend):
@@ -426,25 +427,24 @@ class Picamera2Backend(CameraBackend):
                     # Generate raw filename (.raw extension for now due to picamera2 DNG bug)
                     raw_path = Path(str(output_path).rsplit('.', 1)[0] + '.raw')
                     
-                    # Save JPEG first
-                    request.save("main", str(output_path))
+                    # Save JPEG first (durable: temp + fsync + atomic replace)
+                    atomic_write(output_path, lambda tmp: request.save("main", tmp))
                     self.logger.debug(f"Saved JPEG: {Path(output_path).name}")
-                    
+
                     # Save raw buffer directly (workaround for picamera2 save_dng bug)
                     # picamera2 0.3.33 has a bug: Picamera2Camera.__init__() signature mismatch
                     # Saving raw sensor data as binary until library is fixed
                     try:
                         raw_buffer = request.make_buffer("raw")
-                        with open(raw_path, 'wb') as f:
-                            f.write(raw_buffer)
+                        atomic_write(raw_path, lambda tmp: Path(tmp).write_bytes(raw_buffer))
                         self.logger.debug(f"Saved raw buffer: {raw_path.name}")
                         output_path = (str(output_path), str(raw_path))
                     except Exception as e:
                         self.logger.warning(f"Failed to save raw buffer: {e}, continuing with JPEG only")
                         output_path = str(output_path)
                 else:
-                    # Standard JPEG/PNG capture only
-                    request.save("main", str(output_path))
+                    # Standard JPEG/PNG capture only (durable: temp + fsync + atomic replace)
+                    atomic_write(output_path, lambda tmp: request.save("main", tmp))
                     self.logger.debug(f"Saved {'JPEG' if use_yuv else 'PNG'} with quality={camera_config.quality}")
                     
             finally:

--- a/capture/service.py
+++ b/capture/service.py
@@ -29,7 +29,7 @@ backend_dir = Path(__file__).parent.parent
 if str(backend_dir) not in sys.path:
     sys.path.insert(0, str(backend_dir))
 
-from .utils import setup_rotating_logger
+from .utils import setup_rotating_logger, atomic_write
 from .camera import CameraConfig
 from .manifestHandler import generate_manifest_record, append_manifest_record
 from .backends import CameraBackend, RpicamBackend, Picamera2Backend, GPhoto2Backend
@@ -141,7 +141,8 @@ def _apply_rotation(file_path: Path, rotate_deg: int) -> None:
             return
         with _PILImage.open(file_path) as img:
             rotated = img.transpose(transpose_op)
-        rotated.save(str(file_path), quality=95, subsampling=0)
+        # Durable re-save: temp + fsync + atomic replace, never a partial master in place
+        atomic_write(file_path, lambda tmp: rotated.save(tmp, format="JPEG", quality=95, subsampling=0))
 
     elif suffix == ".cr2":
         # Write EXIF Orientation tag into the CR2 without touching sensor data.
@@ -153,7 +154,8 @@ def _apply_rotation(file_path: Path, rotate_deg: int) -> None:
             exif_dict = piexif.load(str(file_path))
             exif_dict["0th"][_EXIF_ORIENTATION_TAG] = exif_val
             exif_bytes = piexif.dump(exif_dict)
-            piexif.insert(exif_bytes, str(file_path))
+            # Durable: insert into a temp copy, then atomically replace the master
+            atomic_write(file_path, lambda tmp: piexif.insert(exif_bytes, str(file_path), tmp))
         except Exception:
             pass  # piexif not available or CR2 EXIF unreadable — silently skip
 

--- a/capture/utils.py
+++ b/capture/utils.py
@@ -1,6 +1,55 @@
 import hashlib
+import os
 import logging
+from pathlib import Path
+from typing import Callable
 from logging.handlers import RotatingFileHandler
+
+
+def _fsync_file(path) -> None:
+    """Flush a file's bytes to disk. O_RDWR so fsync works on Windows too."""
+    fd = os.open(str(path), os.O_RDWR)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _fsync_dir(directory) -> None:
+    """Flush a directory entry so a rename is durable (POSIX; no-op on Windows)."""
+    try:
+        fd = os.open(str(directory), os.O_RDONLY)
+    except OSError:
+        return  # opening a directory fd is not supported on Windows
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def atomic_write(final_path, write_fn: Callable[[str], None]) -> str:
+    """Durably write a file: temp path, fsync, atomic replace, fsync dir.
+
+    write_fn(tmp_path) must write the complete file to the given path. The temp
+    name keeps the final extension so format-by-extension writers still work.
+    On return the final bytes are on disk, so a manifest written afterwards is
+    never more durable than the image it records.
+    """
+    final_path = Path(final_path)
+    tmp_path = final_path.with_name(f"{final_path.stem}.part{final_path.suffix}")
+    try:
+        write_fn(str(tmp_path))
+        _fsync_file(tmp_path)
+        os.replace(str(tmp_path), str(final_path))
+        _fsync_dir(final_path.parent)
+    except BaseException:
+        try:
+            os.unlink(str(tmp_path))
+        except OSError:
+            pass
+        raise
+    return str(final_path)
+
 
 def compute_sha256(file_path: str) -> str:
     """


### PR DESCRIPTION

- add atomic_write helper (temp + fsync + os.replace + dir fsync)

- apply at picamera2/gphoto2 save sites, raw buffer, and JPEG/CR2 rotation re-saves

- ensures the manifest checksum is never more durable than its image