### PR TITLE
feat(annotations): add record annotations functionality with CRUD operations

### DIFF
--- a/alembic/versions/1a5f017816fd_add_record_annotations_table.py
+++ b/alembic/versions/1a5f017816fd_add_record_annotations_table.py
@@ -1,0 +1,46 @@
+"""add_record_annotations_table
+
+Revision ID: 1a5f017816fd
+Revises: ff2f751fadbb
+Create Date: 2026-07-22 15:15:20.499432
+
+Adds record_annotations: persists the QA "Anotaciones" tab (flagged error
+typologies + free-text notes), which previously only lived in local
+component state and was lost on navigation/refresh.
+
+Note: autogenerate also proposed dropping collections.export_version,
+last_exported_at and last_export_hash — those columns exist in the DB
+(migration dda9bc1bc608) but aren't declared on the Collection model, a
+pre-existing drift unrelated to this change. Left untouched here.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '1a5f017816fd'
+down_revision: Union[str, None] = 'ff2f751fadbb'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table('record_annotations',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('record_id', sa.Integer(), nullable=False),
+    sa.Column('error_types', sa.JSON(), nullable=True),
+    sa.Column('note', sa.Text(), nullable=True),
+    sa.Column('created_at', sa.DateTime(), nullable=False),
+    sa.Column('created_by', sa.String(length=255), nullable=True),
+    sa.ForeignKeyConstraint(['record_id'], ['records.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_record_annotations_id'), 'record_annotations', ['id'], unique=False)
+    op.create_index(op.f('ix_record_annotations_record_id'), 'record_annotations', ['record_id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_record_annotations_record_id'), table_name='record_annotations')
+    op.drop_index(op.f('ix_record_annotations_id'), table_name='record_annotations')
+    op.drop_table('record_annotations')

--- a/app/api/records.py
+++ b/app/api/records.py
@@ -9,13 +9,14 @@ import logging
 
 from app.api.deps import get_db_dependency
 from app.api.auth import get_current_user, RoleChecker
-from app.models.record import Record, RecordImage, ExifData
+from app.models.record import Record, RecordImage, ExifData, RecordAnnotation
 from app.models.camera import CameraSettings
 from app.models.user import User
 from app.schemas.record import (
 	RecordCreate, RecordRead, RecordUpdate,
 	RecordImageCreate, RecordImageRead, RecordImageUpdate,
-	RecordStatusUpdate, BulkStatusUpdate, STATUS_TRANSITIONS
+	RecordStatusUpdate, BulkStatusUpdate, STATUS_TRANSITIONS,
+	RecordAnnotationCreate, RecordAnnotationRead,
 )
 from app.core.config import settings
 from app.core.paths import resolve_within_storage
@@ -491,6 +492,70 @@ def get_image_thumbnail(
 		filename=f"{Path(img.filename).stem}_thumb.jpg",
 		media_type="image/jpeg"
 	)
+
+
+# ==============================================================================
+# Annotation endpoints (QA "Anotaciones" tab: flagged errors + notes)
+# ==============================================================================
+
+@router.get("/{rec_id}/annotations", response_model=List[RecordAnnotationRead])
+def list_record_annotations(
+	rec_id: int,
+	current_user: User = Depends(allow_read_only),
+	db: Session = Depends(get_db_dependency)
+):
+	"""List all annotations for a record, newest first."""
+	rec = db.query(Record).filter(Record.id == rec_id).first()
+	if not rec:
+		raise HTTPException(status_code=404, detail="Record not found")
+
+	annotations = (
+		db.query(RecordAnnotation)
+		.filter(RecordAnnotation.record_id == rec_id)
+		.order_by(RecordAnnotation.created_at.desc())
+		.all()
+	)
+	return [RecordAnnotationRead.model_validate(a) for a in annotations]
+
+
+@router.post("/{rec_id}/annotations", response_model=RecordAnnotationRead)
+def create_record_annotation(
+	rec_id: int,
+	payload: RecordAnnotationCreate,
+	current_user: User = Depends(allow_read_only),
+	db: Session = Depends(get_db_dependency)
+):
+	"""Add an annotation (flagged error and/or note) to a record."""
+	rec = db.query(Record).filter(Record.id == rec_id).first()
+	if not rec:
+		raise HTTPException(status_code=404, detail="Record not found")
+
+	annotation = RecordAnnotation(
+		record_id=rec_id,
+		error_types=payload.error_types,
+		note=payload.note,
+		created_by=current_user.username,
+	)
+	db.add(annotation)
+	db.commit()
+	db.refresh(annotation)
+	return RecordAnnotationRead.model_validate(annotation)
+
+
+@router.delete("/annotations/{annotation_id}")
+def delete_record_annotation(
+	annotation_id: int,
+	current_user: User = Depends(allow_read_only),
+	db: Session = Depends(get_db_dependency)
+):
+	"""Delete a single annotation."""
+	annotation = db.query(RecordAnnotation).filter(RecordAnnotation.id == annotation_id).first()
+	if not annotation:
+		raise HTTPException(status_code=404, detail="Annotation not found")
+
+	db.delete(annotation)
+	db.commit()
+	return {"detail": "Annotation deleted"}
 
 
 # ==============================================================================

--- a/app/models/record.py
+++ b/app/models/record.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from sqlalchemy import Column, Integer, String, DateTime, Text, ForeignKey, CheckConstraint
+from sqlalchemy import Column, Integer, String, DateTime, Text, ForeignKey, CheckConstraint, JSON
 from sqlalchemy.orm import relationship
 
 from app.core.db import Base
@@ -41,6 +41,7 @@ class Record(Base):
 	images = relationship("RecordImage", back_populates="record", cascade="all, delete-orphan")
 	project = relationship("Project", back_populates="records")
 	collection = relationship("Collection", back_populates="records")
+	annotations = relationship("RecordAnnotation", back_populates="record", cascade="all, delete-orphan", order_by="RecordAnnotation.created_at.desc()")
 	
 	# Constraint: must have either project_id OR collection_id (or neither, but not both)
 	__table_args__ = (
@@ -90,6 +91,25 @@ class RecordImage(Base):
 	record = relationship("Record", back_populates="images")
 	camera_settings = relationship("CameraSettings", back_populates="record_image", uselist=False, cascade="all, delete-orphan")
 	exif_data = relationship("ExifData", back_populates="record_image", uselist=False, cascade="all, delete-orphan")
+
+
+class RecordAnnotation(Base):
+	"""
+	A reviewer annotation on a Record: a flagged error typology and/or a free-text note.
+	Created during the QA pass ("Anotaciones" tab) and scoped to a single record.
+	"""
+	__tablename__ = "record_annotations"
+
+	id = Column(Integer, primary_key=True, index=True)
+	record_id = Column(Integer, ForeignKey("records.id", ondelete="CASCADE"), nullable=False, index=True)
+
+	error_types = Column(JSON, nullable=True)  # list of error type ids, e.g. ["blur", "glare"]
+	note = Column(Text, nullable=True)
+
+	created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+	created_by = Column(String(255), nullable=True)
+
+	record = relationship("Record", back_populates="annotations")
 
 
 class ExifData(Base):

--- a/app/schemas/record.py
+++ b/app/schemas/record.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Optional, List, Literal
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, model_validator
 from datetime import datetime
 
 # Valid status values
@@ -198,6 +198,40 @@ class ReorderRecords(BaseModel):
 		if not v:
 			raise ValueError("ordered_ids must not be empty")
 		return v
+
+
+# ==============================================================================
+# RecordAnnotation Schemas (QA "Anotaciones" tab: flagged errors + notes)
+# ==============================================================================
+
+class RecordAnnotationCreate(BaseModel):
+	error_types: List[str] = []
+	note: Optional[str] = None
+
+	@field_validator("note")
+	@classmethod
+	def blank_note_is_none(cls, v: Optional[str]) -> Optional[str]:
+		if v is not None and not v.strip():
+			return None
+		return v
+
+	@model_validator(mode="after")
+	def at_least_one_field(self) -> "RecordAnnotationCreate":
+		if not self.error_types and not self.note:
+			raise ValueError("An annotation needs at least one error type or a note")
+		return self
+
+
+class RecordAnnotationRead(BaseModel):
+	id: int
+	record_id: int
+	error_types: List[str] = []
+	note: Optional[str] = None
+	created_at: Optional[datetime]
+	created_by: Optional[str] = None
+
+	class Config:
+		from_attributes = True
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary
- Reviewer annotations ("Marcar error" / "Agregar nota" on the Anotaciones
  tab) previously lived only in frontend component state — they vanished on
  navigation/refresh and weren't scoped per record.
- Adds a `record_annotations` table and `RecordAnnotation` model
  (`error_types` JSON + free-text `note`), tied to a record via
  `record_id` FK with `ON DELETE CASCADE`.
- Adds `GET/POST /records/{id}/annotations` and
  `DELETE /records/annotations/{id}`, reusing the same
  admin/operator/reviewer role set as the existing status-change endpoints,
  since reviewers are the ones filing these.
- `RecordAnnotationCreate` rejects an annotation with neither an error type
  nor a note (422).

## Test plan
- [x] `alembic upgrade head` applies cleanly on top of `ff2f751fadbb`
- [x] Manual smoke test against the running dev API: create annotation
      (error types), create annotation (note), create with neither → 422,
      list ordered newest-first, delete one, delete the parent record and
      confirm annotations cascade-delete
- [ ] CI

Note: autogenerate also flagged an unrelated pre-existing drift
(`collections.export_version` / `last_exported_at` / `last_export_hash`
exist in the DB but aren't declared on the `Collection` model) — left
untouched, out of scope for this fix.

Please review the fix @Asemica-me 