### PR TITLE
fix(tests): finish the documents→records rename across the test tree (NEH-171)

### DIFF
--- a/tests/integration/test_capture_integration.py
+++ b/tests/integration/test_capture_integration.py
@@ -60,7 +60,7 @@ def test_single_capture_creates_database_record(client, db_session, test_project
     
     # Verify camera settings were saved
     cs = db_session.query(CameraSettings).filter(
-        CameraSettings.document_image_id == doc.id
+        CameraSettings.record_image_id == doc.id
     ).first()
     assert cs is not None
     assert cs.white_balance == "indoor"
@@ -69,7 +69,7 @@ def test_single_capture_creates_database_record(client, db_session, test_project
 @pytest.mark.integration
 def test_dual_capture_creates_two_database_records(client, db_session, test_project):
     """
-    Test that /cameras/capture/dual creates two DocumentImage records.
+    Test that /cameras/capture/dual creates two RecordImage records.
     """
     project_name = test_project.name
     
@@ -92,8 +92,10 @@ def test_dual_capture_creates_two_database_records(client, db_session, test_proj
     assert len(data["file_paths"]) == 2
     
     # Verify both database records were created
-    docs = db_session.query(DocumentImage).filter(
-        DocumentImage.project_id == test_project.id
+    # RecordImage has no project_id — images belong to a Record, which
+    # belongs to the project.
+    docs = db_session.query(RecordImage).join(Record).filter(
+        Record.project_id == test_project.id
     ).all()
     
     assert len(docs) >= 2
@@ -101,7 +103,7 @@ def test_dual_capture_creates_two_database_records(client, db_session, test_proj
     # Check both have camera settings
     for doc in docs[-2:]:
         cs = db_session.query(CameraSettings).filter(
-            CameraSettings.document_image_id == doc.id
+            CameraSettings.record_image_id == doc.id
         ).first()
         assert cs is not None
 
@@ -154,15 +156,15 @@ def test_exif_data_extracted_and_saved(client, db_session, test_project):
     data = response.json()
     
     # Get database record
-    doc = db_session.query(DocumentImage).filter(
-        DocumentImage.file_path == data["file_path"]
+    doc = db_session.query(RecordImage).filter(
+        RecordImage.file_path == data["file_path"]
     ).first()
     
     assert doc is not None
     
     # Check if EXIF data was created
     exif = db_session.query(ExifData).filter(
-        ExifData.document_image_id == doc.id
+        ExifData.record_image_id == doc.id
     ).first()
     
     # EXIF might not be present if PIL can't read it, but raw_exif should have data

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -154,9 +154,13 @@ def test_routes():
     print("\nTesting route registration...")
     try:
         from app.main import app
-        
-        routes = {route.path: route.methods for route in app.routes}
-        
+
+        # Read paths from the OpenAPI schema rather than iterating app.routes:
+        # the entry types in app.routes are starlette internals that changed
+        # across versions (in starlette 1.x, included routers appear as
+        # _IncludedRouter objects with no .path attribute).
+        routes = set(app.openapi()["paths"].keys())
+
         # Check auth routes
         assert "/auth/register" in routes, "Auth register route missing"
         assert "/auth/login" in routes, "Auth login route missing"
@@ -165,9 +169,9 @@ def test_routes():
         
         # Check records routes
         assert "/records/" in routes, "Records list route missing"
-        assert "/records/{record_id}" in routes, "Records get route missing"
-        assert "/records/upload" in routes, "Records upload route missing"
-        assert "/records/{record_id}/file" in routes, "Records file download route missing"
+        assert "/records/{rec_id}" in routes, "Records get route missing"
+        assert "/records/{rec_id}/images" in routes, "Record images route missing"
+        assert "/records/images/{img_id}/file" in routes, "Record image file download route missing"
         
         # Check projects routes
         assert "/projects/" in routes, "Projects list route missing"
@@ -215,7 +219,7 @@ def test_models():
         
         assert "users" in table_names, "Users table not registered"
         assert "projects" in table_names, "Projects table not registered"
-        assert "document_images" in table_names, "Document images table not registered"
+        assert "record_images" in table_names, "Record images table not registered"
         
         print(" [OK] All models are properly registered")
         return True

--- a/tests/validate_system.py
+++ b/tests/validate_system.py
@@ -23,11 +23,11 @@ def validate_imports():
         from app.core.config import settings
         from app.core.db import engine, Base, SessionLocal
         from app.models.project import Project
-        from app.models.document import DocumentImage, ExifData
+        from app.models.record import RecordImage, ExifData
         from app.models.camera import CameraSettings
         from app.models.user import User
         from app.api.cameras import CaptureRequest, CaptureResponse, DualCaptureRequest
-        from app.schemas.document import DocumentRead
+        from app.schemas.record import RecordRead
         from app.schemas.camera import CameraSettingsRead
         from capture.service import single_capture_image, dual_capture_image, is_camera_connected
         from capture.camera import CameraConfig, IMG_SIZES
@@ -44,7 +44,9 @@ def validate_config():
     print("[2/6] Validating configuration...", end=" ")
     try:
         from app.core.config import settings
-        assert settings.DATABASE_URL, "DATABASE_URL not set"
+        # Settings has discrete DATABASE_* fields, not a single DATABASE_URL
+        assert settings.DATABASE_HOST, "DATABASE_HOST not set"
+        assert settings.DATABASE_NAME, "DATABASE_NAME not set"
         assert settings.projects_dir, "projects_dir not set"
         assert settings.data_dir, "data_dir not set"
         print("[OK]")
@@ -62,7 +64,7 @@ def validate_database():
         inspector = inspect(engine)
         tables = inspector.get_table_names()
         
-        required = ["projects", "document_images", "camera_settings", "exif_data"]
+        required = ["projects", "record_images", "camera_settings", "exif_data"]
         for table in required:
             if table not in tables:
                 raise ValueError(f"Table '{table}' not found")
@@ -79,13 +81,15 @@ def validate_api():
     try:
         from app.main import app
         
-        routes = {r.path for r in app.routes if hasattr(r, 'path')}
+        # Paths via the OpenAPI schema: app.routes entries are starlette
+        # internals whose types changed across versions (see test_api.py).
+        routes = set(app.openapi()["paths"].keys())
         required = [
             "/cameras/capture",
             "/cameras/capture/dual",
             "/cameras/devices",
             "/projects/",
-            "/documents/",
+            "/records/",
         ]
         
         for route in required:
@@ -102,13 +106,13 @@ def validate_models():
     """Validate model definitions."""
     print("[5/6] Validating models...", end=" ")
     try:
-        from app.models.document import DocumentImage
+        from app.models.record import RecordImage
         from app.models.camera import CameraSettings
         from app.models.project import Project
-        
+
         # Verify models can be instantiated
         proj = Project(name="test", description="test")
-        doc = DocumentImage(filename="test.jpg", file_path="/test", format="jpg")
+        doc = RecordImage(filename="test.jpg", file_path="/test", format="jpg")
         cs = CameraSettings(record_image_id=1, white_balance="auto")
         
         print("[OK]")

--- a/tests/validate_system.py
+++ b/tests/validate_system.py
@@ -92,8 +92,10 @@ def validate_api():
             "/records/",
         ]
         
+        # Exact membership: substring matching would let "/projects/" pass
+        # via "/projects/{project_id}" even if the list route disappeared.
         for route in required:
-            if not any(route in r for r in routes):
+            if route not in routes:
                 raise ValueError(f"Route '{route}' not found")
         
         print(f"[OK] ({len(routes)} endpoints)")

--- a/tests/validate_system.py
+++ b/tests/validate_system.py
@@ -114,7 +114,7 @@ def validate_models():
 
         # Verify models can be instantiated
         proj = Project(name="test", description="test")
-        doc = RecordImage(filename="test.jpg", file_path="/test", format="jpg")
+        doc = RecordImage(record_id=1, filename="test.jpg", file_path="/test", format="jpg")
         cs = CameraSettings(record_image_id=1, white_balance="auto")
         
         print("[OK]")


### PR DESCRIPTION
The `documents` → `records` rename (migration `c3d4e5f6a7b8`) never reached the test tree. Catalina spotted the visible symptom while verifying NEH-80 (frontend #44): the two long-standing "known" failures in the unit suite both trace to `test_models()` asserting the old `document_images` table name. Pulling on that thread turned up three distinct layers of staleness, all fixed here. The diff is test-only; nothing under `app/` changes.

## What was stale

**1. Old names from the rename.** `tests/unit/test_api.py` asserted `document_images`; `tests/validate_system.py` listed it as a required table, imported the deleted `app.models.document` / `app.schemas.document` modules, and instantiated `DocumentImage`; `tests/integration/test_capture_integration.py` used the undefined `DocumentImage` class and the old `document_image_id` column in five places. One of those queries also filtered on `DocumentImage.project_id`, which has no equivalent column on `RecordImage` — images hang off a `Record`, which owns the `project_id` — so that query is now a join through `Record` rather than a one-word rename.

**2. Route introspection broken by the starlette pin.** Both `test_api.py` and `validate_system.py` walked `app.routes` expecting every entry to have `.path`. Under starlette 1.3.1 (pinned in #48), included routers appear as `_IncludedRouter` objects with no `.path`, and their nested routes carry unprefixed paths — so the routes test crashed outright, and `validate_system`'s `hasattr` filter silently saw only `/health` and the docs routes. Both now read `app.openapi()["paths"]` instead: public API, full prefixed paths, stable across versions. (Caveat for the future: a route registered with `include_in_schema=False` would be invisible to this check; none of the asserted routes is.)

**3. Routes that no longer exist under the asserted names.** The old test asserted `/records/{record_id}`, `/records/upload`, and `/records/{record_id}/file`. Today's API has `/records/{rec_id}`, no standalone upload route (record creation is `POST /records/`, image upload is `POST /records/{rec_id}/images`), and file download at `/records/images/{img_id}/file`. The assertions now name the real endpoints; nothing lost coverage — the two routes that absorbed "upload" are both asserted. Same fix for `validate_system`'s required-route list (`/documents/` → `/records/`), plus one more drift in the same file: `settings.DATABASE_URL` no longer exists (config has discrete `DATABASE_*` fields).

## Verification

- `pytest tests/unit` in the dev container: **62 passed, 0 failed** — first fully green run (baseline before this PR: 61 passed, 1 failed, historically 2).
- `PYTHONPATH=/app python tests/validate_system.py` in the dev container: **6/6 validations pass** (previously died at step 1 on `ModuleNotFoundError`).
- Both integration-test files compile; the capture integration tests need camera hardware to execute and remain gated by their `integration` marker — the queries they run were checked against the current models (`RecordImage.record_id`, `CameraSettings.record_image_id`, `ExifData.record_image_id`).
- `grep -r document_image` finds no references outside `alembic/versions/`, where the old names are historical record and correct.

Fixes NEH-171.
