### PR TITLE
fix(db): schema integrity batch — FK indexes, exif UNIQUE, ondelete CASCADE, enum CHECKs

### DIFF
--- a/alembic/versions/2525f43a4661_add_schema_integrity_constraints.py
+++ b/alembic/versions/2525f43a4661_add_schema_integrity_constraints.py
@@ -1,0 +1,82 @@
+"""add schema integrity constraints
+
+Revision ID: 2525f43a4661
+Revises: 1a5f017816fd
+Create Date: 2026-07-23 05:09:00.169388
+
+Schema-hygiene batch covering four concerns:
+  1. Missing indexes on records.project_id / records.collection_id
+     (NEH-109).
+  2. UNIQUE constraint on exif_data.record_image_id - enforces the
+     documented one-to-one relationship between a RecordImage and its
+     EXIF row (NEH-110). No dedupe logic - if duplicates exist the
+     migration fails loudly by design.
+  3. ondelete='CASCADE' on the camera_settings/exif_data ->
+     record_images foreign keys, so deleting a RecordImage cleans up
+     its children instead of orphaning rows or failing (NEH-111).
+  4. CHECK constraints pinning the enum-like status/role/level/category
+     columns to their documented vocabularies (NEH-112). Note:
+     record_images.role is deliberately left unconstrained - capture
+     code writes open-ended values (cam0/cam1/..., {role}_raw).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2525f43a4661'
+down_revision: Union[str, None] = '1a5f017816fd'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Missing indexes
+    op.create_index('ix_records_project_id', 'records', ['project_id'])
+    op.create_index('ix_records_collection_id', 'records', ['collection_id'])
+
+    # 2. exif_data <-> record_images is documented as one-to-one; enforce it.
+    # No dedupe logic - if duplicates exist the migration fails loudly by design.
+    op.create_unique_constraint('exif_data_record_image_id_key', 'exif_data', ['record_image_id'])
+
+    # 3. ondelete=CASCADE on the record_images children. Constraint names
+    # match those established by migration c3d4e5f6a7b8 (verified current).
+    op.drop_constraint('camera_settings_record_image_id_fkey', 'camera_settings', type_='foreignkey')
+    op.create_foreign_key('camera_settings_record_image_id_fkey', 'camera_settings', 'record_images', ['record_image_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint('exif_data_record_image_id_fkey', 'exif_data', type_='foreignkey')
+    op.create_foreign_key('exif_data_record_image_id_fkey', 'exif_data', 'record_images', ['record_image_id'], ['id'], ondelete='CASCADE')
+
+    # 4. CHECK constraints on the enum-like columns.
+    op.create_check_constraint('check_record_status', 'records', "status IN ('captured','in_review','rejected','approved')")
+    op.create_check_constraint('check_user_role', 'users', "role IN ('admin','operator','reviewer')")
+    op.create_check_constraint('check_project_member_role', 'project_members', "role IN ('operator','reviewer')")
+    op.create_check_constraint('check_system_log_level', 'system_logs', "level IN ('INFO','WARN','ERR')")
+    op.create_check_constraint('check_system_log_category', 'system_logs', "category IN ('access','activity','capture','system')")
+
+
+def downgrade() -> None:
+    # 4. Drop CHECK constraints (reverse order).
+    op.drop_constraint('check_system_log_category', 'system_logs', type_='check')
+    op.drop_constraint('check_system_log_level', 'system_logs', type_='check')
+    op.drop_constraint('check_project_member_role', 'project_members', type_='check')
+    # Migration e5f6a7b8c9d0's downgrade re-introduces the 'contributor'
+    # role value, so this CHECK must be dropped before the chain ever
+    # reaches that revision. Alembic's chain order guarantees that (this
+    # comment is for humans doing partial/manual downgrades).
+    op.drop_constraint('check_user_role', 'users', type_='check')
+    op.drop_constraint('check_record_status', 'records', type_='check')
+
+    # 3. Restore the FKs without ondelete.
+    op.drop_constraint('exif_data_record_image_id_fkey', 'exif_data', type_='foreignkey')
+    op.create_foreign_key('exif_data_record_image_id_fkey', 'exif_data', 'record_images', ['record_image_id'], ['id'])
+    op.drop_constraint('camera_settings_record_image_id_fkey', 'camera_settings', type_='foreignkey')
+    op.create_foreign_key('camera_settings_record_image_id_fkey', 'camera_settings', 'record_images', ['record_image_id'], ['id'])
+
+    # 2. Drop the UNIQUE constraint.
+    op.drop_constraint('exif_data_record_image_id_key', 'exif_data', type_='unique')
+
+    # 1. Drop the indexes.
+    op.drop_index('ix_records_collection_id', table_name='records')
+    op.drop_index('ix_records_project_id', table_name='records')

--- a/alembic/versions/2525f43a4661_add_schema_integrity_constraints.py
+++ b/alembic/versions/2525f43a4661_add_schema_integrity_constraints.py
@@ -34,8 +34,8 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     # 1. Missing indexes
-    op.create_index('ix_records_project_id', 'records', ['project_id'])
-    op.create_index('ix_records_collection_id', 'records', ['collection_id'])
+    op.create_index(op.f('ix_records_project_id'), 'records', ['project_id'], unique=False)
+    op.create_index(op.f('ix_records_collection_id'), 'records', ['collection_id'], unique=False)
 
     # 2. exif_data <-> record_images is documented as one-to-one; enforce it.
     # No dedupe logic - if duplicates exist the migration fails loudly by design.
@@ -78,5 +78,5 @@ def downgrade() -> None:
     op.drop_constraint('exif_data_record_image_id_key', 'exif_data', type_='unique')
 
     # 1. Drop the indexes.
-    op.drop_index('ix_records_collection_id', table_name='records')
-    op.drop_index('ix_records_project_id', table_name='records')
+    op.drop_index(op.f('ix_records_collection_id'), table_name='records')
+    op.drop_index(op.f('ix_records_project_id'), table_name='records')

--- a/app/models/camera.py
+++ b/app/models/camera.py
@@ -10,7 +10,7 @@ class CameraSettings(Base):
     __tablename__ = "camera_settings"
 
     id = Column(Integer, primary_key=True, index=True)
-    record_image_id = Column(Integer, ForeignKey("record_images.id"), unique=True, nullable=False)
+    record_image_id = Column(Integer, ForeignKey("record_images.id", ondelete="CASCADE"), unique=True, nullable=False)
 
     camera_model = Column(String(255), nullable=True)
     camera_manufacturer = Column(String(255), nullable=True)

--- a/app/models/project_member.py
+++ b/app/models/project_member.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, CheckConstraint
 from sqlalchemy.orm import relationship
 
 from app.core.db import Base
@@ -13,3 +13,7 @@ class ProjectMember(Base):
     role       = Column(String(50), nullable=False)   # 'operator' | 'reviewer'
     added_at   = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
     added_by   = Column(String(255), nullable=True)
+
+    __table_args__ = (
+        CheckConstraint("role IN ('operator','reviewer')", name='check_project_member_role'),
+    )

--- a/app/models/record.py
+++ b/app/models/record.py
@@ -24,8 +24,8 @@ class Record(Base):
 	custom_attributes = Column(Text, nullable=True)  # JSON string for custom fields
 	
 	# Organizational hierarchy
-	project_id = Column(Integer, ForeignKey("projects.id", ondelete="SET NULL"), nullable=True)
-	collection_id = Column(Integer, ForeignKey("collections.id", ondelete="SET NULL"), nullable=True)
+	project_id = Column(Integer, ForeignKey("projects.id", ondelete="SET NULL"), nullable=True, index=True)
+	collection_id = Column(Integer, ForeignKey("collections.id", ondelete="SET NULL"), nullable=True, index=True)
 	
 	# QA workflow
 	status = Column(String(20), nullable=False, default="captured")  # captured, in_review, rejected, approved
@@ -48,6 +48,10 @@ class Record(Base):
 		CheckConstraint(
 			'NOT (project_id IS NOT NULL AND collection_id IS NOT NULL)',
 			name='check_record_single_parent'
+		),
+		CheckConstraint(
+			"status IN ('captured','in_review','rejected','approved')",
+			name='check_record_status'
 		),
 	)
 
@@ -116,7 +120,7 @@ class ExifData(Base):
 	__tablename__ = "exif_data"
 
 	id = Column(Integer, primary_key=True, index=True)
-	record_image_id = Column(Integer, ForeignKey("record_images.id"), nullable=False)
+	record_image_id = Column(Integer, ForeignKey("record_images.id", ondelete="CASCADE"), unique=True, nullable=False)
 
 	make = Column(String(255), nullable=True)
 	model = Column(String(255), nullable=True)

--- a/app/models/system_log.py
+++ b/app/models/system_log.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime, CheckConstraint
 from sqlalchemy.sql import func
 
 from app.core.db import Base
@@ -17,3 +17,8 @@ class SystemLog(Base):
     action   = Column(String(80),  nullable=False)  # login_success | project_created | ...
     subject  = Column(String(300), nullable=True)   # affected entity name
     detail   = Column(String(500), nullable=True)   # extra context (IP, count, ...)
+
+    __table_args__ = (
+        CheckConstraint("level IN ('INFO','WARN','ERR')", name='check_system_log_level'),
+        CheckConstraint("category IN ('access','activity','capture','system')", name='check_system_log_category'),
+    )

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from sqlalchemy import Column, Integer, String, Boolean, DateTime
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, CheckConstraint
 
 from app.core.db import Base
 
@@ -14,3 +14,7 @@ class User(Base):
     role = Column(String(50), default="reviewer", nullable=False)  # admin, operator, reviewer
     is_active = Column(Boolean, default=True, nullable=False)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+
+    __table_args__ = (
+        CheckConstraint("role IN ('admin','operator','reviewer')", name='check_user_role'),
+    )

--- a/app/schemas/record.py
+++ b/app/schemas/record.py
@@ -127,7 +127,7 @@ class RecordBase(BaseModel):
 	material: Optional[str] = None
 	date: Optional[str] = None
 	custom_attributes: Optional[str] = None  # JSON string for custom fields
-	status: str = "captured"
+	status: RecordStatus = "captured"
 	sequence: Optional[int] = None
 	rejection_note: Optional[str] = None
 

--- a/tests/unit/test_schema_constraints.py
+++ b/tests/unit/test_schema_constraints.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+Tests for NEH-109/NEH-110/NEH-111/NEH-112: schema-hygiene batch —
+FK indexes on records, UNIQUE on exif_data.record_image_id, ondelete
+CASCADE on the record_images children, and CHECK constraints on the
+enum-like status/role/level/category columns.
+
+SQLite (via db_session's create_all) enforces model-declared CHECK and
+UNIQUE constraints, so those are covered directly here. FK ondelete
+CASCADE is a Postgres-side behavior verified separately against the
+scratch database, not here.
+
+Run with: python -m pytest tests/unit/test_schema_constraints.py
+"""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+
+# ==============================================================================
+# (1) CHECK constraints - invalid values raise IntegrityError
+# ==============================================================================
+
+@pytest.mark.unit
+def test_record_bogus_status_raises_integrity_error(db_session):
+    from app.models.record import Record
+
+    r = Record(title="r", status="bogus")
+    db_session.add(r)
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+
+@pytest.mark.unit
+def test_user_bogus_role_raises_integrity_error(db_session):
+    from app.models.user import User
+
+    u = User(username="u1", email="u1@example.com", hashed_password="x", role="contributor")
+    db_session.add(u)
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+
+@pytest.mark.unit
+def test_project_member_bogus_role_raises_integrity_error(db_session):
+    from app.models.project import Project
+    from app.models.user import User
+    from app.models.project_member import ProjectMember
+
+    proj = Project(name="P")
+    user = User(username="u2", email="u2@example.com", hashed_password="x", role="operator")
+    db_session.add_all([proj, user])
+    db_session.commit()
+
+    pm = ProjectMember(project_id=proj.id, user_id=user.id, role="admin")
+    db_session.add(pm)
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+
+@pytest.mark.unit
+def test_system_log_bogus_level_and_category_raise_integrity_error(db_session):
+    from app.models.system_log import SystemLog
+
+    bad_level = SystemLog(level="DEBUG", category="access", action="login_success")
+    db_session.add(bad_level)
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+    bad_category = SystemLog(level="INFO", category="bogus", action="login_success")
+    db_session.add(bad_category)
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+
+# ==============================================================================
+# (2) UNIQUE constraint on exif_data.record_image_id
+# ==============================================================================
+
+@pytest.mark.unit
+def test_second_exif_data_row_for_same_record_image_raises_integrity_error(db_session):
+    from app.models.project import Project
+    from app.models.record import Record, RecordImage, ExifData
+
+    proj = Project(name="P")
+    db_session.add(proj)
+    db_session.commit()
+
+    rec = Record(title="r", project_id=proj.id)
+    db_session.add(rec)
+    db_session.commit()
+
+    img = RecordImage(
+        record_id=rec.id,
+        filename="a.jpg",
+        file_path="/tmp/a.jpg",
+        format="jpg",
+    )
+    db_session.add(img)
+    db_session.commit()
+
+    exif1 = ExifData(record_image_id=img.id, make="Canon")
+    db_session.add(exif1)
+    db_session.commit()
+
+    exif2 = ExifData(record_image_id=img.id, make="Nikon")
+    db_session.add(exif2)
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+
+# ==============================================================================
+# (3) Happy path - one valid row per constrained table
+# ==============================================================================
+
+@pytest.mark.unit
+def test_valid_rows_commit_fine(db_session):
+    from app.models.project import Project
+    from app.models.user import User
+    from app.models.project_member import ProjectMember
+    from app.models.system_log import SystemLog
+    from app.models.record import Record
+
+    proj = Project(name="P")
+    user = User(username="u3", email="u3@example.com", hashed_password="x", role="operator")
+    db_session.add_all([proj, user])
+    db_session.commit()
+
+    pm = ProjectMember(project_id=proj.id, user_id=user.id, role="operator")
+    log = SystemLog(level="ERR", category="capture", action="capture_failed")
+    rec = Record(title="r", project_id=proj.id, status="approved")
+    db_session.add_all([pm, log, rec])
+    db_session.commit()
+
+
+# ==============================================================================
+# (4) API-level: schema tighten on RecordBase.status
+# ==============================================================================
+
+def _contributor():
+    from app.models.user import User
+    return User(username="contributor", email="contributor@example.com",
+                hashed_password="x", role="operator", is_active=True)
+
+
+@pytest.fixture
+def contributor_client(client, db_session):
+    from app.main import app
+    # POST /records/ is behind allow_contributor, not allow_read_only;
+    # override that exact RoleChecker instance bound in app.api.records.
+    import app.api.records as records
+    app.dependency_overrides[records.allow_contributor] = lambda: _contributor()
+    yield client
+
+
+@pytest.mark.unit
+def test_create_record_with_bogus_status_returns_422(contributor_client, db_session):
+    # RecordCreate ignores `status` on the create path (Record() is built
+    # without it in create_record), so this guards an otherwise-unused
+    # field - belt and suspenders alongside the DB-level CHECK constraint.
+    resp = contributor_client.post("/records/", json={"title": "r", "status": "bogus"})
+    assert resp.status_code == 422, resp.text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/validate_system.py
+++ b/tests/validate_system.py
@@ -109,7 +109,7 @@ def validate_models():
         # Verify models can be instantiated
         proj = Project(name="test", description="test")
         doc = DocumentImage(filename="test.jpg", file_path="/test", format="jpg")
-        cs = CameraSettings(document_image_id=1, white_balance="auto")
+        cs = CameraSettings(record_image_id=1, white_balance="auto")
         
         print("[OK]")
         return True


### PR DESCRIPTION
Four schema-hygiene items from the NEH-40 epic (surfaced during the June Rionegro deployment review), landed together as one hand-written migration (`2525f43a4661`, chained off `1a5f017816fd`) plus matching model edits. Every constraint the migration adds is also declared on the ORM side (`index=True`, `unique=True`, `ondelete=`, `__table_args__` CheckConstraints), so the models and the live schema stay identical — no new drift for the future "autogenerate must be empty" check proposed in NEH-105.

**1. Indexes on `records.project_id` and `records.collection_id` (NEH-109).** Both are foreign keys filtered on the primary list, count, move, and delete paths (`records.py`, `collections.py`), and Postgres does not auto-index foreign keys, so those queries have been doing sequential scans. Only `ix_records_id` existed; this adds `ix_records_project_id` and `ix_records_collection_id`, following the existing naming. Impact is modest today (`records` grows per-document, not per-scan) but the tables only grow.

**2. UNIQUE on `exif_data.record_image_id` (NEH-110).** The model declares the EXIF relationship one-to-one (`uselist=False`), and `camera_settings` already enforces its identical relationship with `unique=True` — but `exif_data` never got the constraint, so the DB silently permits multiple EXIF rows per image, and SQLAlchemy would return an arbitrary one. This adds `exif_data_record_image_id_key`, mirroring `camera_settings`. Deliberately **no dedupe logic**: ExifData is only ever created at image-creation time (two sites in `cameras.py`), so duplicates shouldn't exist; if a live DB somehow holds one, the migration fails loudly rather than silently deleting a row — and `update.sh` takes a pg_dump backup before migrating, so a loud failure is recoverable.

**3. `ondelete='CASCADE'` on the `camera_settings` and `exif_data` FKs (NEH-111).** The cascade rules were inconsistent: `record_images.record_id` cascades at the DB level, but its own children (`camera_settings.record_image_id`, `exif_data.record_image_id`) declared no `ondelete` — the ORM's `cascade='all, delete-orphan'` covers app-code deletes, but any deletion that bypasses the ORM graph (raw SQL during manual recovery, a `pg_restore`, a future bulk `Query.delete()`) would either raise an FK violation or orphan rows. On an appliance that explicitly anticipates manual DB recovery, the schema should enforce its own integrity. The migration drops and recreates `camera_settings_record_image_id_fkey` and `exif_data_record_image_id_fkey` (names established by `c3d4e5f6a7b8`, verified still current) with `ondelete='CASCADE'`.

**4. CHECK constraints on the enum-like columns (NEH-112).** These columns' allowed values lived only in code comments and Pydantic Literals, so manual SQL, a migration, or future code could write a value the filters then silently ignore — leaving a record un-reviewable or un-exportable. Now pinned at the DB level:

| Column | Constraint | Values |
|---|---|---|
| `records.status` | `check_record_status` | captured, in_review, rejected, approved |
| `users.role` | `check_user_role` | admin, operator, reviewer |
| `project_members.role` | `check_project_member_role` | operator, reviewer |
| `system_logs.level` | `check_system_log_level` | INFO, WARN, ERR |
| `system_logs.category` | `check_system_log_category` | access, activity, capture, system |

The `users.role` vocabulary implements the 2026-07-22 decision to keep exactly three roles; the retired `contributor` value (renamed to `operator` by `e5f6a7b8c9d0`) is now rejected at the DB level, and the downgrade path carries a comment about that interaction. **`record_images.role` is deliberately excluded** although the issue listed it: it is not actually an enum — `manifestHandler.py` auto-assigns `cam0`, `cam1`, … when more than two cameras fire and writes `{role}_raw` variants for RAW captures, so a CHECK on the model comment's values would reject real captures. Every current write site for the five constrained columns was audited against `dev`; all values are in-vocabulary, so the migration validates cleanly on existing data. Also tightens `RecordBase.status` from `str` to the existing `RecordStatus` Literal — validation hygiene on the create path (which ignores the field; status changes go through `RecordStatusUpdate`, already a Literal).

**Stance on existing data:** the migration contains no data-mutating SQL. CHECKs and the UNIQUE validate existing rows at upgrade time; a violating row fails the migration loudly *before* the schema constrains wrong data, which is the correct behavior on a field appliance with pre-migration backups.

**Verification:**

- New `tests/unit/test_schema_constraints.py` (7 tests): CHECK violations and the UNIQUE duplicate raise `IntegrityError` under the SQLite test schema; documented-but-unwritten values (`ERR`, `capture`) commit fine; API returns 422 for an invalid status on create. FK cascade is not unit-testable under SQLite (foreign keys off by default), so it was verified on Postgres directly, below.
- Full unit suite: 43 passed; the only failures are the two pre-existing `test_api.py` failures already present on clean `dev`.
- Fresh Postgres 16 scratch DB: full chain `upgrade head` from empty, `downgrade -1`, re-`upgrade head` — all clean.
- Postgres probes: raw `DELETE FROM record_images` cascades both children to zero; `INSERT … role='contributor'` fails with `violates check constraint "check_user_role"`; a second `exif_data` row for the same image fails with `violates unique constraint "exif_data_record_image_id_key"`.

Rides along as a separate commit: one-word fix for a stale `document_image_id` kwarg in `tests/validate_system.py` (a non-collected legacy script touching these same tables).

**Note for whoever lands NEH-105** (the `collections` phantom columns): no content overlap — this PR doesn't touch `collections` — but both migrations will chain off `1a5f017816fd`, so whichever lands second rebases its `down_revision`, a one-line change.

Fixes NEH-109
Fixes NEH-110
Fixes NEH-111
Fixes NEH-112
