### PR TITLE
fix(collection): add direct record count to CollectionRead schema and optimize list_collections query

### DIFF
--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -105,7 +105,26 @@ def list_collections(
     # which shifts when rows are updated. Also required for stable
     # skip/limit pagination.
     items = query.order_by(Collection.id).offset(skip).limit(limit).all()
-    return [CollectionRead.model_validate(i) for i in items]
+
+    # Bulk-count records per collection in one query (avoids N+1 — the
+    # project detail page lists every collection and needs each one's
+    # count for the "No. of images/records" column, NEH-179).
+    counts_by_id: dict[int, int] = {}
+    if items:
+        rows = (
+            db.query(Record.collection_id, func.count(Record.id))
+            .filter(Record.collection_id.in_([c.id for c in items]))
+            .group_by(Record.collection_id)
+            .all()
+        )
+        counts_by_id = {collection_id: count for collection_id, count in rows}
+
+    results = []
+    for i in items:
+        r = CollectionRead.model_validate(i)
+        r.record_count = counts_by_id.get(i.id, 0)
+        results.append(r)
+    return results
 
 
 @router.get("/count")

--- a/app/schemas/collection.py
+++ b/app/schemas/collection.py
@@ -44,6 +44,9 @@ class CollectionRead(CollectionBase):
     created_by: Optional[str] = None
     created_at: datetime
     updated_at: Optional[datetime] = None
+    # Direct record count (Record.collection_id == this collection's id).
+    # None unless the endpoint explicitly populates it (list/hierarchy).
+    record_count: Optional[int] = None
 
     class Config:
         from_attributes = True
@@ -52,7 +55,6 @@ class CollectionRead(CollectionBase):
 class CollectionWithChildren(CollectionRead):
     """Collection with nested child collections (for hierarchical views)."""
     child_collections: List["CollectionRead"] = []
-    record_count: Optional[int] = None
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- `GET /collections/` never returned `record_count` — only `/{id}/hierarchy`
  computed it, per-collection. The project detail page lists every
  top-level collection from the list endpoint, so its "No. of records"
  column always fell back to 0.
- Added `record_count: Optional[int] = None` to `CollectionRead` (removed
  the now-redundant duplicate declaration on `CollectionWithChildren`,
  which inherits it).
- `list_collections` now bulk-counts records per listed collection in a
  single grouped query (`GROUP BY collection_id`, filtered to just the
  returned collection ids) — not one query per collection.

## Test plan
- [x] `pytest tests/unit`: 74 passed
- [x] Verified live against the dev stack: created a project with one
  collection holding 10 records (`collection_id` set, `project_id` NULL,
  per the single-parent DB constraint) — `GET /collections/?project_id=X`
  now returns `"record_count": 10` for it, where it previously had no such
  field at all.

RELATED NEH-179 frontend
