### PR TITLE
fix(security): gate first-user admin bootstrap behind a local token (NEH-56)

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends, HTTPException, Security, Query
+import hmac
+
+from fastapi import APIRouter, Depends, HTTPException, Security, Query, Header
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 from typing import List, Optional
@@ -7,6 +9,7 @@ from app.api.deps import get_db_dependency
 from app.models.user import User
 from app.schemas.user import UserCreate, UserLogin, UserRead, UserRoleUpdate, PasswordReset, PasswordResetRequest, TokenRefresh
 from app.core.security import hash_password, verify_password, create_access_token, verify_access_token
+from app.core.config import settings, is_dev_env
 from app.core.audit import log_event
 
 router = APIRouter()
@@ -20,6 +23,24 @@ users_router = APIRouter()  # mounted at /users in main.py
 _optional_bearer = HTTPBearer(auto_error=False)
 
 
+def _authorize_bootstrap(provided_token: Optional[str], config=settings) -> None:
+    """Gate first-user admin bootstrap behind a local trust factor.
+
+    On a fresh or re-flashed unit the first /register call creates an admin with
+    no auth. BOOTSTRAP_TOKEN is generated per-unit at first boot and is
+    only readable with local (console/SSH) access, so a network attacker cannot
+    claim the admin account. Dev keeps the tokenless bootstrap when no token is set.
+    """
+    configured = config.BOOTSTRAP_TOKEN.strip()
+    if is_dev_env(config.APP_ENV) and not configured:
+        return
+    if not configured:
+        # Production with no token configured: fail closed rather than open the bootstrap.
+        raise HTTPException(status_code=503, detail="First-user setup is unavailable: no bootstrap token configured")
+    if not provided_token or not hmac.compare_digest(provided_token.strip(), configured):
+        raise HTTPException(status_code=401, detail="Invalid or missing bootstrap token")
+
+
 @router.get("/setup/status")
 def setup_status(db: Session = Depends(get_db_dependency)):
     """Check whether initial setup is needed (no users exist yet). No auth required."""
@@ -31,11 +52,15 @@ def setup_status(db: Session = Depends(get_db_dependency)):
 def register(
     payload: UserCreate,
     credentials: Optional[HTTPAuthorizationCredentials] = Security(_optional_bearer),
+    bootstrap_token: Optional[str] = Header(default=None, alias="X-Bootstrap-Token"),
     db: Session = Depends(get_db_dependency),
 ):
     is_first_user = db.query(User).count() == 0
 
-    if not is_first_user:
+    if is_first_user:
+        # Unauthenticated first-user bootstrap requires a local bootstrap token
+        _authorize_bootstrap(bootstrap_token)
+    else:
         # After bootstrap, only admins may create accounts.
         if not credentials:
             raise HTTPException(status_code=401, detail="Not authenticated")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,6 +17,8 @@ class Settings(BaseSettings):
     PROJECTS_ROOT: str = ""
     CAMERA_BACKEND: str = "picamera2"
     SECRET_KEY: str = "dev-secret-change-me"
+    # Per-unit token protecting first-user admin bootstrap over the network
+    BOOTSTRAP_TOKEN: str = ""
     ACCESS_TOKEN_EXPIRE_SECONDS: int = 28800  # 8 hours
     CORS_ORIGINS: list[str] = ["http://localhost:5173", "http://localhost:3000"]
     
@@ -61,6 +63,12 @@ _INSECURE_SECRET_KEYS = {
 
 # Environments exempt from the production guards; anything else must set real secrets
 _DEV_ENVIRONMENTS = {"dev", "development", "test", "testing", "local"}
+
+
+def is_dev_env(app_env: str) -> bool:
+    """True when APP_ENV names a development or test environment."""
+    return app_env.strip().lower() in _DEV_ENVIRONMENTS
+
 
 # Blacklist of DATABASE_PASSWORD values that must never reach a production DB outside dev
 _INSECURE_DB_PASSWORDS = {

--- a/tests/unit/test_bootstrap_token_guard.py
+++ b/tests/unit/test_bootstrap_token_guard.py
@@ -1,0 +1,41 @@
+"""Gate first-user admin bootstrap behind a local bootstrap token."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.auth import _authorize_bootstrap
+
+
+def _cfg(app_env: str, bootstrap_token: str) -> SimpleNamespace:
+    """Minimal stand-in for Settings with just the fields the gate reads."""
+    return SimpleNamespace(APP_ENV=app_env, BOOTSTRAP_TOKEN=bootstrap_token)
+
+
+def test_dev_without_configured_token_allows_bootstrap():
+    # Dev keeps the tokenless first-user flow so local setup needs no configuration
+    _authorize_bootstrap(None, config=_cfg("dev", ""))
+
+
+def test_production_without_configured_token_fails_closed():
+    with pytest.raises(HTTPException) as exc:
+        _authorize_bootstrap("anything", config=_cfg("production", ""))
+    assert exc.value.status_code == 503
+
+
+def test_production_with_matching_token_allows_bootstrap():
+    _authorize_bootstrap("s3cret-token", config=_cfg("production", "s3cret-token"))
+
+
+@pytest.mark.parametrize("provided", [None, "", "wrong-token"])
+def test_production_rejects_missing_or_wrong_token(provided):
+    with pytest.raises(HTTPException) as exc:
+        _authorize_bootstrap(provided, config=_cfg("production", "s3cret-token"))
+    assert exc.value.status_code == 401
+
+
+def test_configured_token_is_enforced_even_in_dev():
+    # If an operator sets a token, dev enforces it too (opt-in)
+    with pytest.raises(HTTPException):
+        _authorize_bootstrap("wrong", config=_cfg("dev", "s3cret-token"))


### PR DESCRIPTION
## Summary

On a fresh or re-flashed unit, `POST /auth/register` creates the first account as admin without authentication. Since the backend binds to `0.0.0.0`, anyone on the venue LAN can claim the admin account before the legitimate operator. Reflashing the SD card reopens this window. This PR secures first-user bootstrap with a per-unit bootstrap token.

## Changes

- `config.py`: Adds the `BOOTSTRAP_TOKEN` setting (bound by field name) and the `is_dev_env()` helper.
- `auth.py`: Enforces `_authorize_bootstrap()` in the first-user `/register` path using the `X-Bootstrap-Token` header.
  - Outside development, the token must match (`hmac.compare_digest`); missing or invalid tokens return `401`.
  - If no token is configured in production, registration fails closed with `503`.
  - Development retains tokenless bootstrap when no token is configured.

## Why this fixes the issue

`BOOTSTRAP_TOKEN` is generated per unit during first-boot provisioning and is only accessible through local (console/SSH) access. An attacker on the network cannot obtain it, preventing unauthorized first-user admin registration.

## Testing

- Added `tests/unit/test_bootstrap_token_guard.py` (7 tests) covering dev bypass, production fail-closed (`503`), valid token, missing/invalid token (`401`), and configured token enforcement in development.

## Dependencies / Follow-up

Production deployment requires first-boot provisioning (NEH-158) to generate `BOOTSTRAP_TOKEN` and write it to `.env`, alongside `SECRET_KEY` and `DATABASE_PASSWORD`. Until then, first-user registration returns `503` on production units.

A companion frontend PR adds the bootstrap token field to `/setup`.

Closes **NEH-56** (backend).