### PR TITLE
fix(auth): check is_active in get_current_user (NEH-53)

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -138,9 +138,10 @@ def get_current_user(
     if not payload:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
     user_id = int(payload.get("sub"))
-    user = db.query(User).filter(User.id == user_id).first()
+    # Mirror refresh_token: reject deactivated users so deactivation cuts access on the next request
+    user = db.query(User).filter(User.id == user_id, User.is_active == True).first()
     if not user:
-        raise HTTPException(status_code=401, detail="User not found")
+        raise HTTPException(status_code=401, detail="User not found or inactive")
     return user
 
 


### PR DESCRIPTION
get_current_user validated the token and that the user exists but never filtered on is_active, so a deactivated user kept a working session until token expiry (up to 8h). Now it mirrors the is_active filter that refresh_token already applies, returning 401 for a deactivated user, so deactivation cuts access on the next request. 

Closes NEH-53