### PR TITLE
fix(records): only the creator or an admin can delete an annotation (NEH-164)

### DIFF
--- a/app/api/records.py
+++ b/app/api/records.py
@@ -21,6 +21,7 @@ from app.schemas.record import (
 from app.core.config import settings
 from app.core.paths import resolve_within_storage
 from app.core.thumbnail import generate_thumbnail, delete_thumbnail
+from app.core.audit import log_event
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -548,13 +549,31 @@ def delete_record_annotation(
 	current_user: User = Depends(allow_read_only),
 	db: Session = Depends(get_db_dependency)
 ):
-	"""Delete a single annotation."""
+	"""Delete a single annotation.
+
+	Operators and reviewers may only delete annotations they created; admins
+	may delete any. If created_by is NULL (legacy row with no owner recorded),
+	ownership cannot be enforced, so the delete is allowed.
+	"""
 	annotation = db.query(RecordAnnotation).filter(RecordAnnotation.id == annotation_id).first()
 	if not annotation:
 		raise HTTPException(status_code=404, detail="Annotation not found")
 
+	if (
+		annotation.created_by
+		and annotation.created_by != current_user.username
+		and current_user.role != "admin"
+	):
+		raise HTTPException(
+			status_code=403,
+			detail="Only the annotation's creator or an admin can delete it"
+		)
+
+	record_id = annotation.record_id
 	db.delete(annotation)
 	db.commit()
+	log_event(db, level="INFO", category="activity", action="annotation_deleted",
+	          actor=current_user.username, subject=f"record {record_id} annotation {annotation_id}")
 	return {"detail": "Annotation deleted"}
 
 

--- a/tests/unit/test_annotation_delete_creator_check.py
+++ b/tests/unit/test_annotation_delete_creator_check.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Tests for DELETE /records/annotations/{annotation_id} (NEH-164).
+
+Operators/reviewers may only delete annotations they created; admins may
+delete any annotation. Legacy annotations with no created_by recorded can
+still be deleted by anyone, since ownership can't be enforced on them.
+Run with: python -m pytest tests/unit/test_annotation_delete_creator_check.py
+"""
+
+import pytest
+
+
+def _user(username, role):
+    from app.models.user import User
+    return User(username=username, email=f"{username}@example.com",
+                hashed_password="x", role=role, is_active=True)
+
+
+def _client_as(client, username, role):
+    from app.main import app
+    import app.api.records as records
+    # records.py binds its own allow_read_only RoleChecker instance;
+    # override that exact object (see tests/unit/test_collections_hierarchy.py).
+    app.dependency_overrides[records.allow_read_only] = lambda: _user(username, role)
+    return client
+
+
+def _make_annotation(db_session, created_by):
+    from app.models.record import Record, RecordAnnotation
+
+    rec = Record(title="r", created_by="someone")
+    db_session.add(rec)
+    db_session.commit()
+
+    annotation = RecordAnnotation(record_id=rec.id, note="n", created_by=created_by)
+    db_session.add(annotation)
+    db_session.commit()
+    db_session.refresh(annotation)
+    return annotation
+
+
+@pytest.mark.unit
+def test_creator_can_delete_own_annotation(client, db_session):
+    annotation = _make_annotation(db_session, created_by="alice")
+    c = _client_as(client, "alice", "operator")
+
+    resp = c.delete(f"/records/annotations/{annotation.id}")
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.unit
+def test_non_creator_non_admin_gets_403(client, db_session):
+    annotation = _make_annotation(db_session, created_by="alice")
+    c = _client_as(client, "bob", "reviewer")
+
+    resp = c.delete(f"/records/annotations/{annotation.id}")
+    assert resp.status_code == 403, resp.text
+
+    from app.models.record import RecordAnnotation
+    assert db_session.query(RecordAnnotation).filter_by(id=annotation.id).first() is not None
+
+
+@pytest.mark.unit
+def test_admin_can_delete_any_annotation(client, db_session):
+    annotation = _make_annotation(db_session, created_by="alice")
+    c = _client_as(client, "root", "admin")
+
+    resp = c.delete(f"/records/annotations/{annotation.id}")
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.unit
+def test_legacy_annotation_with_no_creator_can_be_deleted_by_anyone(client, db_session):
+    annotation = _make_annotation(db_session, created_by=None)
+    c = _client_as(client, "bob", "reviewer")
+
+    resp = c.delete(f"/records/annotations/{annotation.id}")
+    assert resp.status_code == 200, resp.text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Implements the deletion principle agreed at the 2026-07-22 meeting: operators and reviewers delete what they themselves created; admins delete anything. `DELETE /records/annotations/{id}` previously checked only existence — any reviewer could hard-delete any annotation by iterating sequential ids, with no audit trail (it shipped in #47 with no review).

- Creator-or-admin check: 403 when `created_by` is set, differs from the caller, and the caller isn't admin. Legacy rows with `created_by = NULL` stay deletable — ownership can't be enforced where none was recorded.
- `log_event` entry (`annotation_deleted`, category `activity`, level INFO) after the commit, matching the collections/projects pattern — annotations are a QA audit trail, so deletions now leave a trace. (Judgement call: INFO per the routine-action convention; `project_deleted` uses WARN — happy to align if the team prefers.)
- Four tests following the existing `RoleChecker`-override pattern: creator deletes own; non-creator non-admin gets 403 and the row survives; admin deletes any; NULL-owner deletable. All pass in the dev container. (Aside: the container needed an ad-hoc `pip install httpx` to run any TestClient test — starlette 1.3.1's test client requires it and `requirements.txt` doesn't carry it. Pre-existing gap, worth its own small fix under the manifest-lockstep rule.)

**Merge-order note:** hold this until the frontend's 403 handling is fixed. As of frontend `14dbb73`, `apiRequest` treats any non-exempt 403 as a rejected session (`clearSession` + redirect to `/login`) — necessary today because a missing Authorization header surfaces as 403 via `HTTPBearer`, but it means this PR's legitimate ownership denial would log the operator out mid-task instead of showing the inline error. Follow-up issue covers normalising missing-credentials to 401 (the `get_current_user_optional` pattern) and restricting session teardown to 401.