### PR TITLE
fix(capture): guard the picamera2 import in calibration.py

### DIFF
--- a/capture/calibration.py
+++ b/capture/calibration.py
@@ -20,9 +20,10 @@ if sys.platform == "linux":
     try:
         from picamera2 import Picamera2
         _PICAMERA2_AVAILABLE = True
-    except (ImportError, ValueError) as _picamera2_err:
-        Picamera2 = None
-        _PICAMERA2_AVAILABLE = False
+    except (ImportError, ValueError):
+        # Single-name import: on failure the None/False defaults above still hold
+        # (unlike picamera2_backend.py, which imports two names and must reset).
+        pass
 
 from .utils import atomic_write
 

--- a/capture/calibration.py
+++ b/capture/calibration.py
@@ -5,11 +5,24 @@ This module provides calibration functions to determine optimal camera settings
 for specific setups. Calibration profiles can be saved and loaded for reuse.
 """
 import json
+import sys
 import time
 from pathlib import Path
 from datetime import datetime, timezone
 from typing import Optional, Dict, Any
-from picamera2 import Picamera2
+
+# Only import picamera2 on Linux (inside Docker/Raspberry Pi).
+# Catch ValueError too: a numpy ABI mismatch in simplejpeg raises ValueError
+# at import time on some Pi OS + pixi env combinations.
+_PICAMERA2_AVAILABLE = False
+Picamera2 = None
+if sys.platform == "linux":
+    try:
+        from picamera2 import Picamera2
+        _PICAMERA2_AVAILABLE = True
+    except (ImportError, ValueError) as _picamera2_err:
+        Picamera2 = None
+        _PICAMERA2_AVAILABLE = False
 
 from .utils import atomic_write
 
@@ -59,13 +72,16 @@ class CameraCalibration:
                 "success": bool  # Whether AF succeeded
             }
         """
+        if not _PICAMERA2_AVAILABLE:
+            raise RuntimeError("picamera2 is not available on this system")
+
         if verbose:
             print(f"\n{'='*70}")
             print(f"FOCUS CALIBRATION - Camera {self.camera_index}")
             print(f"{'='*70}")
             print("[WARNING] Ensure object is at normal working distance!")
             print(f"Resolution: {img_size[0]}x{img_size[1]}")
-        
+
         picam2 = Picamera2(self.camera_index)
         config = picam2.create_still_configuration(main={"size": img_size})
         picam2.configure(config)
@@ -150,6 +166,9 @@ class CameraCalibration:
                 "frames_for_convergence": int
             }
         """
+        if not _PICAMERA2_AVAILABLE:
+            raise RuntimeError("picamera2 is not available on this system")
+
         if verbose:
             print(f"\n{'='*70}")
             print(f"WHITE BALANCE CALIBRATION - Camera {self.camera_index}")

--- a/tests/unit/test_calibration_import.py
+++ b/tests/unit/test_calibration_import.py
@@ -1,0 +1,26 @@
+"""Regression test for NEH-113: capture/calibration.py must not hard-import
+picamera2 at module load time. On non-Linux dev machines (macOS) the bare
+`from picamera2 import Picamera2` blew up import of the whole module; it
+must now guard the import the same way capture/backends/picamera2_backend.py
+does, and raise a clear RuntimeError if calibration is attempted without it.
+"""
+
+import pytest
+
+
+def test_module_imports_and_constructs_without_picamera2():
+    import capture.calibration
+
+    cal = capture.calibration.CameraCalibration(camera_index=0)
+    assert cal.camera_index == 0
+
+
+@pytest.mark.unit
+def test_calibrate_focus_raises_when_picamera2_unavailable(monkeypatch):
+    import capture.calibration as calibration
+
+    monkeypatch.setattr(calibration, "_PICAMERA2_AVAILABLE", False)
+
+    cal = calibration.CameraCalibration(camera_index=0)
+    with pytest.raises(RuntimeError):
+        cal.calibrate_focus()

--- a/tests/unit/test_calibration_import.py
+++ b/tests/unit/test_calibration_import.py
@@ -22,5 +22,5 @@ def test_calibrate_focus_raises_when_picamera2_unavailable(monkeypatch):
     monkeypatch.setattr(calibration, "_PICAMERA2_AVAILABLE", False)
 
     cal = calibration.CameraCalibration(camera_index=0)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="picamera2 is not available"):
         cal.calibrate_focus()


### PR DESCRIPTION
**The problem.** Almost everywhere in the backend, the `picamera2` library is imported defensively, because it is only present on Raspberry Pi units that use the ArduCam cameras — on a Pi that drives DSLRs through gphoto2, the library simply isn't installed. The one exception was `capture/calibration.py`, which imported it unconditionally at the top of the file (`from picamera2 import Picamera2`, line 12). That means that on a gphoto2-only unit, merely *importing* this module would crash with an ImportError, regardless of whether anything camera-related was actually happening.

**Why nothing has crashed yet.** The module is currently dead code with no live entry point. Nothing imports it at startup: `capture/__init__.py` skips it, and the only two places that reference it do so lazily — `initialize_camera_system()` in `camera_registry.py`, which no code ever calls, and the standalone `calibrate-cli.py` script, which nothing references. The calibration endpoints the UI actually uses (`/calibrate` and `/calibrate/white-balance` in `cameras.py`) deliberately go through the camera backend's already-open Picamera2 handle instead of this module — the comments in `cameras.py` explain that opening a second handle was exactly what the old approach did wrong. So this fix removes a trap for the *next* person who calls into calibration.py, rather than fixing a live crash.

**The fix.** The import is now wrapped in the same guard used by `capture/backends/picamera2_backend.py`: only attempt the import on Linux, catch both `ImportError` and `ValueError` (the latter because a numpy ABI mismatch inside simplejpeg can raise ValueError at import time on some Pi OS + pixi combinations), and record the result in a module flag. The two methods that actually construct a camera — `calibrate_focus` and `calibrate_white_balance` — now check that flag first and raise a clear `RuntimeError("picamera2 is not available on this system")` instead of letting the construction fail confusingly.

**Tests.** A new test file checks three things: the module imports cleanly, a `CameraCalibration` object can be constructed (its constructor only builds a dict, no camera access), and the RuntimeError path fires when picamera2 is unavailable. That last test forces the flag to False via monkeypatch rather than relying on whether the test machine happens to have picamera2 — the wheel is installed in the x86 dev container but may or may not import there, so the test would otherwise be flaky across environments.

Fixes NEH-113
