### PR TITLE
fix(db): drop unused collection export-tracking columns (NEH-105)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,8 +26,9 @@ def init_db() -> None:
 **When adding/modifying models:**
 1. Update the model in `app/models/`
 2. Generate migration: `docker compose exec backend alembic revision --autogenerate -m "description"`
-3. Review the generated migration file
+3. Review the generated migration file — **read every operation and delete anything you did not intend**. Autogenerate emits drops for any table or column the models don't declare, which is how `project_members` was once dropped (`dda9bc1bc608`, restored in `ff2f751fadbb`)
 4. Apply: `docker compose exec backend alembic upgrade head`
+5. Confirm no drift is left: `docker compose exec backend alembic check` — it must print `No new upgrade operations detected`
 
 ### [INFO] Authentication & Security
 
@@ -85,6 +86,13 @@ docker compose exec backend alembic upgrade head
 ```bash
 docker compose exec backend alembic revision --autogenerate -m "description"
 ```
+
+### Check for schema drift (models vs. migrated database)
+```bash
+docker compose exec backend alembic upgrade head
+docker compose exec backend alembic check
+```
+Natively on the Pi, `pixi run db-check-drift` runs both.
 
 ### Check database tables
 ```bash

--- a/alembic/versions/f6a7b8c9d0e1_drop_unused_collection_export_tracking.py
+++ b/alembic/versions/f6a7b8c9d0e1_drop_unused_collection_export_tracking.py
@@ -1,0 +1,51 @@
+"""drop unused collection export tracking columns
+
+Revision ID: f6a7b8c9d0e1
+Revises: 2525f43a4661
+Create Date: 2026-07-25 19:20:00.000000
+
+Removes collections.export_version / last_exported_at / last_export_hash,
+resolving the schema-vs-model drift in NEH-105.
+
+The three columns arrived in dda9bc1bc608 - an unadjusted autogenerate
+that also dropped project_members (restored in ff2f751fadbb) - and were
+never declared on the Collection model, never read, and never written.
+So every row on every unit holds export_version=0 with the other two
+NULL: dropping them loses no data.
+
+They are dropped rather than modelled because export state is already
+tracked on the filesystem, which is where the live code looks: exports
+are named collection_{id}_{YYYYMMDDTHHMMSSZ}.zip and the download
+endpoint resolves the most recent one by globbing that pattern. A
+last_exported_at column would be a second, staler answer to a question
+the filesystem already answers - and NEH-90 will prune those zips,
+at which point the DB copy would start lying. When export needs real
+persistence (NEH-90's async jobs and pruning; NEH-123/124's per-file
+verification) it wants one row per export, not latest-only summary
+columns on the parent.
+
+Downgrade restores the columns exactly as dda9bc1bc608 created them.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f6a7b8c9d0e1'
+down_revision: Union[str, None] = '2525f43a4661'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_column('collections', 'last_export_hash')
+    op.drop_column('collections', 'last_exported_at')
+    op.drop_column('collections', 'export_version')
+
+
+def downgrade() -> None:
+    op.add_column('collections', sa.Column('export_version', sa.Integer(), server_default=sa.text('0'), nullable=False))
+    op.add_column('collections', sa.Column('last_exported_at', sa.DateTime(), nullable=True))
+    op.add_column('collections', sa.Column('last_export_hash', sa.String(length=64), nullable=True))

--- a/pixi.toml
+++ b/pixi.toml
@@ -55,6 +55,13 @@ db-upgrade = "alembic upgrade head"
 db-migrate = { cmd = "alembic revision --autogenerate -m", depends-on = [] }
 db-downgrade = "alembic downgrade -1"
 db-history = "alembic history"
+# Schema drift guard (NEH-105): fails if the ORM models and a
+# migrated database disagree, i.e. if `db-migrate` would emit a
+# non-empty migration. Run it against a database already at head —
+# `pixi run db-upgrade` first. Drift is how collections acquired three
+# columns no model declared (dda9bc1bc608), and how project_members was
+# once dropped by an unreviewed autogenerate.
+db-check-drift = { cmd = "alembic check", depends-on = ["db-upgrade"] }
 
 # Testing
 test-cameras = "python test/test_cameras.py"


### PR DESCRIPTION
Closes NEH-105 — the last open issue in NEH-40, so that epic closes with it.

`collections.export_version`, `last_exported_at` and `last_export_hash` have been in the database since `dda9bc1bc608` (May) but were never declared on the `Collection` model, never read and never written. Every `--autogenerate` since has proposed dropping them: the `record_annotations` migration hit exactly that on 22 July and the drop had to be deleted by hand, with a note left in the docstring of `1a5f017816fd`. The same mechanism dropped `project_members` once already — in that very migration, restored in `ff2f751fadbb`.

## Why drop rather than model

Export state is already tracked on the filesystem, and that is where the live code looks. `POST /collections/{id}/export` writes `collection_{id}_{YYYYMMDDTHHMMSSZ}.zip` into the exports directory, and `GET …/export/download` resolves the most recent export by globbing that pattern and sorting — fixed-width UTC timestamps, so lexicographic order is chronological. A `last_exported_at` column would be a second, staler answer to a question that is already answered exactly; and once NEH-90 prunes old zips, the database copy would start claiming exports that no longer exist.

The other two have no defined meaning: `last_export_hash` is sha256-shaped but nothing specifies what it hashes (the real checksum need, NEH-124, is per-file against the capture manifest), and `export_version` is a counter equal to the number of zips on disk.

When export does need persistence — NEH-90's async jobs and pruning, NEH-123/124's per-file verification — it wants one row per export, not latest-only summary columns on the parent. Modelling these now would commit us to a different design that NEH-37 would then have to migrate away from.

## Verification

Run against a dev database brought to head:

- **No data lost.** The three columns held `export_version = 0` with the other two NULL on every row — as they must, since nothing can write them.
- **`alembic check` reports `No new upgrade operations detected`** (exit 0) after the migration. These three columns were the *only* disagreement between the models and the database; the rest of the schema is clean.
- **Round trip is exact.** `downgrade -1` restores all three with their original types, nullability and `0` server default; re-upgrading drops them again and the check still passes.

## Also here

`pixi run db-check-drift` (`alembic check`, after `db-upgrade`) and the equivalent `docker compose exec` recipe in `DEVELOPMENT.md`, so drift is caught where migrations are written rather than months later. `alembic check` is built in since 1.9 and we pin 1.14.0, so this adds no dependency and no `requirements.txt` / `pixi.toml` lockstep change. Step 3 of the model-change workflow now also tells reviewers to delete unintended operations, citing the `project_members` incident by revision.

NEH-105's acceptance criterion asks for this check to be **enforced in CI**. There is no backend CI to enforce it in — the superproject has only the two docs workflows and the backend has no `.github/workflows` at all, so nothing stands up Postgres. That harness is a bigger piece of work than this fix and belongs in its own issue; this PR gives the check a local home in the meantime.

The migration has not run on the bench Pi, as usual — hardware validation happens at the dev→main promotion. It is a column drop on empty columns with an exact downgrade, and `update.sh` now takes a `pg_dump` first (NEH-97).
