### PR TITLE
fix(records): keep a record's single parent on assignment (NEH-85)

### DIFF
--- a/app/api/projects.py
+++ b/app/api/projects.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List, Optional
 from sqlalchemy.orm import Session
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 from pydantic import BaseModel
 import logging
 
@@ -107,9 +108,15 @@ def add_record_to_project(
     r = db.query(Record).filter(Record.id == rec_id).first()
     if not r:
         raise HTTPException(status_code=404, detail="Record not found")
+    # A record has one parent: attaching it to a project detaches it from any collection
     r.project_id = p.id
+    r.collection_id = None
     db.add(r)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Record parent assignment violates a database constraint")
     return {"detail": "record added"}
 
 

--- a/app/api/records.py
+++ b/app/api/records.py
@@ -156,12 +156,27 @@ def update_record(
 	if not rec:
 		raise HTTPException(status_code=404, detail="Record not found")
 	
-	# Update only provided fields
-	for field, value in payload.model_dump(exclude_unset=True).items():
+	data = payload.model_dump(exclude_unset=True)
+
+	# A record has at most one parent: reject setting both, null the opposite when one is set
+	set_project = data.get("project_id") is not None
+	set_collection = data.get("collection_id") is not None
+	if set_project and set_collection:
+		raise HTTPException(status_code=400, detail="A record cannot belong to both a project and a collection")
+	if set_project:
+		data["collection_id"] = None
+	elif set_collection:
+		data["project_id"] = None
+
+	for field, value in data.items():
 		setattr(rec, field, value)
-	
+
 	db.add(rec)
-	db.commit()
+	try:
+		db.commit()
+	except IntegrityError:
+		db.rollback()
+		raise HTTPException(status_code=409, detail="Record parent assignment violates a database constraint")
 	db.refresh(rec)
 	return RecordRead.model_validate(rec)
 


### PR DESCRIPTION
Assigning a record to a project/collection could violate the single-parent CHECK and return an unhandled 500. update_record and add_record_to_project now null the opposing parent when one is set, reject setting both (400), and guard the commit with IntegrityError -> 409