### PR TITLE
fix(security): throttle login brute force and raise PBKDF2 to 600k (N…

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,6 +1,6 @@
 import hmac
 
-from fastapi import APIRouter, Depends, HTTPException, Security, Query, Header
+from fastapi import APIRouter, Depends, HTTPException, Security, Query, Header, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 from typing import List, Optional
@@ -8,8 +8,9 @@ from typing import List, Optional
 from app.api.deps import get_db_dependency
 from app.models.user import User
 from app.schemas.user import UserCreate, UserLogin, UserRead, UserRoleUpdate, PasswordReset, PasswordResetRequest, TokenRefresh
-from app.core.security import hash_password, verify_password, create_access_token, verify_access_token
+from app.core.security import hash_password, verify_password, create_access_token, verify_access_token, needs_rehash
 from app.core.config import settings, is_dev_env
+from app.core.login_throttle import login_throttle
 from app.core.audit import log_event
 
 router = APIRouter()
@@ -97,10 +98,41 @@ def register(
     return UserRead.model_validate(user)
 
 
+def _client_ip(request: Request) -> str:
+    """Best-effort real client IP for per-IP throttling.
+
+    Behind nginx the socket peer is the proxy, so a naive request.client.host would
+    put every user in one bucket and let 5 failures lock the whole unit. nginx sets
+    X-Real-IP / X-Forwarded-For (see nginx.conf), so prefer those; fall back to the
+    socket peer for direct connections. Per-account throttling is the robust half;
+    this just makes the per-IP half meaningful behind the reverse proxy.
+    """
+    xri = request.headers.get("x-real-ip")
+    if xri:
+        return xri.strip()
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        return xff.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
 @router.post("/login")
-def login(payload: UserLogin, db: Session = Depends(get_db_dependency)):
+def login(payload: UserLogin, request: Request, db: Session = Depends(get_db_dependency)):
+    # Throttle brute force per account and per client IP on the untrusted LAN.
+    ip = _client_ip(request)
+    acct_key = f"user:{payload.username.strip().lower()}"
+    ip_key = f"ip:{ip}"
+
+    retry = login_throttle.retry_after(acct_key, ip_key)
+    if retry > 0:
+        log_event(db, level="WARN", category="access", action="login_throttled",
+                  actor=payload.username, detail=f"locked; retry after {retry}s")
+        raise HTTPException(status_code=429, detail="Too many failed login attempts. Try again later.",
+                            headers={"Retry-After": str(retry)})
+
     user = db.query(User).filter(User.username == payload.username).first()
     if not user or not verify_password(payload.password, user.hashed_password):
+        login_throttle.record_failure(acct_key, ip_key)
         log_event(db, level="WARN", category="access", action="login_failed",
                   actor=payload.username)
         raise HTTPException(status_code=401, detail="Invalid credentials")
@@ -108,6 +140,14 @@ def login(payload: UserLogin, db: Session = Depends(get_db_dependency)):
         log_event(db, level="WARN", category="access", action="login_failed",
                   actor=user.username, detail="cuenta inactiva")
         raise HTTPException(status_code=403, detail="User is inactive")
+
+    # Success: clear the throttle counters and upgrade a legacy/weak hash while we still hold the plaintext
+    login_throttle.reset(acct_key, ip_key)
+    if needs_rehash(user.hashed_password):
+        user.hashed_password = hash_password(payload.password)
+        db.add(user)
+        db.commit()
+
     log_event(db, level="INFO", category="access", action="login_success",
               actor=user.username)
     token = create_access_token(subject=str(user.id))

--- a/app/core/login_throttle.py
+++ b/app/core/login_throttle.py
@@ -1,0 +1,67 @@
+"""In-memory login throttle for the single-process appliance.
+
+Deliberately in-memory, not DB-backed: writing a row per failed login would hammer
+the SD card, and the backend runs as one uvicorn process, so
+process-local state is shared across all requests. State resets on restart, which
+is acceptable — an attacker can't restart the service, and a restart only clears
+lockouts, it never grants access.
+
+Keys are opaque strings; the caller throttles per account and per client IP by
+passing both keys, so brute force is bounded whether it targets one account from
+many IPs or many accounts from one IP.
+"""
+
+import math
+import time
+from threading import Lock
+from typing import Callable
+
+
+class LoginThrottle:
+    def __init__(
+        self,
+        max_failures: int = 5,
+        lockout_seconds: int = 300,
+        window_seconds: int = 900,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self._max = max_failures
+        self._lockout = lockout_seconds
+        self._window = window_seconds
+        self._clock = clock
+        self._lock = Lock()
+        self._state: dict[str, dict] = {}
+
+    def retry_after(self, *keys: str) -> int:
+        """Seconds until the soonest-unlocking key frees up, or 0 if none are locked."""
+        now = self._clock()
+        remaining = 0
+        with self._lock:
+            for key in keys:
+                st = self._state.get(key)
+                if st and st["locked_until"] > now:
+                    remaining = max(remaining, math.ceil(st["locked_until"] - now))
+        return remaining
+
+    def record_failure(self, *keys: str) -> None:
+        """Count a failed attempt against each key; lock the key once it crosses
+        max_failures within the sliding window."""
+        now = self._clock()
+        with self._lock:
+            for key in keys:
+                st = self._state.setdefault(key, {"failures": [], "locked_until": 0.0})
+                st["failures"] = [t for t in st["failures"] if t > now - self._window]
+                st["failures"].append(now)
+                if len(st["failures"]) >= self._max:
+                    st["locked_until"] = now + self._lockout
+                    st["failures"] = []
+
+    def reset(self, *keys: str) -> None:
+        """Clear all state for the given keys (called on a successful login)."""
+        with self._lock:
+            for key in keys:
+                self._state.pop(key, None)
+
+
+# Module-level singleton shared across requests in the single backend process.
+login_throttle = LoginThrottle()

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -22,19 +22,47 @@ def _b64u_decode(data: str) -> bytes:
     return base64.urlsafe_b64decode(data + padding)
 
 
+# PBKDF2-HMAC-SHA256 work factor. Self-describing hashes allow future increases;
+# login upgrades weaker hashes when the plaintext is available.
+_ALGO = "pbkdf2_sha256"
+PBKDF2_ITERATIONS = 600_000
+_LEGACY_ITERATIONS = 100_000  # original hashes were stored bare as "salt$hash"
+
+
+def _pbkdf2(password: str, salt: str, iterations: int) -> str:
+    return hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt.encode("utf-8"), iterations).hex()
+
+
 def hash_password(password: str) -> str:
     salt = secrets.token_hex(16)
-    dk = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt.encode("utf-8"), 100_000)
-    return f"{salt}${dk.hex()}"
+    return f"{_ALGO}${PBKDF2_ITERATIONS}${salt}${_pbkdf2(password, salt, PBKDF2_ITERATIONS)}"
 
 
 def verify_password(password: str, hashed: str) -> bool:
     try:
-        salt, hash_hex = hashed.split("$", 1)
+        parts = hashed.split("$")
+        if len(parts) == 4 and parts[0] == _ALGO:
+            _, iters, salt, digest = parts
+            return hmac.compare_digest(_pbkdf2(password, salt, int(iters)), digest)
+        if len(parts) == 2:
+            # Legacy format: "salt$hash" at the original fixed iteration count.
+            salt, digest = parts
+            return hmac.compare_digest(_pbkdf2(password, salt, _LEGACY_ITERATIONS), digest)
     except Exception:
         return False
-    dk = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt.encode("utf-8"), 100_000)
-    return hmac.compare_digest(dk.hex(), hash_hex)
+    return False
+
+
+def needs_rehash(hashed: str) -> bool:
+    """True when a stored hash uses a weaker scheme than the current default, so a
+    successful login can transparently re-hash the password at full strength."""
+    parts = hashed.split("$")
+    if len(parts) == 4 and parts[0] == _ALGO:
+        try:
+            return int(parts[1]) < PBKDF2_ITERATIONS
+        except ValueError:
+            return True
+    return True  # legacy 2-part or anything unrecognized
 
 
 def create_access_token(subject: str, expires_seconds: Optional[int] = None) -> str:

--- a/tests/unit/test_login_throttle.py
+++ b/tests/unit/test_login_throttle.py
@@ -1,0 +1,55 @@
+"""Login throttle: lockout after repeated failures, reset on success, and that the /auth/login endpoint is actually wired to it."""
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 1000.0
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, seconds):
+        self.t += seconds
+
+
+def test_locks_after_max_failures_then_unlocks_after_timeout():
+    from app.core.login_throttle import LoginThrottle
+    clk = FakeClock()
+    th = LoginThrottle(max_failures=3, lockout_seconds=60, window_seconds=300, clock=clk)
+    key = "user:alice"
+    assert th.retry_after(key) == 0
+    for _ in range(3):
+        th.record_failure(key)
+    assert 0 < th.retry_after(key) <= 60
+    clk.advance(61)
+    assert th.retry_after(key) == 0
+
+
+def test_reset_clears_lockout():
+    from app.core.login_throttle import LoginThrottle
+    clk = FakeClock()
+    th = LoginThrottle(max_failures=2, lockout_seconds=60, clock=clk)
+    key = "ip:1.2.3.4"
+    th.record_failure(key)
+    th.record_failure(key)
+    assert th.retry_after(key) > 0
+    th.reset(key)
+    assert th.retry_after(key) == 0
+
+
+def test_login_endpoint_returns_429_after_repeated_failures(client, db_session, monkeypatch):
+    import app.api.auth as auth_mod
+    from app.core.login_throttle import LoginThrottle
+    from app.models.user import User
+    from app.core.security import hash_password
+
+    monkeypatch.setattr(auth_mod, "login_throttle", LoginThrottle(max_failures=3, lockout_seconds=60))
+    db_session.add(User(username="alice", email="a@example.com",
+                        hashed_password=hash_password("rightpw"), role="admin", is_active=True))
+    db_session.commit()
+
+    for _ in range(3):
+        assert client.post("/auth/login", json={"username": "alice", "password": "wrong"}).status_code == 401
+    resp = client.post("/auth/login", json={"username": "alice", "password": "wrong"})
+    assert resp.status_code == 429
+    assert "Retry-After" in resp.headers

--- a/tests/unit/test_password_hash_upgrade.py
+++ b/tests/unit/test_password_hash_upgrade.py
@@ -1,0 +1,28 @@
+"""PBKDF2 hashing: new-format + legacy verify, and rehash-on-upgrade detection."""
+
+from app.core.security import (
+    hash_password, verify_password, needs_rehash, _pbkdf2, _LEGACY_ITERATIONS,
+)
+
+
+def test_new_hash_roundtrip():
+    h = hash_password("correct horse")
+    assert verify_password("correct horse", h)
+    assert not verify_password("wrong", h)
+    assert not needs_rehash(h)
+
+
+def test_legacy_hash_verifies_and_flags_rehash():
+    # Reconstruct an original-format hash: "salt$hash" at the old 100k iterations.
+    salt = "a" * 32
+    legacy = f"{salt}${_pbkdf2('pw', salt, _LEGACY_ITERATIONS)}"
+    assert verify_password("pw", legacy)
+    assert not verify_password("nope", legacy)
+    assert needs_rehash(legacy)
+
+
+def test_lower_iteration_new_format_flags_rehash():
+    salt = "b" * 32
+    weak = f"pbkdf2_sha256$1000${salt}${_pbkdf2('pw', salt, 1000)}"
+    assert verify_password("pw", weak)
+    assert needs_rehash(weak)


### PR DESCRIPTION
## Summary

The login endpoint had no throttling and used PBKDF2 with 100k iterations (below current guidance of ~600k), making weak operator passwords vulnerable to brute force on the untrusted venue LAN. A compromised account could expose file and secret access paths.

## Change

- **Throttle** (`login_throttle.py`): Adds in-memory per-account and per-IP lockout. After repeated failures, login returns `429` with `Retry-After` and logs a `login_throttled` audit event; counters reset on success. In-memory by design: failed login persistence would add unnecessary SD writes, and the backend runs as a single process.
- **KDF** (`security.py`): Raises PBKDF2-HMAC-SHA256 to 600k iterations with a self-describing format (`pbkdf2_sha256$<iters>$<salt>$<hash>`). `verify_password` continues accepting legacy `salt$hash` (100k), while `needs_rehash` upgrades weaker hashes on login.
- **Real client IP** (`_client_ip`): Uses `X-Real-IP` / `X-Forwarded-For` from nginx so per-IP throttling tracks the actual client instead of the proxy.

## Testing

Added `test_password_hash_upgrade.py` (legacy/new verification, `needs_rehash`) and `test_login_throttle.py` (lockout/unlock, reset, endpoint `429`). Full unit suite passed;

Closes NEH-58.