### PR TITLE
fix(collections): order listings, add /count, structure export 422 detail (NEH-121)

### DIFF
--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -112,7 +112,7 @@ def list_collections(
 @router.get("/count")
 def count_collections(
     project_id: Optional[int] = Query(None, description="Filter by project"),
-    parent_collection_id: Optional[int] = Query(None, description="Filter by parent collection (use 'null' for top-level)"),
+    parent_collection_id: Optional[int] = Query(None, description="Filter by parent collection id"),
     current_user: User = Depends(allow_read_only),
     db: Session = Depends(get_db_dependency),
 ):

--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -102,8 +102,27 @@ def list_collections(
     if parent_collection_id is not None:
         query = query.filter(Collection.parent_collection_id == parent_collection_id)
     
-    items = query.offset(skip).limit(limit).all()
+    # Deterministic order: without an ORDER BY, Postgres returns heap order,
+    # which shifts when rows are updated. Also required for stable
+    # skip/limit pagination.
+    items = query.order_by(Collection.id).offset(skip).limit(limit).all()
     return [CollectionRead.model_validate(i) for i in items]
+
+
+@router.get("/count")
+def count_collections(
+    project_id: Optional[int] = Query(None, description="Filter by project"),
+    parent_collection_id: Optional[int] = Query(None, description="Filter by parent collection (use 'null' for top-level)"),
+    current_user: User = Depends(allow_read_only),
+    db: Session = Depends(get_db_dependency),
+):
+    """Return the total number of collections matching the given filters."""
+    query = db.query(Collection)
+    if project_id is not None:
+        query = query.filter(Collection.project_id == project_id)
+    if parent_collection_id is not None:
+        query = query.filter(Collection.parent_collection_id == parent_collection_id)
+    return {"count": query.count()}
 
 
 @router.get("/{collection_id}", response_model=CollectionRead)
@@ -434,14 +453,20 @@ def export_collection_bagit(
         .all()
     )
     if not records:
-        raise HTTPException(status_code=422, detail="Collection has no records to export.")
+        raise HTTPException(
+            status_code=422,
+            detail={"message": "Collection has no records to export.", "blocking_record_ids": []}
+        )
 
     # All records must be approved
     non_approved = [r.id for r in records if r.status != "approved"]
     if non_approved:
         raise HTTPException(
             status_code=422,
-            detail=f"Cannot export: {len(non_approved)} record(s) are not approved yet: {non_approved}"
+            detail={
+                "message": f"Cannot export: {len(non_approved)} record(s) are not approved yet: {non_approved}",
+                "blocking_record_ids": non_approved,
+            }
         )
 
     # Gather project info for bag metadata

--- a/app/api/records.py
+++ b/app/api/records.py
@@ -112,7 +112,19 @@ def list_records(
 	# Deterministic order: without an ORDER BY, Postgres returns heap order,
 	# which shifts when rows are updated (NEH-159). Also required for stable
 	# skip/limit pagination.
-	recs = query.order_by(Record.id).offset(skip).limit(limit).all()
+	#
+	# Within a collection, listing order must match export order (see
+	# export_collection_bagit in collections.py, which orders by
+	# sequence.nulls_last(), id) and must reflect operator reordering, which
+	# writes `sequence`. The id tiebreaker keeps the order total and
+	# pagination stable (still NEH-159-safe). Project-wide listings (no
+	# collection_id filter) keep pure id order, since per-collection
+	# sequences would interleave meaninglessly across collections.
+	if collection_id is not None:
+		query = query.order_by(Record.sequence.nulls_last(), Record.id)
+	else:
+		query = query.order_by(Record.id)
+	recs = query.offset(skip).limit(limit).all()
 	return [RecordRead.model_validate(r) for r in recs]
 
 

--- a/tests/unit/test_collections_order_count_export_detail.py
+++ b/tests/unit/test_collections_order_count_export_detail.py
@@ -94,6 +94,33 @@ def test_collections_count_with_and_without_project_filter(read_client, db_sessi
 
 
 @pytest.mark.unit
+def test_collections_count_with_parent_collection_filter(read_client, db_session):
+    from app.models.project import Project
+    from app.models.collection import Collection
+
+    proj = Project(name="P")
+    db_session.add(proj)
+    db_session.commit()
+
+    parent = Collection(name="parent", project_id=proj.id)
+    db_session.add(parent)
+    db_session.commit()
+
+    for i in range(4):
+        db_session.add(Collection(name=f"child{i}", parent_collection_id=parent.id))
+    db_session.commit()
+
+    resp = read_client.get("/collections/count", params={"parent_collection_id": parent.id})
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"count": 4}
+
+    # A parent with no subcollections counts zero.
+    resp = read_client.get("/collections/count", params={"parent_collection_id": 999999})
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"count": 0}
+
+
+@pytest.mark.unit
 def test_collections_count_route_not_shadowed_by_collection_id_route(read_client, db_session):
     from app.models.project import Project
     from app.models.collection import Collection

--- a/tests/unit/test_collections_order_count_export_detail.py
+++ b/tests/unit/test_collections_order_count_export_detail.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+Tests for NEH-121: deterministic collection listing order, GET /collections/count,
+sequence-aware record ordering within a collection, and structured export 422 detail.
+Run with: python -m pytest tests/unit/test_collections_order_count_export_detail.py
+"""
+
+import pytest
+
+
+def _reader():
+    from app.models.user import User
+    return User(username="reader", email="r@example.com",
+                hashed_password="x", role="reviewer", is_active=True)
+
+
+@pytest.fixture
+def read_client(client, db_session):
+    from app.main import app
+    # collections.py and records.py each bind their own allow_read_only
+    # RoleChecker instance; override both exact objects (see
+    # tests/unit/test_collections_hierarchy.py).
+    import app.api.collections as collections
+    import app.api.records as records
+    app.dependency_overrides[collections.allow_read_only] = lambda: _reader()
+    app.dependency_overrides[records.allow_read_only] = lambda: _reader()
+    yield client
+
+
+# ==============================================================================
+# (a) list_collections ordering + skip/limit
+# ==============================================================================
+
+@pytest.mark.unit
+def test_list_collections_is_id_ordered_and_paginates(read_client, db_session):
+    from app.models.project import Project
+    from app.models.collection import Collection
+
+    proj = Project(name="P")
+    db_session.add(proj)
+    db_session.commit()
+
+    # Insert out of any natural name order so an accidental name/heap sort
+    # wouldn't accidentally look like id order.
+    names = ["zeta", "alpha", "mu", "beta", "gamma"]
+    for n in names:
+        db_session.add(Collection(name=n, project_id=proj.id))
+    db_session.commit()
+
+    ids = [c.id for c in db_session.query(Collection).order_by(Collection.id).all()]
+
+    resp = read_client.get("/collections/", params={"project_id": proj.id})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert [c["id"] for c in body] == ids
+
+    resp = read_client.get("/collections/", params={"project_id": proj.id, "skip": 1, "limit": 2})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert [c["id"] for c in body] == ids[1:3]
+
+
+# ==============================================================================
+# (b) GET /collections/count
+# ==============================================================================
+
+@pytest.mark.unit
+def test_collections_count_with_and_without_project_filter(read_client, db_session):
+    from app.models.project import Project
+    from app.models.collection import Collection
+
+    proj_a = Project(name="A")
+    proj_b = Project(name="B")
+    db_session.add_all([proj_a, proj_b])
+    db_session.commit()
+
+    for i in range(3):
+        db_session.add(Collection(name=f"a{i}", project_id=proj_a.id))
+    for i in range(2):
+        db_session.add(Collection(name=f"b{i}", project_id=proj_b.id))
+    db_session.commit()
+
+    resp = read_client.get("/collections/count")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"count": 5}
+
+    resp = read_client.get("/collections/count", params={"project_id": proj_a.id})
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"count": 3}
+
+    resp = read_client.get("/collections/count", params={"project_id": proj_b.id})
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"count": 2}
+
+
+@pytest.mark.unit
+def test_collections_count_route_not_shadowed_by_collection_id_route(read_client, db_session):
+    from app.models.project import Project
+    from app.models.collection import Collection
+
+    proj = Project(name="P")
+    db_session.add(proj)
+    db_session.commit()
+    db_session.add(Collection(name="c", project_id=proj.id))
+    db_session.commit()
+
+    # If /count were parsed by GET /{collection_id}, this would 422 (int
+    # validation failure on "count") instead of returning the count payload.
+    resp = read_client.get("/collections/count")
+    assert resp.status_code == 200, resp.text
+    assert "count" in resp.json()
+
+
+# ==============================================================================
+# (c) list_records ordering: sequence.nulls_last() then id, within a collection
+# ==============================================================================
+
+@pytest.mark.unit
+def test_list_records_orders_by_sequence_nulls_last_then_id_within_collection(read_client, db_session):
+    from app.models.project import Project
+    from app.models.collection import Collection
+    from app.models.record import Record
+
+    proj = Project(name="P")
+    db_session.add(proj)
+    db_session.commit()
+    col = Collection(name="C", project_id=proj.id)
+    db_session.add(col)
+    db_session.commit()
+
+    # Insert out of sequence order, mixing NULL and non-NULL sequence values.
+    # Expected order: sequence 0, 1, 2 first (ascending), then NULLs by id.
+    r_null_a = Record(title="null-a", collection_id=col.id, sequence=None)
+    r_seq2 = Record(title="seq-2", collection_id=col.id, sequence=2)
+    r_null_b = Record(title="null-b", collection_id=col.id, sequence=None)
+    r_seq0 = Record(title="seq-0", collection_id=col.id, sequence=0)
+    r_seq1 = Record(title="seq-1", collection_id=col.id, sequence=1)
+    db_session.add_all([r_null_a, r_seq2, r_null_b, r_seq0, r_seq1])
+    db_session.commit()
+    for r in (r_null_a, r_seq2, r_null_b, r_seq0, r_seq1):
+        db_session.refresh(r)
+
+    # NULL-sequence records tiebreak by id, in insertion order here.
+    expected_null_order = sorted([r_null_a.id, r_null_b.id])
+    expected_ids = [r_seq0.id, r_seq1.id, r_seq2.id, *expected_null_order]
+
+    resp = read_client.get("/records/", params={"collection_id": col.id})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert [r["id"] for r in body] == expected_ids
+
+
+@pytest.mark.unit
+def test_list_records_without_collection_id_orders_by_id_only(read_client, db_session):
+    from app.models.project import Project
+    from app.models.record import Record
+
+    proj = Project(name="P")
+    db_session.add(proj)
+    db_session.commit()
+
+    # Sequence values that would sort differently than id if honored;
+    # project-wide listing must ignore them and use pure id order.
+    r1 = Record(title="r1", project_id=proj.id, sequence=5)
+    r2 = Record(title="r2", project_id=proj.id, sequence=1)
+    r3 = Record(title="r3", project_id=proj.id, sequence=None)
+    db_session.add_all([r1, r2, r3])
+    db_session.commit()
+    for r in (r1, r2, r3):
+        db_session.refresh(r)
+
+    resp = read_client.get("/records/", params={"project_id": proj.id})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert [r["id"] for r in body] == [r1.id, r2.id, r3.id]
+
+
+# ==============================================================================
+# (d) export 422 detail is a structured dict
+# ==============================================================================
+
+def _contributor():
+    from app.models.user import User
+    return User(username="contributor", email="c@example.com",
+                hashed_password="x", role="operator", is_active=True)
+
+
+@pytest.fixture
+def contributor_client(client, db_session):
+    from app.main import app
+    import app.api.collections as collections
+    # export_collection_bagit is behind allow_read_only, not allow_contributor;
+    # reuse the reader override for the export calls in these tests.
+    app.dependency_overrides[collections.allow_read_only] = lambda: _contributor()
+    yield client
+
+
+@pytest.mark.unit
+def test_export_empty_collection_returns_structured_422(contributor_client, db_session):
+    from app.models.project import Project
+    from app.models.collection import Collection
+
+    proj = Project(name="P")
+    db_session.add(proj)
+    db_session.commit()
+    col = Collection(name="C", project_id=proj.id)
+    db_session.add(col)
+    db_session.commit()
+
+    resp = contributor_client.post(f"/collections/{col.id}/export")
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert isinstance(detail, dict)
+    assert detail["message"] == "Collection has no records to export."
+    assert detail["blocking_record_ids"] == []
+
+
+@pytest.mark.unit
+def test_export_non_approved_records_returns_structured_422(contributor_client, db_session):
+    from app.models.project import Project
+    from app.models.collection import Collection
+    from app.models.record import Record
+
+    proj = Project(name="P")
+    db_session.add(proj)
+    db_session.commit()
+    col = Collection(name="C", project_id=proj.id)
+    db_session.add(col)
+    db_session.commit()
+
+    r1 = Record(title="r1", collection_id=col.id, status="captured")
+    r2 = Record(title="r2", collection_id=col.id, status="approved")
+    r3 = Record(title="r3", collection_id=col.id, status="in_review")
+    db_session.add_all([r1, r2, r3])
+    db_session.commit()
+    for r in (r1, r2, r3):
+        db_session.refresh(r)
+
+    resp = contributor_client.post(f"/collections/{col.id}/export")
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert isinstance(detail, dict)
+    assert "Cannot export: 2 record(s) are not approved yet" in detail["message"]
+    assert set(detail["blocking_record_ids"]) == {r1.id, r3.id}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Backend half of NEH-121 (collections listings silently capped at 100; export gate follow-ups).

- **`list_collections` gains a deterministic `ORDER BY id`** — required for stable skip/limit pagination, mirroring the records endpoint's existing rationale.
- **New `GET /collections/count`** mirroring `GET /records/count` (same auth, same `{"count": n}` shape, `project_id`/`parent_collection_id` filters). Declared above `GET /{collection_id}` so the path isn't shadowed.
- **`list_records` orders by `sequence.nulls_last(), id` when filtered by `collection_id`** — listing order now matches export order and reflects operator drag-reorder (which writes `sequence`); until now a reorder was silently discarded on reload because the refetch ordered by id. Project-wide listings keep pure id order (per-collection sequences would interleave meaninglessly). The id tiebreaker keeps ordering total, so NEH-159's stability guarantee holds. New captures (`sequence` NULL, until NEH-122) sort after reordered records.
- **Export 422s are now structured**: `detail = {"message": ..., "blocking_record_ids": [...]}` for both the empty-collection and non-approved cases, so the frontend can show the real blocker list instead of a prose string. Message text unchanged.

Tests: `tests/unit/test_collections_order_count_export_detail.py` (7 tests: ordering, pagination, count filters + non-shadowing, sequence ordering with NULLs, both 422 shapes). Full unit suite: 43 passed; the 2 `test_api.py` failures are pre-existing on clean `dev`.

**Landing order:** merge this before frontend `fix/neh-121-collections-cap-export-blockers` — the frontend's `collectionsApi.count()` hard-depends on `/collections/count` existing.

Out of scope, deliberately: image-presence export checks (NEH-91), capture-time sequence assignment (NEH-122).