### PR TITLE
fix(thumbnail): update default dimensions to 600px for improved grid …

### DIFF
--- a/app/core/thumbnail.py
+++ b/app/core/thumbnail.py
@@ -13,8 +13,16 @@ import uuid
 logger = logging.getLogger(__name__)
 
 # Default thumbnail dimensions
-DEFAULT_THUMBNAIL_WIDTH = 200
-DEFAULT_THUMBNAIL_HEIGHT = 200
+#
+# 600px covers the largest grid-view cell size in the frontend (GridView's
+# column-count slider goes down to 2 columns, which can render cells ~500-
+# 540px wide) with a bit of margin. At 200px, `object-fit: cover` was
+# upscaling the thumbnail to fill much larger cells, producing visibly
+# blurry grids — this only affects the display size, not the stored master
+# image, so the storage/bandwidth cost stays a small fraction of the
+# full-resolution capture either way.
+DEFAULT_THUMBNAIL_WIDTH = 600
+DEFAULT_THUMBNAIL_HEIGHT = 600
 DEFAULT_THUMBNAIL_FORMAT = "JPEG"
 DEFAULT_THUMBNAIL_QUALITY = 85
 


### PR DESCRIPTION
GridView.svelte usa object-fit: cover para llenar la celda con el thumbnail (getImageThumbnailUrl), pero el backend los generaba a máximo 200×200px. Con el slider de columnas en su mínimo (2 columnas — el "modo thumbnails grandes" que el propio código menciona en un comentario), la celda llega a ~500-630px de ancho, forzando un upscale de más de 4x sobre una imagen de 200px. Eso es el blur.

Fix: subí DEFAULT_THUMBNAIL_WIDTH/HEIGHT de 200 a 600px — cubre con margen el peor caso de celda, sigue siendo una fracción del tamaño de la imagen master (no hay que preocuparse por espacio en el Pi).
