### PR TITLE
fix(deps): move test-only deps to the dev feature, add httpx, re-lock

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -51,7 +51,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.9-h1588d4d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
@@ -121,7 +120,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/piexif-1.1.3-py_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py311hf88fc01_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/psycopg-3.2.12-pyh848bd53_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psycopg-c-3.2.12-py311h7613044_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
@@ -130,7 +128,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.7.0-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.15-h7508c33_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.20-pyhff2d567_0.conda
@@ -218,7 +215,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.9-h850eeee_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
@@ -288,7 +284,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/piexif-1.1.3-py_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-12.3.0-py311h8e17b9e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/psycopg-3.2.12-pyh848bd53_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psycopg-c-3.2.12-py311hf3b5bb8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
@@ -297,7 +292,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.7.0-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.11.15-h53314ec_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.20-pyhff2d567_0.conda

--- a/pixi.toml
+++ b/pixi.toml
@@ -32,9 +32,9 @@ pyyaml = "==6.0.2"
 pillow = ">=11.0.0"
 piexif = ">=1.1.3"
 
-# Testing
-pytest = "==9.0.2"
+# Archival packaging
 bagit = ">=1.9.0,<2"
+# Image postprocessing
 rawpy = ">=0.27.0,<0.28"
 
 # Camera support - these require system packages
@@ -55,8 +55,6 @@ db-downgrade = "alembic downgrade -1"
 db-history = "alembic history"
 
 # Testing
-test = "pytest tests/"
-test-verbose = "pytest tests/ -v"
 test-cameras = "python test/test_cameras.py"
 
 # Setup system camera packages link (Raspberry Pi specific)
@@ -76,6 +74,12 @@ print(f'Created {pth_file}')
 # Development-only dependencies (same versions as requirements.txt)
 watchfiles = "==1.1.0"
 httptools = "==0.6.4"
+pytest = "==9.0.2"
+httpx = "==0.28.1"
+
+[feature.dev.tasks]
+test = "pytest tests/"
+test-verbose = "pytest tests/ -v"
 
 [environments]
 default = { solve-group = "default" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ uvicorn==0.35.0
 watchfiles==1.1.0
 websockets==15.0.1
 pytest==9.0.2
+httpx==0.28.1
 python-multipart==0.0.20
 
 # Image processing


### PR DESCRIPTION
Two dependency-hygiene items, landed together because they edit the same two files and the issue tracker already noted they should travel together (NEH-168's description: "if NEH-114 later moves test-only deps out of the production environment, httpx moves with pytest").

**1. pytest no longer installs on the appliance (NEH-114).** In `pixi.toml`, pytest was declared in the default `[dependencies]` table — the environment that `setup.sh` and `update.sh` install onto every production Pi with `pixi install --locked`. The appliance never runs tests, so this shipped a test framework onto SD-card-constrained units for no benefit, and it undermined the dev/prod split that the `[feature.dev]` group exists to provide. pytest now lives in `[feature.dev.dependencies]`, and the `test` and `test-verbose` task definitions move into `[feature.dev.tasks]` alongside it — necessary because a task that invokes pytest can't live in an environment that no longer installs pytest. The practical consequence for developers: the invocation is now `pixi run -e dev test` instead of `pixi run test`. The four places that document the old command are updated in a companion superproject PR. `test-cameras` stays where it was — it's a plain-python hardware bench script, not a pytest run. Before making this change I checked that nothing on the appliance path invokes the test tasks: `setup.sh`, `update.sh`, the systemd units, and both repos' CI workflows are all clean.

While editing the file I also fixed a misleading comment: `bagit` and `rawpy` sat under the `# Testing` heading, but both are genuine runtime dependencies (BagIt export and RAW postprocessing). They stay exactly where they were, in `[dependencies]`, now labeled `# Archival packaging` and `# Image postprocessing` to match requirements.txt.

**2. httpx is now a declared dependency (NEH-168).** starlette 1.3.1's `TestClient` requires httpx, but neither manifest listed it — so in a freshly built dev container, `pytest tests/` failed at import for every test file that uses `TestClient`, even though pytest itself was installed. Until now the workaround was an ad-hoc `pip install httpx` inside the running container, which silently disappears on every rebuild. `httpx==0.28.1` (the version already proven in the container) is now pinned in `requirements.txt` — the manifest the Docker dev environment actually installs from, which is where tests run per DEVELOPMENT.md — and in `[feature.dev.dependencies]` on the pixi side. One finding from the re-lock worth recording: on the conda side, httpx was *already* being resolved into both environments transitively through fastapi's dependency chain, at exactly 0.28.1. So the pixi-side pin changes nothing about what gets installed; it converts httpx from an incidental transitive package into a direct, version-locked requirement that can't silently drift when fastapi's dependencies change.

**About the lockfile.** `pixi.lock` was regenerated — deliberately with pixi **0.67.2**, not the current release. The reason: field units install pixi via `curl | bash` at whatever moment they were provisioned, and run `pixi install --locked` against the committed lockfile. pixi 0.68.0 switched to lock-format v7, which older pixi versions cannot read at all. Re-locking with 0.67.2 (the last v6-writing release) keeps the lockfile readable by every field install, old or new — newer pixi reads v6 fine. The resulting lock diff is removal-only and easy to review: pytest and its two exclusive dependencies (pluggy, iniconfig) leave the default environment on both platforms, and nothing else moves. The unit suite was run before and after the change with identical results.

Fixes NEH-114
Fixes NEH-168
