### PR TITLE
fix(api): order GET /records by id for deterministic results

### DIFF
--- a/app/api/records.py
+++ b/app/api/records.py
@@ -108,7 +108,10 @@ def list_records(
 	if orphaned is True:
 		query = query.filter(Record.project_id == None, Record.collection_id == None)
 	
-	recs = query.offset(skip).limit(limit).all()
+	# Deterministic order: without an ORDER BY, Postgres returns heap order,
+	# which shifts when rows are updated (NEH-159). Also required for stable
+	# skip/limit pagination.
+	recs = query.order_by(Record.id).offset(skip).limit(limit).all()
 	return [RecordRead.model_validate(r) for r in recs]
 
 


### PR DESCRIPTION
Companion to UCSB-AMPLab/digitization-toolkit-frontend#25 (NEH-159).

`list_records` had no `ORDER BY`, so Postgres returned heap order — usually insertion order, but a row relocates when it's updated (e.g. a dual capture extending a record), which is what produced the occasional out-of-order thumbnail reported from Rionegro. The frontend strip now sorts defensively on its side; this makes the API itself deterministic for every consumer, and an explicit `ORDER BY` is in any case a precondition for stable `skip`/`limit` pagination.

One line plus a comment. Test suite result is identical before and after the change (2 failed, 14 passed, 2 skipped, 14 errors in the dev container — all pre-existing on `dev`); the modified query verified directly against the dev database.