### PR TITLE
fix(storage): add missing space in unmount message (NEH-183)

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -342,7 +342,7 @@ def unmount_device(
 
     msg = "Device unmounted successfully."
     if override_cleared:
-        msg += "Storage reverted to the default."
+        msg += " Storage reverted to the default."
     return {"message": msg, "override_cleared": override_cleared}
 
 


### PR DESCRIPTION
One-character fix from the bench session: the unmount response concatenated "Device unmounted successfully.Storage reverted to the default." without a space. Part of NEH-183.