### PR TITLE
fix(auth): make 401 for missing credentials explicit, independent of bearer defaults (NEH-167)

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -11,9 +11,10 @@ from app.core.audit import log_event
 
 router = APIRouter()
 users_router = APIRouter()  # mounted at /users in main.py
-security = HTTPBearer()
-# auto_error=False so the dependency doesn't raise when header is absent
-# (allows falling back to ?token= query param for browser src= requests)
+# auto_error=False on every HTTPBearer instance: FastAPI's default (auto_error=True)
+# raises 403 when the Authorization header is missing/malformed, but a missing/invalid
+# session is a 401 ("session problem"), never a 403 ("authorization answer"). Each
+# dependency below raises HTTPException(401, ...) explicitly instead. See NEH-167.
 _optional_bearer = HTTPBearer(auto_error=False)
 
 
@@ -87,7 +88,12 @@ def login(payload: UserLogin, db: Session = Depends(get_db_dependency)):
 
 
 @router.post("/refresh", response_model=TokenRefresh)
-def refresh_token(credentials: HTTPAuthorizationCredentials = Security(security), db: Session = Depends(get_db_dependency)):
+def refresh_token(
+    credentials: Optional[HTTPAuthorizationCredentials] = Security(_optional_bearer),
+    db: Session = Depends(get_db_dependency),
+):
+    if not credentials:
+        raise HTTPException(status_code=401, detail="Not authenticated")
     token = credentials.credentials
     payload = verify_access_token(token)
     if not payload:
@@ -103,9 +109,11 @@ def refresh_token(credentials: HTTPAuthorizationCredentials = Security(security)
 @router.post("/password-reset")
 def reset_password(
     payload: PasswordReset,
-    credentials: HTTPAuthorizationCredentials = Security(security),
+    credentials: Optional[HTTPAuthorizationCredentials] = Security(_optional_bearer),
     db: Session = Depends(get_db_dependency)
 ):
+    if not credentials:
+        raise HTTPException(status_code=401, detail="Not authenticated")
     token = credentials.credentials
     token_payload = verify_access_token(token)
     if not token_payload:

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -11,10 +11,12 @@ from app.core.audit import log_event
 
 router = APIRouter()
 users_router = APIRouter()  # mounted at /users in main.py
-# auto_error=False on every HTTPBearer instance: FastAPI's default (auto_error=True)
-# raises 403 when the Authorization header is missing/malformed, but a missing/invalid
-# session is a 401 ("session problem"), never a 403 ("authorization answer"). Each
-# dependency below raises HTTPException(401, ...) explicitly instead. See NEH-167.
+# auto_error=False on every HTTPBearer instance so the status code for a
+# missing/malformed Authorization header is chosen by our code, not by the
+# framework default (which has varied across FastAPI versions). A credential
+# problem is always a 401 ("session problem"), never a 403 ("authorization
+# answer"); each dependency below raises HTTPException(401, ...) explicitly.
+# See NEH-167.
 _optional_bearer = HTTPBearer(auto_error=False)
 
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -298,5 +298,31 @@ def test_api_endpoints_pytest():
     assert test_new_endpoints()
 
 
+@pytest.mark.unit
+def test_missing_credentials_returns_401_not_403(client):
+    """A protected endpoint with no Authorization header must reject with 401
+    ("session problem"), never 403 ("authorization answer"). NEH-167."""
+    resp = client.get("/users/me")
+    assert resp.status_code == 401
+
+
+@pytest.mark.unit
+def test_refresh_missing_credentials_returns_401(client):
+    """/auth/refresh with no Authorization header must return 401, like every
+    other protected endpoint. NEH-167."""
+    resp = client.post("/auth/refresh")
+    assert resp.status_code == 401
+
+
+@pytest.mark.unit
+def test_password_reset_missing_credentials_returns_401(client):
+    """/auth/password-reset with no Authorization header must return 401. NEH-167."""
+    resp = client.post(
+        "/auth/password-reset",
+        json={"old_password": "x", "new_password": "y"},
+    )
+    assert resp.status_code == 401
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Backend half of NEH-167 (paired with a frontend PR that restricts session teardown to 401). Hardening, not a live-bug fix: on the pinned FastAPI 0.139.0 the auto-error `HTTPBearer` also returns 401 for missing/malformed credentials (verified empirically in the dev container), so this changes no observable behaviour today — it makes the **401 = session problem / 403 = authorization answer** split explicit and independent of framework defaults, so the frontend can safely treat only 401 as session death.

- Removes the auto-error bearer (`security`) and converts its two consumers — `/auth/refresh` and `/auth/password-reset` — to the optional-bearer + explicit-401 pattern `get_current_user` and `register` already use. That was the only auto-error instance in the app; role/creator/inactive 403s are untouched.
- Three new tests assert 401 (not 403) for credential-less requests to `/users/me`, `/auth/refresh`, `/auth/password-reset`. Unit suite in the dev container: 39 passed, plus the two known pre-existing failures in `test_api.py` (route introspection, stale table assertion — unrelated, identical on `dev`).

Adversarially reviewed: full endpoint enumeration found no path where a credential problem yields anything but 401 — including malformed schemes, the `?token=` image endpoints, and `/system/power`.