### PR TITLE
fix(registry): durable cameras.json/calibration writes (NEH-50) + plain-text cleanup 

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -89,12 +89,12 @@ Run the setup script to handle all dependencies:
 ```
 
 This script will:
-1. ✓ Check system compatibility
-2. ✓ Install system packages
-3. ✓ Create/update virtual environment
-4. ✓ Link system site-packages
-5. ✓ Install Python dependencies
-6. ✓ Verify installation
+1. [OK] Check system compatibility
+2. [OK] Install system packages
+3. [OK] Create/update virtual environment
+4. [OK] Link system site-packages
+5. [OK] Install Python dependencies
+6. [OK] Verify installation
 
 ## Verification
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 When using AI assistants (GitHub Copilot, ChatGPT, etc.) to work on this codebase, **always** provide these instructions:
 
-### ⚠️ Database Migrations
+### [WARNING] Database Migrations
 
 **NEVER add `Base.metadata.create_all()` to `app/core/db.py`**
 
@@ -29,20 +29,20 @@ def init_db() -> None:
 3. Review the generated migration file
 4. Apply: `docker compose exec backend alembic upgrade head`
 
-### 🔐 Authentication & Security
+### [INFO] Authentication & Security
 
 - **Custom token system is intentional** - This is a standalone/offline Raspberry Pi application
 - Do NOT suggest replacing with JWT libraries (python-jose, PyJWT) or OAuth2
 - Do NOT add `pydantic[email]` dependency - uses simple regex validation for offline compatibility
 - Secret keys must come from environment variables, never hardcoded
 
-### 🐘 PostgreSQL Configuration
+### [INFO] PostgreSQL Configuration
 
 - Use `postgresql+psycopg://` for psycopg3 (NOT `postgresql://`)
 - Always test with PostgreSQL in development (matching production)
 - Database URL format: `postgresql+psycopg://user:password@host:port/database`
 
-### 📦 Configuration Management
+### [INFO] Configuration Management
 
 **Only add settings that are used by application code**
 
@@ -50,18 +50,18 @@ def init_db() -> None:
 - Infrastructure settings (uvicorn host/port) belong in `docker-compose.yml`, not Settings
 - If you're adding a field to Settings, ensure it's actually used in the code
 
-### 🔧 Docker Commands
+### [INFO] Docker Commands
 
 - Use `docker compose` (not `docker-compose`) on Raspberry Pi
 - Always exec into container for Alembic: `docker compose exec backend alembic ...`
 
 ## Common AI Mistakes to Avoid
 
-1. ✗ Re-adding `create_all()` after it was intentionally removed
-2. ✗ Suggesting JWT/OAuth2 for a standalone offline application  
-3. ✗ Adding unused configuration fields "just in case"
-4. ✗ Using `postgresql://` instead of `postgresql+psycopg://`
-5. ✗ Creating migrations outside Docker (wrong database host)
+1. [ERROR] Re-adding `create_all()` after it was intentionally removed
+2. [ERROR] Suggesting JWT/OAuth2 for a standalone offline application  
+3. [ERROR] Adding unused configuration fields "just in case"
+4. [ERROR] Using `postgresql://` instead of `postgresql+psycopg://`
+5. [ERROR] Creating migrations outside Docker (wrong database host)
 
 ## Quick Reference
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ source .venv/bin/activate
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
-Test: Open your browser and navigate to `http://localhost:8000` to see the health check response → `{"status": "ok"}`
+Test: Open your browser and navigate to `http://localhost:8000` to see the health check response -> `{"status": "ok"}`
 
 ## Camera Backend Configuration
 
@@ -101,7 +101,7 @@ python capture/test_phase1_integration.py
 
 ## License
 
-Copyright © 2025 UCSB – Archives, Memory & Preservation Lab.
+Copyright (c) 2025 UCSB - Archives, Memory & Preservation Lab.
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU Affero General Public License as published by the Free

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -51,7 +51,7 @@ def register(
         raise HTTPException(status_code=409, detail="Username or email already exists")
 
     # First user becomes admin (bootstrap); all subsequent users start as reviewer.
-    # Role is never taken from the request payload — use PATCH /auth/users/{id}/role to elevate.
+    # Role is never taken from the request payload - use PATCH /auth/users/{id}/role to elevate.
     role = "admin" if is_first_user else "reviewer"
 
     user = User(
@@ -161,7 +161,7 @@ allow_read_only = RoleChecker(["admin", "operator", "reviewer"])
 
 
 # ---------------------------------------------------------------------------
-# /users/me — current authenticated user's profile
+# /users/me - current authenticated user's profile
 # ---------------------------------------------------------------------------
 
 @users_router.get("/me", response_model=UserRead)

--- a/app/api/cameras.py
+++ b/app/api/cameras.py
@@ -260,7 +260,7 @@ def get_camera_preview(
 	Capture a low-resolution preview frame and return it as JPEG.
 
 	Called by the frontend every PREVIEW_INTERVAL_MS milliseconds for the
-	live preview view.  Uses a lightweight config (1280×720, no AF, no denoise)
+	live preview view.  Uses a lightweight config (1280x720, no AF, no denoise)
 	so frames are returned quickly without interfering with full captures.
 
 	Returns 404 when the requested camera is not connected.
@@ -310,7 +310,7 @@ def flush_preview_tmp_files(
 
 class FocusRequest(BaseModel):
 	"""Request body for manual focus endpoint."""
-	lens_position: float  # Dioptres: 0 = infinity, 10 ≈ 10 cm
+	lens_position: float  # Dioptres: 0 = infinity, 10 ~ 10 cm
 
 
 class FocusResponse(BaseModel):
@@ -371,7 +371,7 @@ class CameraSettingsRequest(BaseModel):
 	awb_enable: Optional[bool] = None         # Auto white-balance on/off
 	exposure_value: Optional[float] = None    # EV compensation (requires ae_enable=True)
 	exposure_time_us: Optional[int] = None    # Manual shutter time in microseconds
-	analogue_gain: Optional[float] = None     # Manual gain (ISO 100 ≈ 1.0)
+	analogue_gain: Optional[float] = None     # Manual gain (ISO 100 ~ 1.0)
 	colour_gains: Optional[List[float]] = None  # Manual WB as [red_gain, blue_gain]
 	zoom_factor: Optional[float] = None       # ScalerCrop digital zoom (1.0 = full sensor)
 
@@ -907,7 +907,7 @@ def calibrate_white_balance(
 				detail=f"{backend.get_backend_name()} backend does not support white balance calibration",
 			)
 
-		# Route WB calibration through the backend's cached Picamera2 instance —
+		# Route WB calibration through the backend's cached Picamera2 instance -
 		# same reason as autofocus: calibration.py would open a second handle and
 		# corrupt the service's cached one.
 		backend = get_backend()
@@ -955,7 +955,7 @@ def commit_manual_white_balance(
 	Commit manually-sampled AWB gains to the camera registry.
 
 	Called after the user clicks on a neutral area in the live preview.
-	No camera capture is performed — the supplied gains are validated and
+	No camera capture is performed - the supplied gains are validated and
 	saved directly to the registry, the same way as after AWB convergence.
 	"""
 	if len(request.awb_gains) < 2:

--- a/app/api/projects.py
+++ b/app/api/projects.py
@@ -57,7 +57,7 @@ def create_project(
     db.add(p)
     db.commit()
     db.refresh(p)
-    # Auto-add creator as explicit member (unless they're an admin — admins are always implicit)
+    # Auto-add creator as explicit member (unless they're an admin - admins are always implicit)
     if current_user.role != "admin":
         member = ProjectMember(
             project_id=p.id,
@@ -230,7 +230,7 @@ def move_collections(
     db.commit()
     log_event(db, level="INFO", category="activity", action="collections_moved",
               actor=current_user.username,
-              subject=f"{source.name} → {target.name} ({moved} collections)")
+              subject=f"{source.name} -> {target.name} ({moved} collections)")
     return {"moved": moved, "target_project_id": payload.target_project_id}
 
 

--- a/app/api/records.py
+++ b/app/api/records.py
@@ -457,12 +457,12 @@ def _apply_status_change(
 	if allowed_roles is None:
 		raise HTTPException(
 			status_code=422,
-			detail=f"Transition '{current_status}' → '{new_status}' is not allowed."
+			detail=f"Transition '{current_status}' -> '{new_status}' is not allowed."
 		)
 	if user_role not in allowed_roles:
 		raise HTTPException(
 			status_code=403,
-			detail=f"Your role '{user_role}' cannot perform the '{current_status}' → '{new_status}' transition."
+			detail=f"Your role '{user_role}' cannot perform the '{current_status}' -> '{new_status}' transition."
 		)
 
 	rec.status = new_status

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -255,7 +255,7 @@ def unmount_device(
 
     target = Path(body.mountpoint)
 
-    # Only allow unmounting paths we own — must be under _MOUNT_BASE
+    # Only allow unmounting paths we own - must be under _MOUNT_BASE
     try:
         target.resolve().relative_to(_MOUNT_BASE.resolve())
     except ValueError:
@@ -394,7 +394,7 @@ def power_control(
 
     This is intentionally NOT admin-only: the operators who run the toolkit are
     often non-technical staff, and anyone with physical access can already pull
-    the plug — a graceful shutdown from the UI is strictly safer than that.
+    the plug - a graceful shutdown from the UI is strictly safer than that.
 
     The action is audit-logged and committed *before* it is triggered (the DB is
     about to go down), then dispatched via a BackgroundTask so the HTTP response

--- a/app/core/audit.py
+++ b/app/core/audit.py
@@ -18,7 +18,7 @@ def log_event(
     """
     Record an audit event in system_logs. Always commits immediately.
 
-    Safe to call from any route — exceptions are suppressed so that a
+    Safe to call from any route - exceptions are suppressed so that a
     logging failure never breaks the main request.
 
     Parameters
@@ -28,8 +28,8 @@ def log_event(
     category : "access" | "activity" | "capture" | "system"
     action   : machine-readable verb, e.g. "login_success", "project_created"
     actor    : username (or None for system-triggered events)
-    subject  : affected entity name (project name, username, …)
-    detail   : free-form extra context (IP address, record count, …)
+    subject  : affected entity name (project name, username, ...)
+    detail   : free-form extra context (IP address, record count, ...)
     """
     try:
         from app.models.system_log import SystemLog  # late import avoids circular refs

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -19,7 +19,7 @@ DATABASE_URL = (
 # Docker container that can restart under the backend (manual `docker restart`, or the
 # container restart policy), which leaves pooled connections stale. Without
 # pool_pre_ping, the next request to draw a stale connection raises OperationalError
-# and 500s the user before the pool discards it — unacceptable when no one is around
+# and 500s the user before the pool discards it - unacceptable when no one is around
 # to retry. pool_recycle proactively retires connections before they go stale.
 engine = create_engine(
 	DATABASE_URL,

--- a/app/core/storage_override.py
+++ b/app/core/storage_override.py
@@ -4,7 +4,7 @@ Persistent override for the active projects storage path.
 Stored in /var/lib/dtk/storage-override.json so it survives backend restarts
 without requiring an env var change or service restart.
 
-All functions are safe to call from any context — failures are logged and
+All functions are safe to call from any context - failures are logged and
 silently swallowed so a corrupt/missing override file never crashes the app.
 """
 import json
@@ -37,7 +37,7 @@ def set_storage_override(projects_root: str) -> None:
 
 
 def clear_storage_override() -> None:
-    """Remove the override — app reverts to default DATA_DIR/projects path."""
+    """Remove the override - app reverts to default DATA_DIR/projects path."""
     try:
         _OVERRIDE_FILE.unlink(missing_ok=True)
     except Exception:

--- a/app/models/system_log.py
+++ b/app/models/system_log.py
@@ -14,6 +14,6 @@ class SystemLog(Base):
     level    = Column(String(10),  nullable=False)  # INFO | WARN | ERR
     category = Column(String(20),  nullable=False)  # access | activity | capture | system
     actor    = Column(String(150), nullable=True)   # username who triggered the event
-    action   = Column(String(80),  nullable=False)  # login_success | project_created | …
+    action   = Column(String(80),  nullable=False)  # login_success | project_created | ...
     subject  = Column(String(300), nullable=True)   # affected entity name
-    detail   = Column(String(500), nullable=True)   # extra context (IP, count, …)
+    detail   = Column(String(500), nullable=True)   # extra context (IP, count, ...)

--- a/capture/backends/gphoto2_backend.py
+++ b/capture/backends/gphoto2_backend.py
@@ -4,16 +4,16 @@ python-gphoto2 backend for DSLR cameras (Canon EOS, etc.).
 Uses persistent PTP sessions for ~1.3s capture times.
 
 Key design decisions:
-  - Sessions opened once and kept alive between captures — no reconnect overhead.
+  - Sessions opened once and kept alive between captures - no reconnect overhead.
   - capturetarget=Internal RAM, reviewtime=None, autopoweroff=0 applied at init.
   - Port map built lazily from gp.Camera.autodetect(); rebuilt automatically on
     session failure (handles USB re-enumeration after camera power-cycle).
   - Flash guard: disables camera flash (flashmode=Off) at session open and before
     every capture. Flash (UV/visible) causes photochemical degradation of archival
-    paper and ink — use external continuous lighting instead.
+    paper and ink - use external continuous lighting instead.
   - Focus mode detection: warns if lens is not in MF (AF causes ~12s PTP hangs).
 
-Tested with: Canon EOS 1500D × 2, USB 2.0, Raspberry Pi.
+Tested with: Canon EOS 1500D x 2, USB 2.0, Raspberry Pi.
 
 Future hooks (wire up when DSLRCameraConfig is introduced):
   - ISO control via `iso` PTP widget
@@ -41,7 +41,7 @@ except ImportError:
 from .base import CameraBackend
 from ..utils import atomic_write
 
-# Image format mapping: CameraConfig.image_format → PTP imageformat widget value
+# Image format mapping: CameraConfig.image_format -> PTP imageformat widget value
 _IMAGE_FORMAT_MAP = {
     "JPEG":     "L",
     "RAW":      "RAW",
@@ -49,7 +49,7 @@ _IMAGE_FORMAT_MAP = {
 }
 # Default when image_format is None
 _IMAGE_FORMAT_DEFAULT = "L"
-# Reverse mapping: PTP widget value → user-facing label
+# Reverse mapping: PTP widget value -> user-facing label
 _IMAGE_FORMAT_REVERSE_MAP = {v: k for k, v in _IMAGE_FORMAT_MAP.items()}
 
 # Minimum settle time used as retry_delay in capture (seconds).
@@ -63,7 +63,7 @@ class _PTPSession:
     An open PTP/USB session to one DSLR camera.
 
     Created once per camera; held alive between captures. Call close() when done.
-    Not thread-safe — callers must hold the per-camera lock.
+    Not thread-safe - callers must hold the per-camera lock.
     """
 
     def __init__(self, port: str, model: str, logger):
@@ -141,7 +141,7 @@ class _PTPSession:
         Fields that are None are left at their current camera value.
         Flash is always enforced off here as an archival safety guard.
         """
-        # ── Flash guard: must be first, before shutter opens ──────────
+        # -- Flash guard: must be first, before shutter opens ----------
         self._enforce_flash_off()
 
         fmt = getattr(camera_config, "image_format", None)
@@ -177,7 +177,7 @@ class _PTPSession:
         focusmode = self._get_config("focusmode")
         if focusmode and focusmode not in ("Manual", "MF"):
             self._logger.warning(
-                f"[gphoto2] {self.port}: focusmode={focusmode!r} — "
+                f"[gphoto2] {self.port}: focusmode={focusmode!r} - "
                 "AF causes ~12s PTP hangs. Flip lens barrel switch to MF."
             )
 
@@ -187,7 +187,7 @@ class _PTPSession:
         Tries to set the flashmode PTP widget to 'Off'.  If the widget is
         read-only or unavailable (some bodies don't expose it), falls back to
         reading the current value and logging a warning if flash is still
-        active.  Never blocks the capture — returns False when flash cannot
+        active.  Never blocks the capture - returns False when flash cannot
         be confirmed off so callers can decide.
 
         Flash (UV/visible) causes photochemical degradation of archival paper
@@ -198,7 +198,7 @@ class _PTPSession:
                 f"[gphoto2] {self.port}: flash disabled (flashmode=Off)"
             )
             return True
-        # Widget is read-only or not present — check current value
+        # Widget is read-only or not present - check current value
         flashmode = self._get_config("flashmode")
         if flashmode is None:
             # Camera doesn't support the widget; assume no flash
@@ -207,7 +207,7 @@ class _PTPSession:
             self._logger.warning(
                 f"[gphoto2] {self.port}: flashmode={flashmode!r} and cannot be "
                 "set to Off automatically. "
-                "Flash is harmful to archival materials — "
+                "Flash is harmful to archival materials - "
                 "manually disable the flash before capturing."
             )
             return False
@@ -230,7 +230,7 @@ class _PTPSession:
         actual_path to reference the saved file.
 
         When imageformat is RAW, the camera produces a .cr2 file. The embedded
-        full-resolution JPEG (6000×4000, 11 ms to extract) is saved alongside
+        full-resolution JPEG (6000x4000, 11 ms to extract) is saved alongside
         the CR2 as ``{stem}_preview.jpg`` so the existing thumbnail/review
         pipeline has a JPEG to work with.
 
@@ -331,9 +331,9 @@ class GPhoto2Backend(CameraBackend):
                 "Add it to pixi.toml with: pixi add python-gphoto2"
             )
         super().__init__(logger)
-        # camera_index → (model_name, usb_port)
+        # camera_index -> (model_name, usb_port)
         self._port_map: dict[int, tuple[str, str]] = {}
-        # camera_index → open _PTPSession
+        # camera_index -> open _PTPSession
         self._sessions: dict[int, _PTPSession] = {}
         # per-camera lock for capture serialisation
         self._session_locks: dict[int, threading.Lock] = {}
@@ -448,7 +448,7 @@ class GPhoto2Backend(CameraBackend):
         Args:
             output_path: Destination path for the captured JPEG.
             camera_config: CameraConfig (camera_index used for routing).
-            capture_output: Unused — kept for interface compatibility.
+            capture_output: Unused - kept for interface compatibility.
 
         Returns:
             Absolute path string to the saved image file.

--- a/capture/backends/picamera2_backend.py
+++ b/capture/backends/picamera2_backend.py
@@ -144,7 +144,7 @@ class Picamera2Backend(CameraBackend):
             camera_id = info.get("Id", "")
             location = info.get("Location", "")
 
-            # Build stable hardware ID — same logic as CameraRegistry (picamera2 path)
+            # Build stable hardware ID - same logic as CameraRegistry (picamera2 path)
             if camera_id:
                 id_parts = camera_id.split("/")
                 i2c_part = [p for p in id_parts if p.startswith("i2c@")]
@@ -293,7 +293,7 @@ class Picamera2Backend(CameraBackend):
         camera_config,
         capture_output: bool = False
     ) -> str:
-        """Internal capture implementation — must be called with the camera lock held."""
+        """Internal capture implementation - must be called with the camera lock held."""
         try:
             picam2 = self._get_camera(camera_config.camera_index)
             
@@ -400,11 +400,11 @@ class Picamera2Backend(CameraBackend):
                 time.sleep(camera_config.timeout / 1000.0)
             
             # Capture image directly to file with metadata
-            # YUV420→JPEG is done efficiently by libcamera/picamera2
+            # YUV420->JPEG is done efficiently by libcamera/picamera2
             # No manual PIL conversion needed
             self.logger.info(f"Capturing image to: {output_path}")
 
-            # Reset ScalerCrop to full sensor — zoom is preview-only.
+            # Reset ScalerCrop to full sensor - zoom is preview-only.
             # Ensures captures always use the full pixel array regardless of
             # whatever zoom the user had applied to the live preview.
             _pixel_array_size = picam2.camera_properties.get('PixelArraySize')
@@ -530,7 +530,7 @@ class Picamera2Backend(CameraBackend):
         Run an autofocus calibration cycle using the cached Picamera2 instance.
 
         Acquires the per-camera lock so this is safe to call while preview
-        polling is active — it blocks until any in-flight preview completes,
+        polling is active - it blocks until any in-flight preview completes,
         then holds the lock for the duration of the AF cycle.
 
         Unlike the legacy ``CameraCalibration`` class, this method does NOT
@@ -613,7 +613,7 @@ class Picamera2Backend(CameraBackend):
         converged ColourGains.
 
         Like ``run_autofocus_calibration``, this method does NOT open a second
-        Picamera2 instance — doing so would corrupt the service's cached handle.
+        Picamera2 instance - doing so would corrupt the service's cached handle.
 
         After the cycle the camera is left stopped; ``_last_configs`` and
         ``_format_mode`` are cleared so the next request reconfigures cleanly.
@@ -632,7 +632,7 @@ class Picamera2Backend(CameraBackend):
             if picam2.started:
                 picam2.stop()
 
-            # Preview config is sufficient for metadata reads — much faster than still
+            # Preview config is sufficient for metadata reads - much faster than still
             preview_config = picam2.create_preview_configuration(
                 main={"size": (1920, 1080)}
             )
@@ -754,7 +754,7 @@ class Picamera2Backend(CameraBackend):
 
         Args:
             camera_index: The camera index.
-            controls: Dict of picamera2 control names → values.
+            controls: Dict of picamera2 control names -> values.
         """
         picam2 = self._cameras.get(camera_index)
         if picam2 is None:

--- a/capture/calibrate-cli.py
+++ b/capture/calibrate-cli.py
@@ -70,6 +70,6 @@ if __name__ == "__main__":
             save_path = sys.argv[2] if len(sys.argv) > 2 else None
             calibrate_camera_interactive(camera_index, save_path)
         except ValueError:
-            print(f"❌ Error: Invalid camera index '{sys.argv[1]}'")
+            print(f"[ERROR] Invalid camera index '{sys.argv[1]}'")
             print("\nUsage: python calibrate.py [camera_index|dual] [save_path]")
             sys.exit(1)

--- a/capture/calibration.py
+++ b/capture/calibration.py
@@ -11,6 +11,8 @@ from datetime import datetime, timezone
 from typing import Optional, Dict, Any
 from picamera2 import Picamera2
 
+from .utils import atomic_write
+
 class CameraCalibration:
     """
     Manages camera calibration for optimal settings.
@@ -61,7 +63,7 @@ class CameraCalibration:
             print(f"\n{'='*70}")
             print(f"FOCUS CALIBRATION - Camera {self.camera_index}")
             print(f"{'='*70}")
-            print("⚠️  Ensure object is at normal working distance!")
+            print("[WARNING] Ensure object is at normal working distance!")
             print(f"Resolution: {img_size[0]}x{img_size[1]}")
         
         picam2 = Picamera2(self.camera_index)
@@ -73,7 +75,7 @@ class CameraCalibration:
         picam2.set_controls({"AfMode": 1})
         
         if verbose:
-            print("\n🔍 Running autofocus...")
+            print("\n[INFO] Running autofocus...")
         
         # Run autofocus cycle and time it
         af_start = time.time()
@@ -99,13 +101,13 @@ class CameraCalibration:
                 result["distance_meters"] = distance_meters
                 
                 if verbose:
-                    print(f"✅ Autofocus succeeded in {af_time:.2f}s")
-                    print(f"📍 Optimal LensPosition: {lens_position:.2f} dioptres")
-                    print(f"📏 Approximate distance: {distance_meters:.2f} meters ({distance_meters*100:.0f} cm)")
-                    print(f"⚡ Using manual focus will be ~100x faster than AF")
+                    print(f"[OK] Autofocus succeeded in {af_time:.2f}s")
+                    print(f"[INFO] Optimal LensPosition: {lens_position:.2f} dioptres")
+                    print(f"[INFO] Approximate distance: {distance_meters:.2f} meters ({distance_meters*100:.0f} cm)")
+                    print(f"[INFO] Using manual focus will be ~100x faster than AF")
         else:
             if verbose:
-                print(f"❌ Autofocus failed after {af_time:.2f}s")
+                print(f"[ERROR] Autofocus failed after {af_time:.2f}s")
         
         picam2.stop()
         picam2.close()
@@ -152,7 +154,7 @@ class CameraCalibration:
             print(f"\n{'='*70}")
             print(f"WHITE BALANCE CALIBRATION - Camera {self.camera_index}")
             print(f"{'='*70}")
-            print("⚠️  Place a neutral gray card or white paper in frame!")
+            print("[WARNING] Place a neutral gray card or white paper in frame!")
             print(f"Resolution: {img_size[0]}x{img_size[1]}")
             print(f"Stabilization frames: {stabilization_frames}")
         
@@ -175,7 +177,7 @@ class CameraCalibration:
             picam2.start()
             
             if verbose:
-                print("\n🔄 Running AWB convergence...")
+                print("\n[INFO] Running AWB convergence...")
             
             # Enable auto white balance and let it converge
             picam2.set_controls({"AwbEnable": True, "AwbMode": 0})  # 0 = Auto
@@ -219,22 +221,22 @@ class CameraCalibration:
                     result["converged"] = variance_r < 0.05 and variance_b < 0.05
                 
                 if verbose:
-                    print(f"\n✅ White balance calibration complete")
-                    print(f"🎨 AWB Gains: Red={final_gains[0]:.3f}, Blue={final_gains[1]:.3f}")
+                    print(f"\n[OK] White balance calibration complete")
+                    print(f"[INFO] AWB Gains: Red={final_gains[0]:.3f}, Blue={final_gains[1]:.3f}")
                     if colour_temp:
-                        print(f"🌡️  Colour temperature: ~{colour_temp}K")
+                        print(f"[INFO] Colour temperature: ~{colour_temp}K")
                     if result.get("converged"):
-                        print(f"✅ AWB converged (stable)")
+                        print(f"[OK] AWB converged (stable)")
                     else:
-                        print(f"⚠️  AWB may not be fully converged, consider more frames")
+                        print(f"[WARNING] AWB may not be fully converged, consider more frames")
             else:
                 if verbose:
-                    print(f"\n❌ Failed to get AWB gains from camera")
+                    print(f"\n[ERROR] Failed to get AWB gains from camera")
                     
         except Exception as e:
             result["error"] = str(e)
             if verbose:
-                print(f"\n❌ White balance calibration failed: {e}")
+                print(f"\n[ERROR] White balance calibration failed: {e}")
         
         # Store in calibration data
         self.calibration_data["white_balance"] = result
@@ -251,11 +253,11 @@ class CameraCalibration:
         """
         filepath = Path(filepath)
         filepath.parent.mkdir(parents=True, exist_ok=True)
-        
-        with open(filepath, 'w') as f:
-            json.dump(self.calibration_data, f, indent=2)
-        
-        print(f"\n💾 Calibration profile saved to: {filepath}")
+
+        # Atomic + durable: temp + fsync + replace, so a power cut cannot truncate it
+        atomic_write(filepath, lambda tmp: Path(tmp).write_text(json.dumps(self.calibration_data, indent=2)))
+
+        print(f"\n[INFO] Calibration profile saved to: {filepath}")
     
     def load_profile(self, filepath: str) -> Dict[str, Any]:
         """
@@ -267,10 +269,13 @@ class CameraCalibration:
         Returns:
             Loaded calibration data
         """
-        with open(filepath, 'r') as f:
-            self.calibration_data = json.load(f)
-        
-        print(f"📂 Loaded calibration profile from: {filepath}")
+        try:
+            with open(filepath, 'r') as f:
+                self.calibration_data = json.load(f)
+            print(f"[INFO] Loaded calibration profile from: {filepath}")
+        except (json.JSONDecodeError, OSError) as e:
+            # Corrupt/unreadable profile: keep current defaults instead of crashing
+            print(f"[WARNING] Could not load calibration profile {filepath} ({e}); keeping defaults")
         return self.calibration_data
     
     def get_recommended_config(self) -> Dict[str, Any]:

--- a/capture/camera_registry.py
+++ b/capture/camera_registry.py
@@ -5,9 +5,12 @@ Manages physical camera identification, calibration, and configuration
 at a global level (PROJECTS_ROOT/cameras.json).
 """
 import json
+import logging
 from pathlib import Path
 from datetime import datetime, timezone
 from typing import Dict, Optional, List, Tuple
+
+from .utils import atomic_write
 
 try:
     from picamera2 import Picamera2
@@ -15,6 +18,8 @@ try:
 except (ImportError, ValueError):
     Picamera2 = None  # type: ignore[assignment]
     _PICAMERA2_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
 
 class CameraRegistry:
     """
@@ -43,16 +48,25 @@ class CameraRegistry:
         self.cameras = self._load_registry()
     
     def _load_registry(self) -> Dict:
-        """Load camera registry from disk."""
-        if self.registry_path.exists():
+        """Load the camera registry, self-healing from a corrupt/truncated file."""
+        if not self.registry_path.exists():
+            return {"cameras": {}, "version": "1.0"}
+        try:
             with open(self.registry_path, 'r') as f:
                 return json.load(f)
-        return {"cameras": {}, "version": "1.0"}
-    
+        except (json.JSONDecodeError, OSError) as e:
+            # Corrupt/unreadable registry: keep it aside for inspection and start
+            # fresh so project creation and captures are never blocked.
+            logger.warning(f"cameras.json is unreadable ({e}); starting from an empty registry")
+            try:
+                self.registry_path.replace(self.registry_path.with_name(self.registry_path.name + ".corrupt"))
+            except OSError:
+                pass
+            return {"cameras": {}, "version": "1.0"}
+
     def _save_registry(self):
-        """Save camera registry to disk."""
-        with open(self.registry_path, 'w') as f:
-            json.dump(self.cameras, f, indent=2)
+        """Save the camera registry atomically (temp + fsync + replace)."""
+        atomic_write(self.registry_path, lambda tmp: Path(tmp).write_text(json.dumps(self.cameras, indent=2)))
     
     @staticmethod
     def _get_camera_hardware_id_gphoto2(camera_index: int) -> Tuple[Optional[str], Dict]:
@@ -347,10 +361,10 @@ def initialize_camera_system(run_calibration: bool = True) -> Dict:
             focus_result = cal.calibrate_focus(verbose=False)
             
             if focus_result["success"]:
-                print(f"  ✅ Focus calibrated: {focus_result['lens_position']:.2f} dioptres")
+                print(f"  [OK] Focus calibrated: {focus_result['lens_position']:.2f} dioptres")
                 registry.update_calibration(hw_id, cal.calibration_data)
             else:
-                print(f"  ❌ Calibration failed")
+                print(f"  [ERROR] Calibration failed")
         
         results["cameras"][idx] = {
             "hardware_id": hw_id,

--- a/capture/project_manager.py
+++ b/capture/project_manager.py
@@ -34,9 +34,9 @@ def _projects_root() -> Path:
     """Resolve the active projects root at call time.
 
     Read from settings on every call (rather than a module-level constant
-    captured at import) so a runtime storage-drive switch — POST
+    captured at import) so a runtime storage-drive switch - POST
     /system/storage/activate flips the storage override in
-    app.core.config.Settings.projects_dir — takes effect immediately for new
+    app.core.config.Settings.projects_dir - takes effect immediately for new
     captures, keeping writes and reads on the same disk.
     """
     return settings.projects_dir

--- a/capture/scripts/dual_shoot.sh
+++ b/capture/scripts/dual_shoot.sh
@@ -68,7 +68,7 @@ try_capture() {
   local e1_ms=$(( t1_end - t1_start ))
   local delta_start_ms=$(( t1_start - t0_start ))
 
-  # Safe defaults if files didn’t materialize
+  # Safe defaults if files didn't materialize
   local b0=0 b1=0 s0="" s1=""
   [[ -f "$f0" ]] && b0=$(stat -c%s "$f0") && s0=$(sha256_of "$f0")
   [[ -f "$f1" ]] && b1=$(stat -c%s "$f1") && s1=$(sha256_of "$f1")

--- a/capture/scripts/gphoto2_lib_test.py
+++ b/capture/scripts/gphoto2_lib_test.py
@@ -10,7 +10,7 @@ Key findings from testing:
   - Lens barrel MUST be set to MF (manual focus). AF causes ~12s hangs.
   - capturetarget=Internal RAM and reviewtime=None are set automatically.
   - Stable external continuous lighting eliminates exposure-hunt errors.
-    Do NOT use the built-in popup flash — UV/visible flash causes
+    Do NOT use the built-in popup flash - UV/visible flash causes
     photochemical degradation of archival paper and ink.
   - settle=3s between shots is the reliable minimum for the 1500D.
 
@@ -37,14 +37,14 @@ except ImportError:
 
 
 # ---------------------------------------------------------------------------
-# Camera context manager — holds the PTP session open between captures
+# Camera context manager - holds the PTP session open between captures
 # ---------------------------------------------------------------------------
 
 class DSLRCamera:
     """Persistent gphoto2 camera session. Use as a context manager.
 
     Opens the PTP session once on enter, applies speed settings, and keeps
-    the connection alive for multiple captures — no reconnect overhead or
+    the connection alive for multiple captures - no reconnect overhead or
     Device Busy errors between shots.
     """
 
@@ -56,7 +56,7 @@ class DSLRCamera:
     def __enter__(self):
         # gphoto2 requires BOTH port info AND camera abilities (model driver).
         # Setting only the port gives -105 Unknown model on init().
-        # autodetect() is NOT thread-safe — callers should pass model= explicitly
+        # autodetect() is NOT thread-safe - callers should pass model= explicitly
         # when opening cameras from worker threads.
         model = self.model
         if model is None:
@@ -122,7 +122,7 @@ class DSLRCamera:
         """Capture and download one image. Returns elapsed seconds.
 
         Retries within the same persistent session on transient I/O-busy
-        errors — no reconnect needed, just a short wait for the camera buffer.
+        errors - no reconnect needed, just a short wait for the camera buffer.
         Fatal errors (e.g. -1 Unspecified) are raised immediately.
         """
         outpath.parent.mkdir(parents=True, exist_ok=True)

--- a/capture/scripts/gphoto2_test.py
+++ b/capture/scripts/gphoto2_test.py
@@ -103,9 +103,9 @@ def cmd_config(args):
             current = info.get("current", "?")
             choices = info.get("choices", [])
             if key == "focusmode" and current not in ("Manual", "MF"):
-                marker = " ◀ SET LENS TO MF — AF is the main source of latency & PTP Busy errors"
+                marker = " < SET LENS TO MF - AF is the main source of latency & PTP Busy errors"
             elif key in ("capturetarget", "reviewtime", "continuousaf"):
-                marker = " ◀ speed-relevant"
+                marker = " < speed-relevant"
             else:
                 marker = ""
             print(f"  {label:30s}  current={current!r:20s}  choices={choices}{marker}")
@@ -123,8 +123,8 @@ def cmd_preset(args):
     ports = args.port  # list
 
     # Settings that minimise capture+download latency:
-    #   capturetarget=0  → Internal RAM (skip SD card write)
-    #   reviewtime=0     → No on-camera image review delay (if supported)
+    #   capturetarget=0  -> Internal RAM (skip SD card write)
+    #   reviewtime=0     -> No on-camera image review delay (if supported)
     speed_settings = [
         ("capturetarget", "0"),   # Internal RAM
         ("reviewtime",    "0"),   # None / Off
@@ -135,7 +135,7 @@ def cmd_preset(args):
         for key, val in speed_settings:
             r = _gphoto2("--set-config", f"{key}={val}", port=port, timeout=10)
             status = "OK" if r.returncode == 0 else f"SKIP ({r.stderr.strip().splitlines()[-1] if r.stderr else 'unknown'})"
-            print(f"  set {key}={val!r}  → {status}")
+            print(f"  set {key}={val!r}  -> {status}")
 
     print("\nDone. Run 'config' subcommand to verify.")
 
@@ -154,7 +154,7 @@ def _capture_one(port: str, outpath: Path, retry: int = 3, retry_delay: float = 
 
     Note: 'PTP Device Busy / Canon EOS Full-Press failed' is almost always
     caused by autofocus being active (AI Focus / AI Servo mode). The fix is
-    to switch the lens barrel switch to MF (manual focus) — AF cannot be
+    to switch the lens barrel switch to MF (manual focus) - AF cannot be
     disabled via software on these bodies. With MF the first attempt succeeds
     immediately and no retries are needed.
     """
@@ -189,7 +189,7 @@ def _capture_one(port: str, outpath: Path, retry: int = 3, retry_delay: float = 
 def cmd_capture(args):
     """Capture a single image from one camera."""
     outpath = Path(args.out)
-    print(f"Capturing from {args.port} → {outpath} ...")
+    print(f"Capturing from {args.port} -> {outpath} ...")
     result = _capture_one(args.port, outpath)
     if result.success:
         size = outpath.stat().st_size / 1_048_576

--- a/capture/service.py
+++ b/capture/service.py
@@ -104,9 +104,9 @@ def is_camera_connected(camera_index: int = 0) -> bool:
 # EXIF Orientation tag values for clockwise rotations.
 # The image/sensor data is never modified; viewers that honour EXIF display the page upright, so the preservation master keeps full fidelity.
 _EXIF_ORIENTATION_FOR_DEG = {
-    90: 6,    # 90° CW  > EXIF "rotated 90 CW"
-    180: 3,   # 180°    > EXIF "rotated 180"
-    270: 8,   # 270° CW > EXIF "rotated 90 CCW"
+    90: 6,    # 90 deg CW  > EXIF "rotated 90 CW"
+    180: 3,   # 180 deg    > EXIF "rotated 180"
+    270: 8,   # 270 deg CW > EXIF "rotated 90 CCW"
 }
 
 # Offset of the EXIF Orientation tag within a CR2/JPEG EXIF block.
@@ -119,7 +119,7 @@ def _apply_rotation(file_path: Path, rotate_deg: int) -> None:
 
     Applies to JPEG and CR2 masters: the pixel/sensor data is never re-encoded,
     only the orientation metadata is set, so the preservation master keeps full
-    fidelity. Skips 0° and unsupported file types.
+    fidelity. Skips 0 deg and unsupported file types.
     """
     deg = rotate_deg % 360
     if deg == 0:
@@ -437,13 +437,13 @@ def capture_preview_frame(camera_index: int) -> bytes:
     """
     Capture a low-resolution preview frame and return JPEG bytes.
 
-    Not saved to the project directory — intended for live preview polling
+    Not saved to the project directory - intended for live preview polling
     from the frontend. Uses a stable per-camera temp file that is overwritten
     on every call (rather than mkstemp), so at most one file per camera ever
     exists in /tmp even if the process is killed unexpectedly.
 
     The preview uses a lightweight configuration:
-      - 1280×720 (native fast mode, no cropping)
+      - 1280x720 (native fast mode, no cropping)
       - No autofocus cycle (too slow for live preview)
       - No AE stabilisation wait
       - No temporal denoise warmup
@@ -470,7 +470,7 @@ def capture_preview_frame(camera_index: int) -> bytes:
     except NotImplementedError:
         pass  # fall through to picamera2 path
 
-    # Fixed per-camera path — overwrites the same file each poll cycle.
+    # Fixed per-camera path - overwrites the same file each poll cycle.
     # A per-camera lock serialises concurrent requests so two tabs never
     # race on the same path.
     tmp_path = _PREVIEW_TMP_DIR / f"{_PREVIEW_PREFIX}{camera_index}.jpg"
@@ -478,7 +478,7 @@ def capture_preview_frame(camera_index: int) -> bytes:
 
     preview_config = CameraConfig(
         camera_index=camera_index,
-        img_size=(1280, 720),        # Native 80 fps mode — fast, no crop
+        img_size=(1280, 720),        # Native 80 fps mode - fast, no crop
         autofocus_on_capture=False,  # Skip AF cycle for live preview
         timeout=0,                   # No AE stabilisation wait
         denoise_frames=0,            # No temporal denoise warmup

--- a/scripts/setup_camera_backends.sh
+++ b/scripts/setup_camera_backends.sh
@@ -54,10 +54,10 @@ PICAMERA2_PACKAGES=(
 # Check and install common packages
 for pkg in "${COMMON_PACKAGES[@]}"; do
     if check_installed "$pkg"; then
-        echo -e "${GREEN}✓${NC} $pkg (already installed)"
+        echo -e "${GREEN}[OK]${NC} $pkg (already installed)"
     else
-        echo -e "${YELLOW}→${NC} Installing $pkg..."
-        sudo apt-get install -y "$pkg" || echo -e "${RED}✗ Failed to install $pkg${NC}"
+        echo -e "${YELLOW}->${NC} Installing $pkg..."
+        sudo apt-get install -y "$pkg" || echo -e "${RED}[ERROR] Failed to install $pkg${NC}"
     fi
 done
 
@@ -66,10 +66,10 @@ echo ""
 echo "Installing Picamera2 system dependencies..."
 for pkg in "${PICAMERA2_PACKAGES[@]}"; do
     if check_installed "$pkg"; then
-        echo -e "${GREEN}✓${NC} $pkg (already installed)"
+        echo -e "${GREEN}[OK]${NC} $pkg (already installed)"
     else
-        echo -e "${YELLOW}→${NC} Installing $pkg..."
-        sudo apt-get install -y "$pkg" || echo -e "${RED}✗ Failed to install $pkg${NC}"
+        echo -e "${YELLOW}->${NC} Installing $pkg..."
+        sudo apt-get install -y "$pkg" || echo -e "${RED}[ERROR] Failed to install $pkg${NC}"
     fi
 done
 
@@ -81,9 +81,9 @@ BACKEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_DIR="$BACKEND_DIR/.venv"
 
 if [ -d "$VENV_DIR" ]; then
-    echo -e "${GREEN}✓${NC} Virtual environment exists: $VENV_DIR"
+    echo -e "${GREEN}[OK]${NC} Virtual environment exists: $VENV_DIR"
 else
-    echo -e "${YELLOW}→${NC} Creating virtual environment..."
+    echo -e "${YELLOW}->${NC} Creating virtual environment..."
     python3 -m venv "$VENV_DIR"
 fi
 
@@ -92,11 +92,11 @@ SITE_PACKAGES="$VENV_DIR/lib/python3.11/site-packages"
 PTH_FILE="$SITE_PACKAGES/system-packages.pth"
 
 if [ -f "$PTH_FILE" ]; then
-    echo -e "${GREEN}✓${NC} System packages already linked to venv"
+    echo -e "${GREEN}[OK]${NC} System packages already linked to venv"
 else
-    echo -e "${YELLOW}→${NC} Linking system site-packages to venv..."
+    echo -e "${YELLOW}->${NC} Linking system site-packages to venv..."
     echo "/usr/lib/python3/dist-packages" > "$PTH_FILE"
-    echo -e "${GREEN}✓${NC} System packages linked (libcamera accessible in venv)"
+    echo -e "${GREEN}[OK]${NC} System packages linked (libcamera accessible in venv)"
 fi
 
 echo ""
@@ -106,16 +106,16 @@ echo "----------------------------------------"
 source "$VENV_DIR/bin/activate"
 
 # Upgrade pip
-echo -e "${YELLOW}→${NC} Upgrading pip..."
+echo -e "${YELLOW}->${NC} Upgrading pip..."
 pip install --upgrade pip -q
 
 # Install requirements
 if [ -f "$BACKEND_DIR/requirements.txt" ]; then
-    echo -e "${YELLOW}→${NC} Installing from requirements.txt..."
+    echo -e "${YELLOW}->${NC} Installing from requirements.txt..."
     pip install -r "$BACKEND_DIR/requirements.txt"
-    echo -e "${GREEN}✓${NC} Python dependencies installed"
+    echo -e "${GREEN}[OK]${NC} Python dependencies installed"
 else
-    echo -e "${RED}✗ requirements.txt not found${NC}"
+    echo -e "${RED}[ERROR] requirements.txt not found${NC}"
     exit 1
 fi
 
@@ -124,26 +124,26 @@ echo "Step 5: Verifying installation..."
 echo "--------------------------------"
 
 # Test imports
-echo -e "${YELLOW}→${NC} Testing camera backend imports..."
+echo -e "${YELLOW}->${NC} Testing camera backend imports..."
 
-if python3 -c "from capture.backends import RpicamBackend; print('✓ RpicamBackend')" 2>/dev/null; then
-    echo -e "${GREEN}✓${NC} Subprocess backend available"
+if python3 -c "from capture.backends import RpicamBackend; print('[OK] RpicamBackend')" 2>/dev/null; then
+    echo -e "${GREEN}[OK]${NC} Subprocess backend available"
 else
-    echo -e "${RED}✗ Subprocess backend failed to import${NC}"
+    echo -e "${RED}[ERROR] Subprocess backend failed to import${NC}"
 fi
 
-if python3 -c "from capture.backends import Picamera2Backend; print('✓ Picamera2Backend')" 2>/dev/null; then
-    echo -e "${GREEN}✓${NC} Picamera2 backend available"
+if python3 -c "from capture.backends import Picamera2Backend; print('[OK] Picamera2Backend')" 2>/dev/null; then
+    echo -e "${GREEN}[OK]${NC} Picamera2 backend available"
 else
-    echo -e "${RED}✗ Picamera2 backend failed to import${NC}"
+    echo -e "${RED}[ERROR] Picamera2 backend failed to import${NC}"
     echo -e "${YELLOW}  This may be due to missing system packages${NC}"
 fi
 
 # Test libcamera
-if python3 -c "import libcamera; print('✓ libcamera')" 2>/dev/null; then
-    echo -e "${GREEN}✓${NC} libcamera Python bindings accessible"
+if python3 -c "import libcamera; print('[OK] libcamera')" 2>/dev/null; then
+    echo -e "${GREEN}[OK]${NC} libcamera Python bindings accessible"
 else
-    echo -e "${YELLOW}⚠${NC} libcamera not accessible (picamera2 backend will not work)"
+    echo -e "${YELLOW}[WARNING]${NC} libcamera not accessible (picamera2 backend will not work)"
 fi
 
 echo ""

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -53,7 +53,7 @@ def test_imports():
         
         return True
     except Exception as e:
-        print(f"✗ Import failed: {e}")
+        print(f"[ERROR] Import failed: {e}")
         return False
 
 
@@ -72,7 +72,7 @@ def test_password_hashing():
         print(" [OK] Password hashing works correctly")
         return True
     except Exception as e:
-        print(f"✗ Password hashing test failed: {e}")
+        print(f"[ERROR] Password hashing test failed: {e}")
         return False
 
 
@@ -99,7 +99,7 @@ def test_token_generation():
         print(" [OK] Token generation and verification works correctly")
         return True
     except Exception as e:
-        print(f"✗ Token test failed: {e}")
+        print(f"[ERROR] Token test failed: {e}")
         return False
 
 
@@ -142,7 +142,7 @@ def test_schemas():
         print(" [OK] Schema validation works correctly")
         return True
     except Exception as e:
-        print(f"✗ Schema test failed: {e}")
+        print(f"[ERROR] Schema test failed: {e}")
         return False
 
 
@@ -190,10 +190,10 @@ def test_routes():
         print(" [OK] All required routes are registered")
         return True
     except AssertionError as e:
-        print(f"✗ Route test failed: {e}")
+        print(f"[ERROR] Route test failed: {e}")
         return False
     except Exception as e:
-        print(f"✗ Route test error: {e}")
+        print(f"[ERROR] Route test error: {e}")
         return False
 
 
@@ -220,10 +220,10 @@ def test_models():
         print(" [OK] All models are properly registered")
         return True
     except AssertionError as e:
-        print(f"✗ Model test failed: {e}")
+        print(f"[ERROR] Model test failed: {e}")
         return False
     except Exception as e:
-        print(f"✗ Model test error: {e}")
+        print(f"[ERROR] Model test error: {e}")
         return False
 
 
@@ -250,7 +250,7 @@ def test_new_endpoints():
         print(" [OK] New endpoint schemas work correctly")
         return True
     except Exception as e:
-        print(f"✗ New endpoint test failed: {e}")
+        print(f"[ERROR] New endpoint test failed: {e}")
         return False
 
 

--- a/tests/unit/test_projects_root_live.py
+++ b/tests/unit/test_projects_root_live.py
@@ -9,7 +9,7 @@ Before the fix, capture/project_manager.py captured
 ``PROJECTS_ROOT = settings.projects_dir`` as a module-level constant at import
 time, so after an operator activated an external drive new captures kept
 writing to the OLD root while the registry/delete/export/storage-panel readers
-followed the NEW root — splitting a project across two disks.
+followed the NEW root - splitting a project across two disks.
 
 Run with: python -m pytest tests/unit/test_projects_root_live.py
 """
@@ -18,7 +18,7 @@ import tempfile
 from pathlib import Path
 
 # Importing capture.project_manager runs LOG_FILE.parent.mkdir(...) at module
-# import time, with settings.log_dir defaulting to /var/log/dtk — not writable
+# import time, with settings.log_dir defaulting to /var/log/dtk - not writable
 # on dev machines. Point the already-instantiated settings at a writable temp
 # dir BEFORE the capture import so this test is hermetic.
 from app.core.config import settings
@@ -43,7 +43,7 @@ def test_project_capture_root_follows_runtime_override(tmp_path, monkeypatch):
         lambda: str(new_root),
     )
 
-    # No re-import of pm — the module has been imported once already, exactly
+    # No re-import of pm - the module has been imported once already, exactly
     # as it is in the long-running backend process when the drive is switched.
     resolved = pm.project_capture_root("My Project")
 
@@ -54,7 +54,7 @@ def test_project_capture_root_follows_runtime_override(tmp_path, monkeypatch):
 
 def test_projects_root_reflects_override_change_between_calls(tmp_path, monkeypatch):
     """Two successive resolutions with different overrides must land on
-    different disks — proving the root is read per call, not cached."""
+    different disks - proving the root is read per call, not cached."""
     root_a = tmp_path / "disk-a"
     root_b = tmp_path / "disk-b"
     root_a.mkdir()

--- a/tests/unit/test_system_power.py
+++ b/tests/unit/test_system_power.py
@@ -156,7 +156,7 @@ def test_power_helper_failure_is_logged(power_client, monkeypatch):
 
     resp = power_client.post("/system/power", json={"action": "poweroff"})
 
-    # The endpoint itself still returns 200 — the failure happens post-response.
+    # The endpoint itself still returns 200 - the failure happens post-response.
     assert resp.status_code == 200
     assert errors, "helper failure should have been logged"
     assert "poweroff" in errors[-1]

--- a/tests/unit/test_system_storage_helper.py
+++ b/tests/unit/test_system_storage_helper.py
@@ -6,7 +6,7 @@ raw sudo mount/umount/mkdir/chown.
 
 These assert the exact argv passed to subprocess.run so a future regression that
 reintroduces raw sudo calls (or the hardcoded pi:pi chown) is caught. They also
-assert the backend never mkdirs/rmdirs under the mounts root — the root is
+assert the backend never mkdirs/rmdirs under the mounts root - the root is
 root-owned and the helper is its only writer. Run with:
     python -m pytest tests/unit/test_system_storage_helper.py
 """
@@ -89,7 +89,7 @@ def test_mount_uses_helper_and_does_not_mkdir(admin_client, monkeypatch, dir_op_
 @pytest.mark.unit
 def test_mount_failure_returns_500_without_cleanup(admin_client, monkeypatch, dir_op_recorder):
     """When the helper fails, surface its stderr as a 500 and do NOT try to
-    rmdir the mountpoint — the helper cleans up its own directory."""
+    rmdir the mountpoint - the helper cleans up its own directory."""
     import app.api.system as system
 
     monkeypatch.setattr(system, "_parse_lsblk", _one_vfat_partition)


### PR DESCRIPTION
## What
Two related changes on the backend:

1. **NEH-50 fix** - make the camera registry and calibration profiles durable.
   - `cameras.json` (`camera_registry.py`) and calibration profiles
     (`calibration.py`) are now written atomically (temp + fsync + os.replace),
     so a power cut can no longer leave truncated JSON.
   - `_load_registry`/`load_profile` catch `JSONDecodeError`/`OSError`: a
     corrupt file is set aside as `.corrupt` and load falls back to defaults,
     so a bad registry no longer blocks project creation persistently.

2. **Cleanup** - replace emojis/unicode with plain text across the backend.
   - Status emojis become indicators: `[OK]`, `[ERROR]`, `[WARNING]`; other
     decorative emojis become `[INFO]`.
   - Typographic symbols become ASCII (dashes -> `-`, arrow -> `->`,
     multiplication -> `x`, degree -> `deg`, ellipsis -> `...`, etc.)

The two logical parts are in separate commits, so the cleanup can be split out
if preferred.

---

Closes #68
