### PR TITLE
fix(security): production secret guards + pydantic-settings v2 env wiring (NEH-54, NEH-55, NEH-134)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -59,8 +59,15 @@ _INSECURE_SECRET_KEYS = {
     "secret-key-here-change-in-production",
 }
 
-# Environments exempt from the SECRET_KEY guard; anything else must set a strong key
+# Environments exempt from the production guards; anything else must set real secrets
 _DEV_ENVIRONMENTS = {"dev", "development", "test", "testing", "local"}
+
+# Blacklist of DATABASE_PASSWORD values that must never reach a production DB outside dev
+_INSECURE_DB_PASSWORDS = {
+    "",
+    "password",
+    "change-this-in-production",
+}
 
 
 def _guard_secret_key(config: "Settings") -> None:
@@ -80,5 +87,21 @@ def _guard_secret_key(config: "Settings") -> None:
         )
 
 
+def _guard_database_password(config: "Settings") -> None:
+    """Refuse to start outside dev with a placeholder DATABASE_PASSWORD.
+
+    Per-unit passwords are generated at first boot; this is the
+    defense-in-depth half: a unit that slipped through on a shared placeholder
+    fails loudly instead of running with a credential known to every appliance.
+    """
+    if config.APP_ENV.strip().lower() in _DEV_ENVIRONMENTS:
+        return
+    if config.DATABASE_PASSWORD.strip() in _INSECURE_DB_PASSWORDS:
+        raise RuntimeError(
+            f"DATABASE_PASSWORD is unset or left at a shared placeholder while APP_ENV={config.APP_ENV!r}. Set a strong, unique DATABASE_PASSWORD (e.g. with `openssl rand -hex 32`) before starting outside development."
+        )
+
+
 settings = Settings()
 _guard_secret_key(settings)
+_guard_database_password(settings)

--- a/tests/unit/test_database_password_guard.py
+++ b/tests/unit/test_database_password_guard.py
@@ -1,0 +1,33 @@
+"""Guard against booting outside dev with a placeholder DATABASE_PASSWORD"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.config import _guard_database_password
+
+
+def _cfg(app_env: str, db_password: str) -> SimpleNamespace:
+    """Minimal stand-in for Settings with just the fields the guard reads."""
+    return SimpleNamespace(APP_ENV=app_env, DATABASE_PASSWORD=db_password)
+
+
+@pytest.mark.parametrize("app_env", ["dev", "development", "test", "testing", "local", "DEV"])
+def test_dev_environments_allow_placeholder(app_env):
+    # Dev must keep booting on the shipped placeholder so nothing needs configuring locally
+    _guard_database_password(_cfg(app_env, "password"))
+
+
+@pytest.mark.parametrize("bad_pw", ["", "   ", "password", "change-this-in-production"])
+def test_production_rejects_placeholder_or_empty(bad_pw):
+    with pytest.raises(RuntimeError):
+        _guard_database_password(_cfg("production", bad_pw))
+
+
+def test_unknown_environment_is_treated_as_production():
+    with pytest.raises(RuntimeError):
+        _guard_database_password(_cfg("staging", "password"))
+
+
+def test_production_with_strong_password_boots():
+    _guard_database_password(_cfg("production", "b2d84605f1c9a7e3b5d02f18a3f9c1e7"))


### PR DESCRIPTION
## Summary

Hardens `app/core/config.py` against shipping appliances with shared secrets and fixes `pydantic-settings` v2 environment variable binding so documented configuration options actually work.

This PR addresses three related configuration issues:

- **NEH-54** : Fail fast when `SECRET_KEY` is default or empty outside development.
- **NEH-55**: Fail fast when `DATABASE_PASSWORD` is a shared placeholder outside development.
- **NEH-134**: Replace the obsolete `Field(env=...)` pattern with the correct `pydantic-settings` v2 environment binding.

## Background

Per-device `SECRET_KEY` and `DATABASE_PASSWORD` are generated during first-boot provisioning (NEH-158 / superproject #200). These runtime guards provide defense in depth by ensuring production deployments never start with default credentials.

If `APP_ENV` is set to a production environment and either secret remains a placeholder, the backend now fails immediately instead of running with forgeable session tokens or a database password shared across appliances.

## Changes

### NEH-54: `SECRET_KEY` production guard

- Add `APP_ENV` (default: `development`).
- Run `_guard_secret_key(settings)` immediately after `Settings()` is instantiated, before `security.py` imports and binds `SECRET_KEY`.
- Outside the development allowlist (`dev`, `development`, `test`, `testing`, `local`), raise `RuntimeError` if `SECRET_KEY` is empty or still set to the default value.

### NEH-55: `DATABASE_PASSWORD` production guard

- Add `_guard_database_password(settings)` alongside the secret key guard.
- Reject known placeholder passwords (`""`, `password`, `change-this-in-production`) outside development.
- Preserve the existing Docker Compose development fallback.

### NEH-134: `pydantic-settings` v2 environment binding

- Replace obsolete `Field(env=...)` usage with `validation_alias` where field names differ from their intended environment variables:
  - `DTK_EXPORTS_DIR` --> `EXPORTS_ROOT`
  - `DTK_MAX_UPLOAD_BYTES` --> `MAX_UPLOAD_BYTES`
- Remove redundant `Field(env=...)` declarations from fields that already bind by name.
- Replace `ConfigDict` with `SettingsConfigDict` for the `BaseSettings` configuration.

## Behavior

- **Development** (`APP_ENV=development`, default): behavior is unchanged.
- **Production** (any non-development environment): startup fails if `SECRET_KEY` or `DATABASE_PASSWORD` is missing or set to a known placeholder.

## Testing

- Added `tests/unit/test_secret_key_guard.py` and `tests/unit/test_database_password_guard.py`.
- Covered:
  - Development environment exemption.
  - Production rejection of placeholder values.
  - Unknown environments treated as production.
  - Successful startup with valid secrets.
- Verified `DTK_EXPORTS_DIR` and `DTK_MAX_UPLOAD_BYTES` bind correctly through `validation_alias`.
- Confirmed `.env` loading continues to work with `SettingsConfigDict`.

## Companion PR

The corresponding superproject PR [#244](https://github.com/UCSB-AMPLab/digitization-toolkit-software/pull/244) updates `.env.example` by removing obsolete configuration options, documenting `DTK_EXPORTS_DIR`, and describing the new production guards.

Closes **NEH-55**.