### PR TITLE
release(backend): ship the NEH-32 authentication and secrets hardening to main

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,8 +26,9 @@ def init_db() -> None:
 **When adding/modifying models:**
 1. Update the model in `app/models/`
 2. Generate migration: `docker compose exec backend alembic revision --autogenerate -m "description"`
-3. Review the generated migration file
+3. Review the generated migration file — **read every operation and delete anything you did not intend**. Autogenerate emits drops for any table or column the models don't declare, which is how `project_members` was once dropped (`dda9bc1bc608`, restored in `ff2f751fadbb`)
 4. Apply: `docker compose exec backend alembic upgrade head`
+5. Confirm no drift is left: `docker compose exec backend alembic check` — it must print `No new upgrade operations detected`
 
 ### [INFO] Authentication & Security
 
@@ -85,6 +86,13 @@ docker compose exec backend alembic upgrade head
 ```bash
 docker compose exec backend alembic revision --autogenerate -m "description"
 ```
+
+### Check for schema drift (models vs. migrated database)
+```bash
+docker compose exec backend alembic upgrade head
+docker compose exec backend alembic check
+```
+Natively on the Pi, `pixi run db-check-drift` runs both.
 
 ### Check database tables
 ```bash

--- a/alembic/versions/7e0b2c73bda1_add_capture_mode_and_rejection_audit.py
+++ b/alembic/versions/7e0b2c73bda1_add_capture_mode_and_rejection_audit.py
@@ -1,0 +1,100 @@
+"""add capture_mode and rejection audit trail (NEH-208)
+
+Revision ID: 7e0b2c73bda1
+Revises: f6a7b8c9d0e1
+Create Date: 2026-07-28 12:00:00.000000
+
+Part 1 of the NEH-208 review-workflow redesign. This migration:
+
+1. Creates `record_rejections`: one row per rejection event (mandatory
+   predefined_reason from the same 6-value list the annotation feature
+   already uses, optional free-text comment, who/when).
+2. Adds `record_images.is_current` / `superseded_at` / `rejection_id` so a
+   rejected image is never deleted or overwritten — it stays in place,
+   flagged as superseded once a recapture installs its replacement, and
+   stays linked to the rejection that flagged it.
+3. Adds `records.capture_mode` ("single" | "dual") and backfills it for
+   every existing record by inferring from its images: dual capture always
+   writes RecordImage.role in ('left','right') with a shared pair_id
+   (cameras.py), so any record with such images is 'dual'; everything else
+   (including records with zero images) is 'single'.
+4. Drops `records.rejection_note` — superseded by
+   record_rejections.predefined_reason/comment, which now carries this
+   information instead. Downgrade restores it empty (nullable); the text
+   itself is not recoverable, same as this repo's other lossy downgrades.
+
+The second half of the redesign (captured -> in_review data migration and
+narrowing the status CHECK constraint) is a separate migration
+(b2a1f9c4d3e6) chained after this one, so the judgment-call backfill here
+stays isolated from that mechanical rewrite.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7e0b2c73bda1'
+down_revision: Union[str, None] = 'f6a7b8c9d0e1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Rejection audit table.
+    op.create_table(
+        'record_rejections',
+        sa.Column('id', sa.Integer(), primary_key=True, index=True),
+        sa.Column('record_id', sa.Integer(), sa.ForeignKey('records.id', ondelete='CASCADE'), nullable=False, index=True),
+        sa.Column('predefined_reason', sa.String(length=20), nullable=False),
+        sa.Column('comment', sa.Text(), nullable=True),
+        sa.Column('rejected_by', sa.String(length=255), nullable=True),
+        sa.Column('rejected_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_check_constraint(
+        'check_record_rejection_reason',
+        'record_rejections',
+        "predefined_reason IN ('blur','glare','shadow','focus','exposure','dirt')",
+    )
+
+    # 2. RecordImage audit-trail columns.
+    op.add_column('record_images', sa.Column('is_current', sa.Boolean(), nullable=False, server_default=sa.true()))
+    op.add_column('record_images', sa.Column('superseded_at', sa.DateTime(), nullable=True))
+    op.add_column('record_images', sa.Column('rejection_id', sa.Integer(), sa.ForeignKey('record_rejections.id', ondelete='SET NULL'), nullable=True))
+    op.create_index(op.f('ix_record_images_rejection_id'), 'record_images', ['rejection_id'])
+
+    # 3. capture_mode: add nullable, backfill, then lock down.
+    op.add_column('records', sa.Column('capture_mode', sa.String(length=10), nullable=True))
+    op.execute("""
+        UPDATE records SET capture_mode = 'dual'
+        WHERE id IN (
+            SELECT DISTINCT record_id FROM record_images
+            WHERE role IN ('left', 'right') OR pair_id IS NOT NULL
+        )
+    """)
+    op.execute("UPDATE records SET capture_mode = 'single' WHERE capture_mode IS NULL")
+    op.alter_column('records', 'capture_mode', nullable=False)
+    op.create_check_constraint(
+        'check_record_capture_mode',
+        'records',
+        "capture_mode IN ('single','dual')",
+    )
+
+    # 4. rejection_note is superseded by record_rejections.
+    op.drop_column('records', 'rejection_note')
+
+
+def downgrade() -> None:
+    op.add_column('records', sa.Column('rejection_note', sa.Text(), nullable=True))
+
+    op.drop_constraint('check_record_capture_mode', 'records', type_='check')
+    op.drop_column('records', 'capture_mode')
+
+    op.drop_index(op.f('ix_record_images_rejection_id'), table_name='record_images')
+    op.drop_column('record_images', 'rejection_id')
+    op.drop_column('record_images', 'superseded_at')
+    op.drop_column('record_images', 'is_current')
+
+    op.drop_constraint('check_record_rejection_reason', 'record_rejections', type_='check')
+    op.drop_table('record_rejections')

--- a/alembic/versions/e11b1fbb07e1_migrate_captured_status_to_in_review.py
+++ b/alembic/versions/e11b1fbb07e1_migrate_captured_status_to_in_review.py
@@ -1,0 +1,48 @@
+"""migrate 'captured' record status to 'in_review' (NEH-208)
+
+Revision ID: e11b1fbb07e1
+Revises: 7e0b2c73bda1
+Create Date: 2026-07-28 12:05:00.000000
+
+Part 2 of the NEH-208 review-workflow redesign. "captured" stops being a
+persisted/exposed status entirely — a record now enters the queue as
+"in_review" the instant it's captured (see app/api/cameras.py), with no
+manual promotion step. This maps every existing 'captured' row to
+'in_review' and narrows the CHECK constraint accordingly.
+
+Downgrade restores the wider constraint but does not attempt to reverse
+the data migration — which rows were 'captured' vs. legitimately already
+'in_review' is not recoverable, same reasoning as this repo's other lossy
+downgrades (e.g. f6a7b8c9d0e1).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e11b1fbb07e1'
+down_revision: Union[str, None] = '7e0b2c73bda1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE records SET status = 'in_review' WHERE status = 'captured'")
+    op.drop_constraint('check_record_status', 'records', type_='check')
+    op.create_check_constraint(
+        'check_record_status',
+        'records',
+        "status IN ('in_review','rejected','approved')",
+    )
+    op.alter_column('records', 'status', server_default='in_review')
+
+
+def downgrade() -> None:
+    op.drop_constraint('check_record_status', 'records', type_='check')
+    op.create_check_constraint(
+        'check_record_status',
+        'records',
+        "status IN ('captured','in_review','rejected','approved')",
+    )
+    op.alter_column('records', 'status', server_default='captured')

--- a/alembic/versions/f6a7b8c9d0e1_drop_unused_collection_export_tracking.py
+++ b/alembic/versions/f6a7b8c9d0e1_drop_unused_collection_export_tracking.py
@@ -1,0 +1,51 @@
+"""drop unused collection export tracking columns
+
+Revision ID: f6a7b8c9d0e1
+Revises: 2525f43a4661
+Create Date: 2026-07-25 19:20:00.000000
+
+Removes collections.export_version / last_exported_at / last_export_hash,
+resolving the schema-vs-model drift in NEH-105.
+
+The three columns arrived in dda9bc1bc608 - an unadjusted autogenerate
+that also dropped project_members (restored in ff2f751fadbb) - and were
+never declared on the Collection model, never read, and never written.
+So every row on every unit holds export_version=0 with the other two
+NULL: dropping them loses no data.
+
+They are dropped rather than modelled because export state is already
+tracked on the filesystem, which is where the live code looks: exports
+are named collection_{id}_{YYYYMMDDTHHMMSSZ}.zip and the download
+endpoint resolves the most recent one by globbing that pattern. A
+last_exported_at column would be a second, staler answer to a question
+the filesystem already answers - and NEH-90 will prune those zips,
+at which point the DB copy would start lying. When export needs real
+persistence (NEH-90's async jobs and pruning; NEH-123/124's per-file
+verification) it wants one row per export, not latest-only summary
+columns on the parent.
+
+Downgrade restores the columns exactly as dda9bc1bc608 created them.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f6a7b8c9d0e1'
+down_revision: Union[str, None] = '2525f43a4661'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_column('collections', 'last_export_hash')
+    op.drop_column('collections', 'last_exported_at')
+    op.drop_column('collections', 'export_version')
+
+
+def downgrade() -> None:
+    op.add_column('collections', sa.Column('export_version', sa.Integer(), server_default=sa.text('0'), nullable=False))
+    op.add_column('collections', sa.Column('last_exported_at', sa.DateTime(), nullable=True))
+    op.add_column('collections', sa.Column('last_export_hash', sa.String(length=64), nullable=True))

--- a/app/api/API_spec.yaml
+++ b/app/api/API_spec.yaml
@@ -623,7 +623,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/RecordRead'
         '409':
-          description: Database integrity error
+          description: Sanitized constraint violation (constraint name and message, no SQL)
+        '422':
+          description: Validation error (e.g. a record given both a project and a collection)
 
     get:
       summary: List all records with optional filtering

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -275,7 +275,7 @@ def set_user_active(
     return UserRead.model_validate(user)
 
 
-@router.delete("/{user_id}")
+@router.delete("/users/{user_id}")
 def delete_user(
     user_id: int,
     current_user: User = Depends(allow_admin),
@@ -284,6 +284,20 @@ def delete_user(
     user = db.query(User).filter(User.id == user_id).first()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
+    if user.id == current_user.id:
+        raise HTTPException(status_code=400, detail="Admins cannot delete their own account")
+    # Refuse to remove the last active admin: a headless appliance with no active
+    # admin can't manage users/storage/logs and can't mint a new admin (register
+    # needs an admin token once users exist) — an unrecoverable lockout (NEH-57).
+    if user.role == "admin" and user.is_active:
+        other_active_admins = db.query(User).filter(
+            User.role == "admin", User.is_active == True, User.id != user.id
+        ).count()
+        if other_active_admins == 0:
+            raise HTTPException(status_code=400, detail="Cannot delete the last active admin")
+    deleted_username = user.username
     db.delete(user)
     db.commit()
+    log_event(db, level="INFO", category="access", action="user_deleted",
+              actor=current_user.username, subject=deleted_username)
     return {"detail": "user deleted successfully"}

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,6 +1,6 @@
 import hmac
 
-from fastapi import APIRouter, Depends, HTTPException, Security, Query, Header
+from fastapi import APIRouter, Depends, HTTPException, Security, Query, Header, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 from typing import List, Optional
@@ -8,8 +8,9 @@ from typing import List, Optional
 from app.api.deps import get_db_dependency
 from app.models.user import User
 from app.schemas.user import UserCreate, UserLogin, UserRead, UserRoleUpdate, PasswordReset, PasswordResetRequest, TokenRefresh
-from app.core.security import hash_password, verify_password, create_access_token, verify_access_token
+from app.core.security import hash_password, verify_password, create_access_token, verify_access_token, needs_rehash
 from app.core.config import settings, is_dev_env
+from app.core.login_throttle import login_throttle
 from app.core.audit import log_event
 
 router = APIRouter()
@@ -97,10 +98,41 @@ def register(
     return UserRead.model_validate(user)
 
 
+def _client_ip(request: Request) -> str:
+    """Best-effort real client IP for per-IP throttling.
+
+    Behind nginx the socket peer is the proxy, so a naive request.client.host would
+    put every user in one bucket and let 5 failures lock the whole unit. nginx sets
+    X-Real-IP / X-Forwarded-For (see nginx.conf), so prefer those; fall back to the
+    socket peer for direct connections. Per-account throttling is the robust half;
+    this just makes the per-IP half meaningful behind the reverse proxy.
+    """
+    xri = request.headers.get("x-real-ip")
+    if xri:
+        return xri.strip()
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        return xff.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
 @router.post("/login")
-def login(payload: UserLogin, db: Session = Depends(get_db_dependency)):
+def login(payload: UserLogin, request: Request, db: Session = Depends(get_db_dependency)):
+    # Throttle brute force per account and per client IP on the untrusted LAN.
+    ip = _client_ip(request)
+    acct_key = f"user:{payload.username.strip().lower()}"
+    ip_key = f"ip:{ip}"
+
+    retry = login_throttle.retry_after(acct_key, ip_key)
+    if retry > 0:
+        log_event(db, level="WARN", category="access", action="login_throttled",
+                  actor=payload.username, detail=f"locked; retry after {retry}s")
+        raise HTTPException(status_code=429, detail="Too many failed login attempts. Try again later.",
+                            headers={"Retry-After": str(retry)})
+
     user = db.query(User).filter(User.username == payload.username).first()
     if not user or not verify_password(payload.password, user.hashed_password):
+        login_throttle.record_failure(acct_key, ip_key)
         log_event(db, level="WARN", category="access", action="login_failed",
                   actor=payload.username)
         raise HTTPException(status_code=401, detail="Invalid credentials")
@@ -108,6 +140,14 @@ def login(payload: UserLogin, db: Session = Depends(get_db_dependency)):
         log_event(db, level="WARN", category="access", action="login_failed",
                   actor=user.username, detail="cuenta inactiva")
         raise HTTPException(status_code=403, detail="User is inactive")
+
+    # Success: clear the throttle counters and upgrade a legacy/weak hash while we still hold the plaintext
+    login_throttle.reset(acct_key, ip_key)
+    if needs_rehash(user.hashed_password):
+        user.hashed_password = hash_password(payload.password)
+        db.add(user)
+        db.commit()
+
     log_event(db, level="INFO", category="access", action="login_success",
               actor=user.username)
     token = create_access_token(subject=str(user.id))

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends, HTTPException, Security, Query
+import hmac
+
+from fastapi import APIRouter, Depends, HTTPException, Security, Query, Header
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 from typing import List, Optional
@@ -7,6 +9,7 @@ from app.api.deps import get_db_dependency
 from app.models.user import User
 from app.schemas.user import UserCreate, UserLogin, UserRead, UserRoleUpdate, PasswordReset, PasswordResetRequest, TokenRefresh
 from app.core.security import hash_password, verify_password, create_access_token, verify_access_token
+from app.core.config import settings, is_dev_env
 from app.core.audit import log_event
 
 router = APIRouter()
@@ -20,6 +23,24 @@ users_router = APIRouter()  # mounted at /users in main.py
 _optional_bearer = HTTPBearer(auto_error=False)
 
 
+def _authorize_bootstrap(provided_token: Optional[str], config=settings) -> None:
+    """Gate first-user admin bootstrap behind a local trust factor.
+
+    On a fresh or re-flashed unit the first /register call creates an admin with
+    no auth. BOOTSTRAP_TOKEN is generated per-unit at first boot and is
+    only readable with local (console/SSH) access, so a network attacker cannot
+    claim the admin account. Dev keeps the tokenless bootstrap when no token is set.
+    """
+    configured = config.BOOTSTRAP_TOKEN.strip()
+    if is_dev_env(config.APP_ENV) and not configured:
+        return
+    if not configured:
+        # Production with no token configured: fail closed rather than open the bootstrap.
+        raise HTTPException(status_code=503, detail="First-user setup is unavailable: no bootstrap token configured")
+    if not provided_token or not hmac.compare_digest(provided_token.strip(), configured):
+        raise HTTPException(status_code=401, detail="Invalid or missing bootstrap token")
+
+
 @router.get("/setup/status")
 def setup_status(db: Session = Depends(get_db_dependency)):
     """Check whether initial setup is needed (no users exist yet). No auth required."""
@@ -31,11 +52,15 @@ def setup_status(db: Session = Depends(get_db_dependency)):
 def register(
     payload: UserCreate,
     credentials: Optional[HTTPAuthorizationCredentials] = Security(_optional_bearer),
+    bootstrap_token: Optional[str] = Header(default=None, alias="X-Bootstrap-Token"),
     db: Session = Depends(get_db_dependency),
 ):
     is_first_user = db.query(User).count() == 0
 
-    if not is_first_user:
+    if is_first_user:
+        # Unauthenticated first-user bootstrap requires a local bootstrap token
+        _authorize_bootstrap(bootstrap_token)
+    else:
         # After bootstrap, only admins may create accounts.
         if not credentials:
             raise HTTPException(status_code=401, detail="Not authenticated")

--- a/app/api/cameras.py
+++ b/app/api/cameras.py
@@ -17,6 +17,7 @@ from app.models.collection import Collection
 from app.schemas.camera import CameraSettingsCreate, CameraSettingsRead, CameraSettingsUpdate
 from app.core.thumbnail import generate_thumbnail
 from app.core.storage_ops import resolve_project_name
+from app.core.db_errors import integrity_conflict
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -1120,9 +1121,9 @@ def create_camera_settings(
 		db.add(cs)
 		db.commit()
 		db.refresh(cs)
-	except IntegrityError:
+	except IntegrityError as e:
 		db.rollback()
-		raise HTTPException(status_code=409, detail="Camera settings already exist for this record")
+		raise integrity_conflict(e)
 	return CameraSettingsRead.model_validate(cs)
 
 

--- a/app/api/cameras.py
+++ b/app/api/cameras.py
@@ -528,11 +528,24 @@ def trigger_capture(
 		effective_project_id = None if request.collection_id else project_id
 
 		# Get or create Record
+		is_recapture = False
 		if request.record_id:
 			# Link to existing record
 			record = db.query(Record).filter(Record.id == request.record_id).first()
 			if not record:
 				raise HTTPException(status_code=404, detail=f"Record {request.record_id} not found")
+			if record.status == "rejected":
+				# Recapture (NEH-208): a rejected record can only be redone with
+				# the same capture mode it was originally taken with — a single
+				# capture can't turn a dual-mode record's pair back into one image.
+				if record.capture_mode != "single":
+					raise HTTPException(
+						status_code=422,
+						detail=f"Record {record.id} was captured in '{record.capture_mode}' mode; use the dual-capture endpoint to recapture it."
+					)
+				is_recapture = True
+				from app.api.records import _supersede_current_images
+				_supersede_current_images(record)
 		else:
 			# Create new record for this capture
 			record = Record(
@@ -543,6 +556,7 @@ def trigger_capture(
 				collection_id=request.collection_id,
 				sequence=_next_record_sequence(db, effective_project_id, request.collection_id),
 				created_by=current_user.username,
+				capture_mode="single",
 			)
 			db.add(record)
 			db.flush()  # Get the ID
@@ -600,11 +614,14 @@ def trigger_capture(
 				raw_exif=str(exif_dict),
 			)
 			db.add(ex)
-		
+
+		if is_recapture:
+			record.status = "in_review"
+
 		db.commit()
 		db.refresh(record)
 		db.refresh(img)
-		
+
 		logger.info(f"Created record {record.id}, image {img.id}, capture_id={capture_id}")
 		
 		return CaptureResponse(
@@ -689,11 +706,24 @@ def trigger_dual_capture(
 		effective_project_id = None if request.collection_id else project_id
 		
 		# Get or create Record
+		is_recapture = False
 		if request.record_id:
 			# Link to existing record (adding new pages to multi-page document)
 			record = db.query(Record).filter(Record.id == request.record_id).first()
 			if not record:
 				raise HTTPException(status_code=404, detail=f"Record {request.record_id} not found")
+			if record.status == "rejected":
+				# Recapture (NEH-208): a rejected record can only be redone with
+				# the same capture mode it was originally taken with — a dual
+				# pair can't turn a single-mode record into two images.
+				if record.capture_mode != "dual":
+					raise HTTPException(
+						status_code=422,
+						detail=f"Record {record.id} was captured in '{record.capture_mode}' mode; use the single-capture endpoint to recapture it."
+					)
+				is_recapture = True
+				from app.api.records import _supersede_current_images
+				_supersede_current_images(record)
 		else:
 			# Create new record for this dual capture
 			record = Record(
@@ -704,6 +734,7 @@ def trigger_dual_capture(
 				collection_id=request.collection_id,
 				sequence=_next_record_sequence(db, effective_project_id, request.collection_id),
 				created_by=current_user.username,
+				capture_mode="dual",
 			)
 			db.add(record)
 			db.flush()  # Get the ID
@@ -796,7 +827,10 @@ def trigger_dual_capture(
 		role1 = "right" if request.left_camera_index == 0 else "left"
 		img0 = create_image_record(str(path0), 0, role0)
 		img1 = create_image_record(str(path1), 1, role1)
-		
+
+		if is_recapture:
+			record.status = "in_review"
+
 		db.commit()
 		db.refresh(record)
 		

--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -482,6 +482,16 @@ def export_collection_bagit(
             },
         )
 
+    image_less = [r.id for r in records if not any(i.is_current for i in r.images)]
+    if image_less:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": f"Cannot export: {len(image_less)} record(s) have no image: {image_less}",
+                "blocking_record_ids": image_less,
+            },
+        )
+
     # One export per collection at a time: a retry returns the running job instead of
     # stacking a second export that doubles disk pressure. Integrity checks and the
     # zip build happen in the job, surfaced via the status endpoint.

--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -14,6 +14,7 @@ from app.models.user import User
 from app.schemas.collection import CollectionCreate, CollectionRead, CollectionUpdate, CollectionWithChildren
 from app.schemas.record import ReorderRecords
 from app.core.audit import log_event
+from app.core.config import settings
 from app.core.storage_ops import (
     collection_and_descendants,
     relocate_image,
@@ -500,24 +501,63 @@ def export_collection_bagit(
         data_dir = tmp_path / "data"
         data_dir.mkdir()
 
-        # Copy image files into data/ numbered by their position in the ordered list
+        from app.core.paths import resolve_within_storage
+        from app.core.integrity import verify_images_against_manifest
+
+        to_copy = []  # (rec_dir_name, dest_name, resolved_src, img)
+        missing = []
+        used_names: dict = {}
         for idx, rec in enumerate(records):
             seq_label = f"{idx + 1:04d}"
             safe_title = "".join(c if c.isalnum() or c in "-_ " else "_" for c in (rec.title or "record"))[:60]
-            rec_dir = data_dir / f"{seq_label}_{safe_title}"
-            rec_dir.mkdir(exist_ok=True)
-
-            # Only current images: a rejected-then-superseded file must never land in an export bag (NEH-208)
+            rec_dir_name = f"{seq_label}_{safe_title}"
             for img in sorted([i for i in rec.images if i.is_current], key=lambda i: (i.role or "z", i.id)):
-                if not img.file_path:
-                    continue
-                src = _Path(img.file_path)
-                if not src.exists():
-                    logger.warning(f"Missing file for image {img.id}: {img.file_path}")
+                resolved = resolve_within_storage(img.file_path) if img.file_path else None
+                if resolved is None or not resolved.exists():
+                    missing.append({"record_id": rec.id, "record_image_id": img.id, "file_path": img.file_path})
                     continue
                 role_prefix = img.role or f"img_{img.id}"
-                dest_name = f"{role_prefix}{src.suffix}"
-                _shutil.copy2(src, rec_dir / dest_name)
+                dest_name = f"{role_prefix}{resolved.suffix}"
+                seen = used_names.setdefault(rec_dir_name, set())
+                if dest_name in seen:
+                    dest_name = f"{role_prefix}_{img.id}{resolved.suffix}"
+                seen.add(dest_name)
+                to_copy.append((rec_dir_name, dest_name, resolved, img))
+
+        if missing:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "message": f"Cannot export: {len(missing)} image file(s) missing from disk.",
+                    "missing_image_ids": [m["record_image_id"] for m in missing],
+                    "missing": missing,
+                },
+            )
+
+        mismatches = verify_images_against_manifest([img for _, _, _, img in to_copy])
+        if mismatches:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "message": f"Cannot export: {len(mismatches)} file(s) fail their capture-time checksum (possible corruption).",
+                    "mismatched_image_ids": [m["record_image_id"] for m in mismatches],
+                    "mismatches": mismatches,
+                },
+            )
+
+        # Copy the planned payload
+        for rec_dir_name, dest_name, resolved, img in to_copy:
+            rec_dir = data_dir / rec_dir_name
+            rec_dir.mkdir(exist_ok=True)
+            _shutil.copy2(resolved, rec_dir / dest_name)
+
+        expected_rows = sum(1 for rec in records for img in rec.images if img.is_current and img.file_path)
+        copied_files = sum(1 for p in data_dir.rglob("*") if p.is_file())
+        if copied_files != expected_rows or copied_files != len(to_copy):
+            raise HTTPException(
+                status_code=500,
+                detail=f"Export payload incomplete: staged {copied_files} files for {expected_rows} image rows",
+            )
 
         # Write metadata sidecar before bagging
         metadata_payload = {
@@ -569,6 +609,29 @@ def export_collection_bagit(
             json.dumps(metadata_payload, indent=2, ensure_ascii=False),
             encoding="utf-8"
         )
+
+        from app.core.storage_ops import resolve_project_name
+        from capture.project_manager import project_capture_root
+        capture_ids = {img.capture_id for rec in records for img in rec.images if img.is_current and img.capture_id}
+        if capture_ids:
+            proj_name = resolve_project_name(db, collection)
+            manifest_src = project_capture_root(proj_name) / "metadata" / "manifest.jsonl" if proj_name else None
+            if manifest_src and manifest_src.exists():
+                kept = []
+                for line in manifest_src.read_text(encoding="utf-8").splitlines():
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    try:
+                        entry = json.loads(stripped)
+                    except json.JSONDecodeError:
+                        continue
+                    if entry.get("capture_id") in capture_ids:
+                        kept.append(stripped)
+                if kept:
+                    meta_dir = data_dir / "metadata"
+                    meta_dir.mkdir(exist_ok=True)
+                    (meta_dir / "manifest.jsonl").write_text("\n".join(kept) + "\n", encoding="utf-8")
 
         # Create BagIt bag in-place
         bag_metadata = {

--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -15,6 +15,8 @@ from app.schemas.collection import CollectionCreate, CollectionRead, CollectionU
 from app.schemas.record import ReorderRecords
 from app.core.audit import log_event
 from app.core.config import settings
+from app.core.export_jobs import export_jobs
+from app.core.export_service import run_export
 from app.core.storage_ops import (
     collection_and_descendants,
     relocate_image,
@@ -448,19 +450,13 @@ def export_collection_bagit(
     db: Session = Depends(get_db_dependency)
 ):
     """
-    Package all approved records in this collection as a BagIt zip archive.
+    Start a background BagIt export of this collection and return a job to poll.
 
-    Requires ALL records in the collection to have status 'approved'.
-    The generated zip is saved to the exports directory and a download URL is returned.
+    Requires all records to be approved. The heavy work (integrity verification and
+    streaming the zip straight into the exports dir, with no staging copy) runs in a
+    background job, so proxied clients never hit nginx's read timeout; poll
+    GET /{collection_id}/export/status/{job_id} for progress.
     """
-    import bagit
-    import json
-    import shutil as _shutil
-    import tempfile
-    import zipfile
-    from datetime import datetime, timezone
-    from pathlib import Path as _Path
-
     collection = db.query(Collection).filter(Collection.id == collection_id).first()
     if not collection:
         raise HTTPException(status_code=404, detail=f"Collection {collection_id} not found")
@@ -474,10 +470,8 @@ def export_collection_bagit(
     if not records:
         raise HTTPException(
             status_code=422,
-            detail={"message": "Collection has no records to export.", "blocking_record_ids": []}
+            detail={"message": "Collection has no records to export.", "blocking_record_ids": []},
         )
-
-    # All records must be approved
     non_approved = [r.id for r in records if r.status != "approved"]
     if non_approved:
         raise HTTPException(
@@ -485,179 +479,37 @@ def export_collection_bagit(
             detail={
                 "message": f"Cannot export: {len(non_approved)} record(s) are not approved yet: {non_approved}",
                 "blocking_record_ids": non_approved,
-            }
-        )
-
-    # Gather project info for bag metadata
-    project = db.query(Project).filter(Project.id == collection.project_id).first() if collection.project_id else None
-
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    bag_name = f"collection_{collection_id}_{timestamp}"
-    exports_dir = settings.exports_dir
-    exports_dir.mkdir(parents=True, exist_ok=True)
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = _Path(tmpdir)
-        data_dir = tmp_path / "data"
-        data_dir.mkdir()
-
-        from app.core.paths import resolve_within_storage
-        from app.core.integrity import verify_images_against_manifest
-
-        to_copy = []  # (rec_dir_name, dest_name, resolved_src, img)
-        missing = []
-        used_names: dict = {}
-        for idx, rec in enumerate(records):
-            seq_label = f"{idx + 1:04d}"
-            safe_title = "".join(c if c.isalnum() or c in "-_ " else "_" for c in (rec.title or "record"))[:60]
-            rec_dir_name = f"{seq_label}_{safe_title}"
-            for img in sorted([i for i in rec.images if i.is_current], key=lambda i: (i.role or "z", i.id)):
-                resolved = resolve_within_storage(img.file_path) if img.file_path else None
-                if resolved is None or not resolved.exists():
-                    missing.append({"record_id": rec.id, "record_image_id": img.id, "file_path": img.file_path})
-                    continue
-                role_prefix = img.role or f"img_{img.id}"
-                dest_name = f"{role_prefix}{resolved.suffix}"
-                seen = used_names.setdefault(rec_dir_name, set())
-                if dest_name in seen:
-                    dest_name = f"{role_prefix}_{img.id}{resolved.suffix}"
-                seen.add(dest_name)
-                to_copy.append((rec_dir_name, dest_name, resolved, img))
-
-        if missing:
-            raise HTTPException(
-                status_code=422,
-                detail={
-                    "message": f"Cannot export: {len(missing)} image file(s) missing from disk.",
-                    "missing_image_ids": [m["record_image_id"] for m in missing],
-                    "missing": missing,
-                },
-            )
-
-        mismatches = verify_images_against_manifest([img for _, _, _, img in to_copy])
-        if mismatches:
-            raise HTTPException(
-                status_code=422,
-                detail={
-                    "message": f"Cannot export: {len(mismatches)} file(s) fail their capture-time checksum (possible corruption).",
-                    "mismatched_image_ids": [m["record_image_id"] for m in mismatches],
-                    "mismatches": mismatches,
-                },
-            )
-
-        # Copy the planned payload
-        for rec_dir_name, dest_name, resolved, img in to_copy:
-            rec_dir = data_dir / rec_dir_name
-            rec_dir.mkdir(exist_ok=True)
-            _shutil.copy2(resolved, rec_dir / dest_name)
-
-        expected_rows = sum(1 for rec in records for img in rec.images if img.is_current and img.file_path)
-        copied_files = sum(1 for p in data_dir.rglob("*") if p.is_file())
-        if copied_files != expected_rows or copied_files != len(to_copy):
-            raise HTTPException(
-                status_code=500,
-                detail=f"Export payload incomplete: staged {copied_files} files for {expected_rows} image rows",
-            )
-
-        # Write metadata sidecar before bagging
-        metadata_payload = {
-            "exported_at": timestamp,
-            "collection": {
-                "id": collection.id,
-                "name": collection.name,
-                "description": collection.description,
-                "collection_type": collection.collection_type,
-                "archival_metadata": collection.archival_metadata,
-                "created_by": collection.created_by,
-                "created_at": collection.created_at.isoformat() if collection.created_at else None,
             },
-            "project": {
-                "id": project.id if project else None,
-                "name": project.name if project else None,
-            } if project else None,
-            "records": [
-                {
-                    "id": r.id,
-                    "sequence": r.sequence,
-                    "title": r.title,
-                    "description": r.description,
-                    "object_typology": r.object_typology,
-                    "author": r.author,
-                    "material": r.material,
-                    "date": r.date,
-                    "status": r.status,
-                    "created_by": r.created_by,
-                    "created_at": r.created_at.isoformat() if r.created_at else None,
-                    "images": [
-                        {
-                            "id": img.id,
-                            "filename": img.filename,
-                            "role": img.role,
-                            "sequence": img.sequence,
-                            "format": img.format,
-                            "resolution_width": img.resolution_width,
-                            "resolution_height": img.resolution_height,
-                            "file_size": img.file_size,
-                        }
-                        for img in r.images if img.is_current
-                    ],
-                }
-                for r in records
-            ],
-        }
-        (data_dir / "metadata.json").write_text(
-            json.dumps(metadata_payload, indent=2, ensure_ascii=False),
-            encoding="utf-8"
         )
 
-        from app.core.storage_ops import resolve_project_name
-        from capture.project_manager import project_capture_root
-        capture_ids = {img.capture_id for rec in records for img in rec.images if img.is_current and img.capture_id}
-        if capture_ids:
-            proj_name = resolve_project_name(db, collection)
-            manifest_src = project_capture_root(proj_name) / "metadata" / "manifest.jsonl" if proj_name else None
-            if manifest_src and manifest_src.exists():
-                kept = []
-                for line in manifest_src.read_text(encoding="utf-8").splitlines():
-                    stripped = line.strip()
-                    if not stripped:
-                        continue
-                    try:
-                        entry = json.loads(stripped)
-                    except json.JSONDecodeError:
-                        continue
-                    if entry.get("capture_id") in capture_ids:
-                        kept.append(stripped)
-                if kept:
-                    meta_dir = data_dir / "metadata"
-                    meta_dir.mkdir(exist_ok=True)
-                    (meta_dir / "manifest.jsonl").write_text("\n".join(kept) + "\n", encoding="utf-8")
-
-        # Create BagIt bag in-place
-        bag_metadata = {
-            "Source-Organization": project.name if project else "Digitization Toolkit",
-            "External-Description": collection.description or collection.name,
-            "Bagging-Date": timestamp[:8],
-            "External-Identifier": f"collection-{collection_id}",
-            "Bag-Count": "1 of 1",
-            "Record-Count": str(len(records)),
-        }
-        bagit.make_bag(str(tmp_path), bag_metadata, checksum=["md5", "sha256"])
-
-        # Zip the bag
-        zip_path = exports_dir / f"{bag_name}.zip"
-        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-            for file in tmp_path.rglob("*"):
-                if file.is_file():
-                    zf.write(file, arcname=_Path(bag_name) / file.relative_to(tmp_path))
-
-    logger.info(f"BagIt export created: {zip_path} ({zip_path.stat().st_size} bytes)")
+    # One export per collection at a time: a retry returns the running job instead of
+    # stacking a second export that doubles disk pressure. Integrity checks and the
+    # zip build happen in the job, surfaced via the status endpoint.
+    job = export_jobs.start(collection_id, lambda j: run_export(j, collection_id))
+    log_event(db, level="INFO", category="activity", action="export_started",
+              actor=current_user.username, subject=collection.name)
     return {
-        "bag_name": bag_name,
-        "zip_filename": zip_path.name,
-        "size_bytes": zip_path.stat().st_size,
-        "download_url": f"/collections/{collection_id}/export/download",
+        "job_id": job.id,
+        "state": job.state,
+        "status_url": f"/collections/{collection_id}/export/status/{job.id}",
     }
+
+
+@router.get("/{collection_id}/export/status/{job_id}")
+def export_status(
+    collection_id: int,
+    job_id: str,
+    current_user: User = Depends(allow_read_only),
+    db: Session = Depends(get_db_dependency),
+):
+    """Poll the state and progress of a background export job."""
+    job = export_jobs.get(job_id)
+    if not job or job.collection_id != collection_id:
+        raise HTTPException(status_code=404, detail="Export job not found")
+    body = job.to_dict()
+    if job.state == "done" and job.zip_filename:
+        body["download_url"] = f"/collections/{collection_id}/export/download"
+    return body
 
 
 @router.get("/{collection_id}/export/download")

--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -507,7 +507,8 @@ def export_collection_bagit(
             rec_dir = data_dir / f"{seq_label}_{safe_title}"
             rec_dir.mkdir(exist_ok=True)
 
-            for img in sorted(rec.images, key=lambda i: (i.role or "z", i.id)):
+            # Only current images: a rejected-then-superseded file must never land in an export bag (NEH-208)
+            for img in sorted([i for i in rec.images if i.is_current], key=lambda i: (i.role or "z", i.id)):
                 if not img.file_path:
                     continue
                 src = _Path(img.file_path)
@@ -558,7 +559,7 @@ def export_collection_bagit(
                             "resolution_height": img.resolution_height,
                             "file_size": img.file_size,
                         }
-                        for img in r.images
+                        for img in r.images if img.is_current
                     ],
                 }
                 for r in records

--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -105,7 +105,26 @@ def list_collections(
     # which shifts when rows are updated. Also required for stable
     # skip/limit pagination.
     items = query.order_by(Collection.id).offset(skip).limit(limit).all()
-    return [CollectionRead.model_validate(i) for i in items]
+
+    # Bulk-count records per collection in one query (avoids N+1 — the
+    # project detail page lists every collection and needs each one's
+    # count for the "No. of images/records" column, NEH-179).
+    counts_by_id: dict[int, int] = {}
+    if items:
+        rows = (
+            db.query(Record.collection_id, func.count(Record.id))
+            .filter(Record.collection_id.in_([c.id for c in items]))
+            .group_by(Record.collection_id)
+            .all()
+        )
+        counts_by_id = {collection_id: count for collection_id, count in rows}
+
+    results = []
+    for i in items:
+        r = CollectionRead.model_validate(i)
+        r.record_count = counts_by_id.get(i.id, 0)
+        results.append(r)
+    return results
 
 
 @router.get("/count")

--- a/app/api/projects.py
+++ b/app/api/projects.py
@@ -159,19 +159,29 @@ def update_project(
     # keyed by name, so a rename moves the entire directory as a unit and rewrites
     # the stored paths. This keeps every capture and its manifest together and
     # leaves no stranded old-name directory for delete_project to miss later.
+    moved = False
+    wrote_journal = False
+    old_root = new_root = None
     if name_changed:
         from capture.project_manager import secure_project_filename, project_capture_root
+        from app.core.storage_ops import write_rename_journal, clear_rename_journal
 
         # secure_project_filename collapses many display names onto one directory,
         # so only touch the disk when the directory name actually changes.
         if secure_project_filename(old_name) != secure_project_filename(p.name):
             old_root = project_capture_root(old_name)
             new_root = project_capture_root(p.name)
+            # Record intent durably before the move so a crash between the move
+            # and the commit is repairable at startup rather than left dangling.
+            write_rename_journal(p.id, old_name, p.name, old_root, new_root)
+            wrote_journal = True
             try:
                 moved = move_project_tree(old_root, new_root)
             except FileExistsError:
+                clear_rename_journal()
                 raise HTTPException(status_code=409, detail="A project directory with this name already exists on disk")
             except OSError as e:
+                clear_rename_journal()
                 logger.error(f"Failed to move project directory {old_root} -> {new_root}: {e}")
                 raise HTTPException(status_code=500, detail="Failed to move project files on disk")
 
@@ -187,7 +197,21 @@ def update_project(
                         img.thumbnail_path = new_tp
 
     db.add(p)
-    db.commit()
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        # Undo the on-disk move so the filesystem matches the rolled-back DB.
+        if moved and old_root is not None:
+            try:
+                move_project_tree(new_root, old_root)
+            except OSError:
+                logger.exception("Failed to roll back project directory move; startup reconciliation will repair")
+        if wrote_journal:
+            clear_rename_journal()
+        raise
+    if wrote_journal:
+        clear_rename_journal()
     db.refresh(p)
     return ProjectRead.model_validate(p)
 

--- a/app/api/projects.py
+++ b/app/api/projects.py
@@ -25,6 +25,7 @@ from app.models.user import User
 from app.schemas.project import ProjectCreate, ProjectRead, ProjectBase, ProjectUpdate
 from app.schemas.project_member import ProjectMemberCreate, ProjectMemberRead
 from app.core.audit import log_event
+from app.core.db_errors import integrity_conflict
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -106,9 +107,9 @@ def add_record_to_project(
     db.add(r)
     try:
         db.commit()
-    except IntegrityError:
+    except IntegrityError as e:
         db.rollback()
-        raise HTTPException(status_code=409, detail="Record parent assignment violates a database constraint")
+        raise integrity_conflict(e)
     return {"detail": "record added"}
 
 

--- a/app/api/records.py
+++ b/app/api/records.py
@@ -22,6 +22,7 @@ from app.schemas.record import (
 	RecordRejectRequest, RecordRejectionRead,
 )
 from app.core.config import settings
+from app.core.db_errors import integrity_conflict
 from app.core.paths import resolve_within_storage
 from app.core.thumbnail import generate_thumbnail, delete_thumbnail
 from app.core.audit import log_event
@@ -103,7 +104,7 @@ def create_record(
 		db.refresh(rec)
 	except IntegrityError as e:
 		db.rollback()
-		raise HTTPException(status_code=409, detail=f"Database integrity error: {str(e)}")
+		raise integrity_conflict(e)
 	
 	return RecordRead.model_validate(rec)
 
@@ -210,9 +211,9 @@ def update_record(
 	db.add(rec)
 	try:
 		db.commit()
-	except IntegrityError:
+	except IntegrityError as e:
 		db.rollback()
-		raise HTTPException(status_code=409, detail="Record parent assignment violates a database constraint")
+		raise integrity_conflict(e)
 	db.refresh(rec)
 	return _serialize_record(rec)
 

--- a/app/api/records.py
+++ b/app/api/records.py
@@ -657,11 +657,15 @@ def update_record_status(
 
 	Valid transitions and required roles:
 	- in_review > approved  : reviewer, admin
+	- approved  > in_review : reviewer, admin  (undo a mistaken approve, NEH-209)
+	- rejected  > in_review : reviewer, admin  (undo a mistaken reject, NEH-209)
 
-	Rejection is not reachable through this endpoint — use POST
+	Formal rejection is not reachable through this endpoint — use POST
 	/{rec_id}/reject, which requires a mandatory predefined_reason (NEH-208).
-	approved is terminal; recapture (rejected -> in_review) only happens as a
-	side effect of the capture endpoints in app/api/cameras.py.
+	Recapture (rejected -> in_review as a side effect of a new capture
+	arriving) only happens via the capture endpoints in app/api/cameras.py —
+	the undo transition above is a plain status reset with no new image, no
+	reason, and no audit entry.
 	"""
 	rec = db.query(Record).options(joinedload(Record.images)).filter(Record.id == rec_id).first()
 	if not rec:

--- a/app/api/records.py
+++ b/app/api/records.py
@@ -440,8 +440,15 @@ def delete_image(
 	if thumbnail_path:
 		delete_thumbnail(str(thumbnail_path))
 	
+	record_id = img.record_id
 	db.delete(img)
 	db.commit()
+
+	record = db.query(Record).filter(Record.id == record_id).first()
+	if record and record.status == "approved" and not any(i.is_current for i in record.images):
+		record.status = "in_review"
+		db.add(record)
+		db.commit()
 	return {"detail": "Image deleted"}
 
 

--- a/app/api/records.py
+++ b/app/api/records.py
@@ -9,7 +9,9 @@ import logging
 
 from app.api.deps import get_db_dependency
 from app.api.auth import get_current_user, RoleChecker
-from app.models.record import Record, RecordImage, ExifData, RecordAnnotation
+from datetime import datetime, timezone
+
+from app.models.record import Record, RecordImage, ExifData, RecordAnnotation, RecordRejection
 from app.models.camera import CameraSettings
 from app.models.user import User
 from app.schemas.record import (
@@ -17,6 +19,7 @@ from app.schemas.record import (
 	RecordImageCreate, RecordImageRead, RecordImageUpdate,
 	RecordStatusUpdate, BulkStatusUpdate, STATUS_TRANSITIONS,
 	RecordAnnotationCreate, RecordAnnotationRead,
+	RecordRejectRequest, RecordRejectionRead,
 )
 from app.core.config import settings
 from app.core.paths import resolve_within_storage
@@ -28,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 allow_contributor = RoleChecker(["admin", "operator"])
 allow_read_only = RoleChecker(["admin", "operator", "reviewer"])
+allow_reviewer = RoleChecker(["admin", "reviewer"])
 
 # Streamed uploads are copied in 1 MiB chunks so the size cap is enforced as bytes arrive, even when Content-Length is missing or wrong (e.g. chunked encoding).
 _UPLOAD_CHUNK = 1024 * 1024
@@ -52,6 +56,23 @@ def _save_upload_capped(src, dst_path: Path, max_bytes: int) -> int:
 	return total
 
 
+def _serialize_record(rec: Record, include_superseded: bool = False) -> RecordRead:
+	"""RecordRead.model_validate(rec), with images narrowed to current-only by default (NEH-208)."""
+	data = RecordRead.model_validate(rec)
+	if not include_superseded:
+		data.images = [img for img in data.images if img.is_current]
+	return data
+
+
+def _supersede_current_images(record: Record) -> None:
+	"""Flip every current image on a record to superseded. Used when a recapture is about to add new current image(s) (NEH-208)."""
+	now = datetime.now(timezone.utc)
+	for img in record.images:
+		if img.is_current:
+			img.is_current = False
+			img.superseded_at = now
+
+
 # ==============================================================================
 # Record endpoints (archival documents/objects)
 # ==============================================================================
@@ -74,6 +95,7 @@ def create_record(
 		project_id=rec_in.project_id,
 		collection_id=rec_in.collection_id,
 		created_by=rec_in.created_by or current_user.username,
+		capture_mode=rec_in.capture_mode,
 	)
 	try:
 		db.add(rec)
@@ -126,7 +148,7 @@ def list_records(
 	else:
 		query = query.order_by(Record.id)
 	recs = query.offset(skip).limit(limit).all()
-	return [RecordRead.model_validate(r) for r in recs]
+	return [_serialize_record(r) for r in recs]
 
 
 @router.get("/count")
@@ -155,7 +177,7 @@ def get_record(
 	rec = db.query(Record).options(joinedload(Record.images)).filter(Record.id == rec_id).first()
 	if not rec:
 		raise HTTPException(status_code=404, detail="Record not found")
-	return RecordRead.model_validate(rec)
+	return _serialize_record(rec)
 
 
 @router.patch("/{rec_id}", response_model=RecordRead)
@@ -192,7 +214,7 @@ def update_record(
 		db.rollback()
 		raise HTTPException(status_code=409, detail="Record parent assignment violates a database constraint")
 	db.refresh(rec)
-	return RecordRead.model_validate(rec)
+	return _serialize_record(rec)
 
 
 @router.delete("/{rec_id}")
@@ -344,19 +366,21 @@ async def add_image_to_record(
 @router.get("/{rec_id}/images", response_model=List[RecordImageRead])
 def list_record_images(
 	rec_id: int,
+	include_superseded: bool = Query(default=False, description="Include images superseded by a recapture (NEH-208)"),
 	current_user: User = Depends(allow_read_only),
 	db: Session = Depends(get_db_dependency)
 ):
-	"""Get all images for a specific record, ordered by sequence."""
+	"""Get all images for a specific record, ordered by sequence. Superseded (rejected-and-replaced) images are excluded by default."""
 	# Verify record exists
 	rec = db.query(Record).filter(Record.id == rec_id).first()
 	if not rec:
 		raise HTTPException(status_code=404, detail="Record not found")
-	
-	images = db.query(RecordImage).filter(
-		RecordImage.record_id == rec_id
-	).order_by(RecordImage.sequence.nullslast(), RecordImage.created_at).all()
-	
+
+	query = db.query(RecordImage).filter(RecordImage.record_id == rec_id)
+	if not include_superseded:
+		query = query.filter(RecordImage.is_current.is_(True))
+	images = query.order_by(RecordImage.sequence.nullslast(), RecordImage.created_at).all()
+
 	return [RecordImageRead.model_validate(img) for img in images]
 
 
@@ -596,14 +620,13 @@ def delete_record_annotation(
 def _apply_status_change(
 	rec: Record,
 	new_status: str,
-	rejection_note: Optional[str],
 	user_role: str,
 ) -> None:
 	"""
 	Validate and apply a status transition on a Record.
 	Raises HTTPException on invalid transition or insufficient role.
 	"""
-	current_status = rec.status or "captured"
+	current_status = rec.status
 	if current_status == new_status:
 		return  # no-op
 
@@ -620,7 +643,6 @@ def _apply_status_change(
 		)
 
 	rec.status = new_status
-	rec.rejection_note = rejection_note if new_status == "rejected" else None
 
 
 @router.patch("/{rec_id}/status", response_model=RecordRead)
@@ -634,23 +656,22 @@ def update_record_status(
 	Change the QA status of a record.
 
 	Valid transitions and required roles:
-	- captured  > in_review : operator, admin, reviewer
-	- in_review > rejected  : reviewer, admin
 	- in_review > approved  : reviewer, admin
-	- in_review > captured  : operator, admin  (cancel review)
-	- rejected  > captured  : operator, admin  (prepare for retake)
-	- approved  > rejected  : reviewer, admin  (flag for rework)
-	- approved  > captured  : admin only       (full reset)
+
+	Rejection is not reachable through this endpoint — use POST
+	/{rec_id}/reject, which requires a mandatory predefined_reason (NEH-208).
+	approved is terminal; recapture (rejected -> in_review) only happens as a
+	side effect of the capture endpoints in app/api/cameras.py.
 	"""
 	rec = db.query(Record).options(joinedload(Record.images)).filter(Record.id == rec_id).first()
 	if not rec:
 		raise HTTPException(status_code=404, detail="Record not found")
 
-	_apply_status_change(rec, payload.status, payload.rejection_note, current_user.role)
+	_apply_status_change(rec, payload.status, current_user.role)
 
 	db.commit()
 	db.refresh(rec)
-	return RecordRead.model_validate(rec)
+	return _serialize_record(rec)
 
 
 @router.post("/bulk-status", response_model=List[RecordRead])
@@ -678,18 +699,11 @@ def bulk_update_status(
 	updated: list[Record] = []
 
 	for rec in records:
-		current_status = rec.status or "captured"
-		if current_status == payload.status:
-			updated.append(rec)
-			continue
-
-		allowed_roles = STATUS_TRANSITIONS.get((current_status, payload.status))
-		if allowed_roles is None or current_user.role not in allowed_roles:
+		try:
+			_apply_status_change(rec, payload.status, current_user.role)
+		except HTTPException:
 			skipped.append(rec.id)
 			continue
-
-		rec.status = payload.status
-		rec.rejection_note = payload.rejection_note if payload.status == "rejected" else None
 		updated.append(rec)
 
 	db.commit()
@@ -699,4 +713,75 @@ def bulk_update_status(
 	if skipped:
 		logger.info(f"bulk-status: skipped {len(skipped)} records (invalid transition or insufficient role): {skipped}")
 
-	return [RecordRead.model_validate(r) for r in updated]
+	return [_serialize_record(r) for r in updated]
+
+
+# ==============================================================================
+# Rejection endpoints (NEH-208)
+# ==============================================================================
+
+@router.post("/{rec_id}/reject", response_model=RecordRead)
+def reject_record(
+	rec_id: int,
+	payload: RecordRejectRequest,
+	current_user: User = Depends(allow_reviewer),
+	db: Session = Depends(get_db_dependency)
+):
+	"""
+	Reject a record's current capture with a mandatory predefined reason.
+
+	Flags every current image as part of this rejection's audit trail (for a
+	dual-mode record that's both L and R — a dual-camera pair can only ever be
+	redone together, never one side alone) and moves the record to
+	'rejected'. Rejected images are never deleted or overwritten; they stay
+	queryable via GET /{rec_id}/rejections after a recapture supersedes them.
+	"""
+	rec = db.query(Record).options(joinedload(Record.images)).filter(Record.id == rec_id).first()
+	if not rec:
+		raise HTTPException(status_code=404, detail="Record not found")
+	if rec.status != "in_review":
+		raise HTTPException(
+			status_code=422,
+			detail=f"Cannot reject a record with status '{rec.status}'. Only 'in_review' records can be rejected."
+		)
+
+	current_images = [img for img in rec.images if img.is_current]
+
+	rejection = RecordRejection(
+		record_id=rec.id,
+		predefined_reason=payload.predefined_reason,
+		comment=payload.comment,
+		rejected_by=current_user.username,
+	)
+	db.add(rejection)
+	db.flush()  # assign rejection.id before linking images
+
+	for img in current_images:
+		img.rejection_id = rejection.id
+
+	rec.status = "rejected"
+
+	db.commit()
+	db.refresh(rec)
+	return _serialize_record(rec)
+
+
+@router.get("/{rec_id}/rejections", response_model=List[RecordRejectionRead])
+def list_record_rejections(
+	rec_id: int,
+	current_user: User = Depends(allow_read_only),
+	db: Session = Depends(get_db_dependency)
+):
+	"""List a record's rejection history, newest first, each with the image(s) it flagged."""
+	rec = db.query(Record).filter(Record.id == rec_id).first()
+	if not rec:
+		raise HTTPException(status_code=404, detail="Record not found")
+
+	rejections = (
+		db.query(RecordRejection)
+		.options(joinedload(RecordRejection.images))
+		.filter(RecordRejection.record_id == rec_id)
+		.order_by(RecordRejection.rejected_at.desc())
+		.all()
+	)
+	return [RecordRejectionRead.model_validate(r) for r in rejections]

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -342,7 +342,7 @@ def unmount_device(
 
     msg = "Device unmounted successfully."
     if override_cleared:
-        msg += "Storage reverted to the default."
+        msg += " Storage reverted to the default."
     return {"message": msg, "override_cleared": override_cleared}
 
 

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -50,15 +50,19 @@ def get_system_logs(
 @router.get("/integrity")
 def integrity_check(
     verify_hashes:  bool = Query(default=True, description="Recompute sha256 and compare against the capture manifest"),
-    max_hash_checks: int = Query(default=0, ge=0, description="Cap on files hashed (0 = no cap)"),
+    full: bool = Query(default=False, description="Hash every manifested file. Off by default: a full sweep re-hashes every capture, which is I/O-punishing on a unit holding tens of thousands of images"),
+    max_hash_checks: int = Query(default=1000, ge=1, description="Upper bound on files hashed when not running a full sweep; a random sample is taken above this many eligible files"),
     current_user: User = Depends(allow_admin),
     db: Session        = Depends(get_db_dependency),
 ):
     """Reconcile the database against the image files and the capture manifest.
 
-    Reports images whose files are missing, image files no row or manifest
-    references, bytes that no longer match the capture-time sha256, and parentless
+    Reports images whose files are missing, image files with no row or manifest
+    reference, bytes that no longer match the capture-time sha256, and parentless
     records. Read-only and admin-only. Run after an SD re-clone or DB restore.
+
+    Hash verification defaults to a bounded random sample; pass full=true for the
+    exhaustive (and much slower) sweep.
     """
     from app.core.integrity import run_integrity_check
     from app.core import audit
@@ -66,7 +70,7 @@ def integrity_check(
     report = run_integrity_check(
         db,
         verify_hashes=verify_hashes,
-        max_hash_checks=(max_hash_checks or None),
+        max_hash_checks=(None if full else max_hash_checks),
     )
     summary = report["summary"]
     audit.log_event(
@@ -77,7 +81,9 @@ def integrity_check(
         actor=current_user.username,
         detail=(
             f"missing_files={summary['missing_files']} orphan_files={summary['orphan_files']} "
-            f"manifest_mismatches={summary['manifest_mismatches']} hashes_checked={summary['hashes_checked']}"
+            f"manifest_mismatches={summary['manifest_mismatches']} "
+            f"hashes_checked={summary['hashes_checked']}/{summary['hashes_eligible']} "
+            f"sampled={summary['hash_sampled']}"
         ),
     )
     return report

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -180,43 +180,34 @@ class ActivateStorageRequest(BaseModel):
 def get_storage_info(current_user: User = Depends(allow_read_only)):
     """Return current projects path and disk usage figures."""
     from app.core.config import settings
-    from app.core.storage_override import get_storage_override, StorageOverrideError
+    from app.core.storage_override import get_storage_override_or_fallback
 
-    # An unreadable override is surfaced as an error, not treated as "no override"
-    try:
-        projects_path = settings.projects_dir
-        is_override = get_storage_override() is not None
-    except StorageOverrideError as e:
-        return {
-            "projects_path": None,
-            "is_override":   True,
-            "error":         str(e),
-            "total_bytes":   0,
-            "used_bytes":    0,
-            "free_bytes":    0,
-            "available":     False,
-        }
+    # A corrupt override reverts to internal storage; override_invalid flags the fallback for a UI warning.
+    override, override_invalid = get_storage_override_or_fallback()
+    projects_path = settings.projects_dir
 
     try:
         projects_path.mkdir(parents=True, exist_ok=True)
         usage = shutil.disk_usage(projects_path)
     except OSError:
         return {
-            "projects_path": str(projects_path),
-            "is_override":   is_override,
-            "total_bytes":   0,
-            "used_bytes":    0,
-            "free_bytes":    0,
-            "available":     False,
+            "projects_path":    str(projects_path),
+            "is_override":      override is not None,
+            "override_invalid": override_invalid,
+            "total_bytes":      0,
+            "used_bytes":       0,
+            "free_bytes":       0,
+            "available":        False,
         }
 
     return {
-        "projects_path": str(projects_path),
-        "is_override":   is_override,
-        "total_bytes":   usage.total,
-        "used_bytes":    usage.used,
-        "free_bytes":    usage.free,
-        "available":     True,
+        "projects_path":    str(projects_path),
+        "is_override":      override is not None,
+        "override_invalid": override_invalid,
+        "total_bytes":      usage.total,
+        "used_bytes":       usage.used,
+        "free_bytes":       usage.free,
+        "available":        True,
     }
 
 

--- a/app/core/bag_export.py
+++ b/app/core/bag_export.py
@@ -1,0 +1,96 @@
+"""Stream a BagIt archive straight into a zip, without staging a second copy.
+
+The output validates as a BagIt 0.97 bag: unzip it and `bagit.Bag(dir).validate()`
+passes.
+"""
+
+import hashlib
+import zipfile
+from pathlib import Path
+from typing import Callable, Iterable, List, Optional, Tuple
+
+_CHUNK = 1024 * 1024
+
+# (source_path, rel_path) — rel_path is the file's location under data/
+PayloadFile = Tuple[Path, str]
+# (bytes, rel_path) — for generated sidecars (metadata.json, manifest.jsonl)
+PayloadBlob = Tuple[bytes, str]
+
+
+def _manifest_lines(entries: List[Tuple[str, str]]) -> str:
+    # BagIt manifest line: "<checksum>  <path-relative-to-bag>"
+    return "".join(f"{checksum}  {path}\n" for path, checksum in entries)
+
+
+def write_bag_zip(
+    zip_path: Path,
+    bag_name: str,
+    bag_info: dict,
+    payload_files: Iterable[PayloadFile],
+    payload_blobs: Iterable[PayloadBlob] = (),
+    progress_cb: Optional[Callable[[int, int], None]] = None,
+) -> dict:
+    """Write a BagIt bag as a zip at zip_path, reading each source once.
+    Returns a small summary (file_count, total_bytes). progress_cb(done, total) is called after each payload item if given.
+    """
+    payload_files = list(payload_files)
+    payload_blobs = list(payload_blobs)
+    total = len(payload_files) + len(payload_blobs)
+    done = 0
+
+    sha_entries: List[Tuple[str, str]] = []  # (bag-relative path, sha256)
+    md5_entries: List[Tuple[str, str]] = []
+    total_bytes = 0
+
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED, allowZip64=True) as zf:
+        for source_path, rel in payload_files:
+            rel = rel.replace("\\", "/")
+            sha, md5 = hashlib.sha256(), hashlib.md5()
+            size = 0
+            with open(source_path, "rb") as src, zf.open(f"{bag_name}/data/{rel}", "w") as dst:
+                for chunk in iter(lambda: src.read(_CHUNK), b""):
+                    dst.write(chunk)
+                    sha.update(chunk)
+                    md5.update(chunk)
+                    size += len(chunk)
+            sha_entries.append((f"data/{rel}", sha.hexdigest()))
+            md5_entries.append((f"data/{rel}", md5.hexdigest()))
+            total_bytes += size
+            done += 1
+            if progress_cb:
+                progress_cb(done, total)
+
+        for data, rel in payload_blobs:
+            rel = rel.replace("\\", "/")
+            zf.writestr(f"{bag_name}/data/{rel}", data)
+            sha_entries.append((f"data/{rel}", hashlib.sha256(data).hexdigest()))
+            md5_entries.append((f"data/{rel}", hashlib.md5(data).hexdigest()))
+            total_bytes += len(data)
+            done += 1
+            if progress_cb:
+                progress_cb(done, total)
+
+        # Tag files. Payload-Oxum lets a validator check the payload byte/file totals
+        # without reading the files, so include it.
+        info = dict(bag_info)
+        info["Payload-Oxum"] = f"{total_bytes}.{len(sha_entries)}"
+        tag_files = {
+            "bagit.txt": "BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n",
+            "bag-info.txt": "".join(f"{k}: {v}\n" for k, v in info.items()),
+            "manifest-sha256.txt": _manifest_lines(sha_entries),
+            "manifest-md5.txt": _manifest_lines(md5_entries),
+        }
+        for name, content in tag_files.items():
+            zf.writestr(f"{bag_name}/{name}", content)
+
+        # Tag manifests hash the tag files above (not themselves).
+        tag_sha = "".join(
+            f"{hashlib.sha256(c.encode('utf-8')).hexdigest()}  {n}\n" for n, c in tag_files.items()
+        )
+        tag_md5 = "".join(
+            f"{hashlib.md5(c.encode('utf-8')).hexdigest()}  {n}\n" for n, c in tag_files.items()
+        )
+        zf.writestr(f"{bag_name}/tagmanifest-sha256.txt", tag_sha)
+        zf.writestr(f"{bag_name}/tagmanifest-md5.txt", tag_md5)
+
+    return {"file_count": len(sha_entries), "total_bytes": total_bytes}

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,10 +1,11 @@
-from pydantic_settings import BaseSettings
-from pydantic import Field, ConfigDict
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field
 from pathlib import Path
 
 class Settings(BaseSettings):
-    # Deployment environment. Anything outside _DEV_ENVIRONMENTS requires a real SECRET_KEY
-    APP_ENV: str = Field(default="development", env="APP_ENV")
+    # Deployment environment
+    # Anything outside _DEV_ENVIRONMENTS requires a real SECRET_KEY
+    APP_ENV: str = "development"
     DATABASE_USER: str = "user"
     DATABASE_PASSWORD: str = "password"
     DATABASE_HOST: str = "db"
@@ -12,17 +13,19 @@ class Settings(BaseSettings):
     DATABASE_NAME: str = "digitization_toolkit"
     DTK_DATA_DIR: str = "/var/lib/dtk"
     DTK_LOG_DIR: str = "/var/log/dtk"
-    PROJECTS_ROOT: str = Field(default="", env="PROJECTS_ROOT")
-    EXPORTS_ROOT: str = Field(default="", env="DTK_EXPORTS_DIR")
-    CAMERA_BACKEND: str = Field(default="picamera2", env="CAMERA_BACKEND")
-    SECRET_KEY: str = Field(default="dev-secret-change-me", env="SECRET_KEY")
-    ACCESS_TOKEN_EXPIRE_SECONDS: int = Field(default=28800, env="ACCESS_TOKEN_EXPIRE_SECONDS")  # 8 hours
-    CORS_ORIGINS: list[str] = Field(default=["http://localhost:5173", "http://localhost:3000"], env="CORS_ORIGINS")
+    
+    PROJECTS_ROOT: str = ""
+    CAMERA_BACKEND: str = "picamera2"
+    SECRET_KEY: str = "dev-secret-change-me"
+    ACCESS_TOKEN_EXPIRE_SECONDS: int = 28800  # 8 hours
+    CORS_ORIGINS: list[str] = ["http://localhost:5173", "http://localhost:3000"]
+    
+    EXPORTS_ROOT: str = Field(default="", validation_alias="DTK_EXPORTS_DIR")
     # Application-level cap on uploaded image size. Defends the SD even if nginx (client_max_body_size 100m) is not in front of the app. Enforced while streaming.
-    MAX_UPLOAD_BYTES: int = Field(default=100 * 1024 * 1024, env="DTK_MAX_UPLOAD_BYTES")
+    MAX_UPLOAD_BYTES: int = Field(default=100 * 1024 * 1024, validation_alias="DTK_MAX_UPLOAD_BYTES")
     app_version: str = "0.0.0-dev"
 
-    model_config = ConfigDict(
+    model_config = SettingsConfigDict(
         env_file="../.env",  # Load .env from project root when running from backend/
         env_file_encoding="utf-8",
         extra="ignore"  # Ignore extra fields from .env like uvicorn_host
@@ -49,11 +52,11 @@ class Settings(BaseSettings):
         return Path(self.EXPORTS_ROOT) if self.EXPORTS_ROOT else (self.data_dir / "exports")
 
 
-# SECRET_KEY values that must never sign session tokens outside dev (NEH-54); includes the .env.example placeholder
+# Blacklist of SECRET_KEY values that must never sign session tokens outside development
 _INSECURE_SECRET_KEYS = {
     "",
     "dev-secret-change-me",
-    "your-secret-key-here-change-in-production",
+    "secret-key-here-change-in-production",
 }
 
 # Environments exempt from the SECRET_KEY guard; anything else must set a strong key

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -43,8 +43,10 @@ class Settings(BaseSettings):
     
     @property
     def projects_dir(self) -> Path:
-        from app.core.storage_override import get_storage_override
-        override = get_storage_override()
+        # A corrupt override value (e.g. a path to a non-existent disk) is treated as "no override" so the fallback root is used instead. 
+        # This avoids splitting a project across two disks if the operator accidentally removes the external drive.
+        from app.core.storage_override import get_storage_override_or_fallback
+        override, _corrupt = get_storage_override_or_fallback()
         if override:
             return Path(override)
         return Path(self.PROJECTS_ROOT) if self.PROJECTS_ROOT else (self.data_dir / "projects")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -3,6 +3,8 @@ from pydantic import Field, ConfigDict
 from pathlib import Path
 
 class Settings(BaseSettings):
+    # Deployment environment. Anything outside _DEV_ENVIRONMENTS requires a real SECRET_KEY
+    APP_ENV: str = Field(default="development", env="APP_ENV")
     DATABASE_USER: str = "user"
     DATABASE_PASSWORD: str = "password"
     DATABASE_HOST: str = "db"
@@ -47,4 +49,33 @@ class Settings(BaseSettings):
         return Path(self.EXPORTS_ROOT) if self.EXPORTS_ROOT else (self.data_dir / "exports")
 
 
+# SECRET_KEY values that must never sign session tokens outside dev (NEH-54); includes the .env.example placeholder
+_INSECURE_SECRET_KEYS = {
+    "",
+    "dev-secret-change-me",
+    "your-secret-key-here-change-in-production",
+}
+
+# Environments exempt from the SECRET_KEY guard; anything else must set a strong key
+_DEV_ENVIRONMENTS = {"dev", "development", "test", "testing", "local"}
+
+
+def _guard_secret_key(config: "Settings") -> None:
+    """Refuse to start outside dev with a default/empty SECRET_KEY.
+
+    Runs at import time, right after Settings() is built, so it fires before
+    security.py reads settings.SECRET_KEY at its own module level. A FastAPI
+    startup event would be too late: by then the weak key is already bound.
+    """
+    if config.APP_ENV.strip().lower() in _DEV_ENVIRONMENTS:
+        return
+    if config.SECRET_KEY.strip() in _INSECURE_SECRET_KEYS:
+        raise RuntimeError(
+            "SECRET_KEY is unset or left at the insecure default while "
+            f"APP_ENV={config.APP_ENV!r}. Set a strong, unique SECRET_KEY "
+            "(e.g. `openssl rand -hex 32`) before starting outside development."
+        )
+
+
 settings = Settings()
+_guard_secret_key(settings)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,6 +17,8 @@ class Settings(BaseSettings):
     PROJECTS_ROOT: str = ""
     CAMERA_BACKEND: str = "picamera2"
     SECRET_KEY: str = "dev-secret-change-me"
+    # Per-unit token protecting first-user admin bootstrap over the network
+    BOOTSTRAP_TOKEN: str = ""
     ACCESS_TOKEN_EXPIRE_SECONDS: int = 28800  # 8 hours
     CORS_ORIGINS: list[str] = ["http://localhost:5173", "http://localhost:3000"]
     
@@ -61,6 +63,12 @@ _INSECURE_SECRET_KEYS = {
 
 # Environments exempt from the production guards; anything else must set real secrets
 _DEV_ENVIRONMENTS = {"dev", "development", "test", "testing", "local"}
+
+
+def is_dev_env(app_env: str) -> bool:
+    """True when APP_ENV names a development or test environment."""
+    return app_env.strip().lower() in _DEV_ENVIRONMENTS
+
 
 # Blacklist of DATABASE_PASSWORD values that must never reach a production DB outside dev
 _INSECURE_DB_PASSWORDS = {

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -59,8 +59,15 @@ _INSECURE_SECRET_KEYS = {
     "secret-key-here-change-in-production",
 }
 
-# Environments exempt from the SECRET_KEY guard; anything else must set a strong key
+# Environments exempt from the production guards; anything else must set real secrets
 _DEV_ENVIRONMENTS = {"dev", "development", "test", "testing", "local"}
+
+# Blacklist of DATABASE_PASSWORD values that must never reach a production DB outside dev
+_INSECURE_DB_PASSWORDS = {
+    "",
+    "password",
+    "change-this-in-production",
+}
 
 
 def _guard_secret_key(config: "Settings") -> None:
@@ -80,5 +87,21 @@ def _guard_secret_key(config: "Settings") -> None:
         )
 
 
+def _guard_database_password(config: "Settings") -> None:
+    """Refuse to start outside dev with a placeholder DATABASE_PASSWORD.
+
+    Per-unit passwords are generated at first boot; this is the
+    defense-in-depth half: a unit that slipped through on a shared placeholder
+    fails loudly instead of running with a credential known to every appliance.
+    """
+    if config.APP_ENV.strip().lower() in _DEV_ENVIRONMENTS:
+        return
+    if config.DATABASE_PASSWORD.strip() in _INSECURE_DB_PASSWORDS:
+        raise RuntimeError(
+            f"DATABASE_PASSWORD is unset or left at a shared placeholder while APP_ENV={config.APP_ENV!r}. Set a strong, unique DATABASE_PASSWORD (e.g. with `openssl rand -hex 32`) before starting outside development."
+        )
+
+
 settings = Settings()
 _guard_secret_key(settings)
+_guard_database_password(settings)

--- a/app/core/db_errors.py
+++ b/app/core/db_errors.py
@@ -1,0 +1,52 @@
+"""Map SQLAlchemy IntegrityError to sanitized API responses.
+
+The appliance is LAN-exposed on port 80, so constraint-violation responses must
+never echo the offending SQL statement or its bound parameters. This module
+turns an IntegrityError into a 409 carrying only the violated constraint name
+and a human-readable message.
+"""
+from typing import Optional
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+
+# Friendly messages keyed by the canonical (Postgres) constraint name. Anything
+# not listed falls back to _DEFAULT_MESSAGE; the constraint name is still returned.
+_CONSTRAINT_MESSAGES = {
+	"check_record_single_parent": "A record belongs to either a project or a collection, not both.",
+	"camera_settings_record_image_id_key": "Camera settings already exist for this record.",
+}
+
+# SQLite names unnamed constraints differently from Postgres; map the substrings
+# it prints back to the canonical name so responses are uniform across engines.
+_SQLITE_ALIASES = {
+	"check_record_single_parent": "check_record_single_parent",
+	"camera_settings.record_image_id": "camera_settings_record_image_id_key",
+}
+
+_DEFAULT_MESSAGE = "The request conflicts with a database constraint."
+
+
+def constraint_name(exc: IntegrityError) -> Optional[str]:
+	"""Best-effort canonical name of the violated constraint, or None. Never returns SQL or bound parameters."""
+	orig = getattr(exc, "orig", None)
+	if orig is None:
+		return None
+	# Postgres (psycopg): structured diagnostics carry the constraint name directly.
+	name = getattr(getattr(orig, "diag", None), "constraint_name", None)
+	if name:
+		return name
+	# SQLite: recover the canonical name from the short message text.
+	text = str(orig)
+	for token, canonical in _SQLITE_ALIASES.items():
+		if token in text:
+			return canonical
+	return None
+
+
+def integrity_conflict(exc: IntegrityError) -> HTTPException:
+	"""Build a sanitized 409 for a DB integrity violation, exposing the constraint name and a friendly message only."""
+	name = constraint_name(exc)
+	detail = {"message": _CONSTRAINT_MESSAGES.get(name, _DEFAULT_MESSAGE)}
+	if name:
+		detail["constraint"] = name
+	return HTTPException(status_code=409, detail=detail)

--- a/app/core/export_jobs.py
+++ b/app/core/export_jobs.py
@@ -1,0 +1,106 @@
+"""In-process registry of background export jobs for the single-process appliance"""
+
+import logging
+import threading
+import time
+import uuid
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ExportJob:
+    def __init__(self, collection_id: int):
+        self.id = uuid.uuid4().hex
+        self.collection_id = collection_id
+        self.state = "queued"        # queued | running | done | failed
+        self.done = 0
+        self.total = 0
+        self.zip_filename: Optional[str] = None
+        self.error: Optional[str] = None       # human-readable message
+        self.detail = None                      # structured detail (e.g. missing/mismatch lists)
+        self.created_at = time.time()
+        self.finished_at: Optional[float] = None
+
+    def set_progress(self, done: int, total: int) -> None:
+        self.done = done
+        self.total = total
+
+    def to_dict(self) -> dict:
+        return {
+            "job_id": self.id,
+            "collection_id": self.collection_id,
+            "state": self.state,
+            "done": self.done,
+            "total": self.total,
+            "zip_filename": self.zip_filename,
+            "error": self.error,
+            "detail": self.detail,
+        }
+
+
+class ExportJobRegistry:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._jobs: dict[str, ExportJob] = {}
+        self._active_by_collection: dict[int, str] = {}
+
+    def active_for(self, collection_id: int) -> Optional[ExportJob]:
+        with self._lock:
+            jid = self._active_by_collection.get(collection_id)
+            job = self._jobs.get(jid) if jid else None
+            if job and job.state in ("queued", "running"):
+                return job
+            return None
+
+    def get(self, job_id: str) -> Optional[ExportJob]:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def start(self, collection_id: int, work: Callable[[ExportJob], None]) -> ExportJob:
+        """Start `work(job)` in a background thread, or return the collection's
+        already-running job so a retry never stacks a second export."""
+        with self._lock:
+            existing_id = self._active_by_collection.get(collection_id)
+            existing = self._jobs.get(existing_id) if existing_id else None
+            if existing and existing.state in ("queued", "running"):
+                return existing
+            job = ExportJob(collection_id)
+            self._jobs[job.id] = job
+            self._active_by_collection[collection_id] = job.id
+        threading.Thread(target=self._run, args=(job, work), daemon=True).start()
+        return job
+
+    def _run(self, job: ExportJob, work: Callable[[ExportJob], None]) -> None:
+        job.state = "running"
+        try:
+            work(job)
+            if job.state == "running":
+                job.state = "done"
+        except ExportError as e:
+            job.state = "failed"
+            job.error = str(e)
+            job.detail = e.detail
+        except Exception as e:
+            job.state = "failed"
+            job.error = str(e)
+            logger.exception(f"Export job {job.id} for collection {job.collection_id} failed")
+        finally:
+            job.finished_at = time.time()
+            with self._lock:
+                if self._active_by_collection.get(job.collection_id) == job.id:
+                    del self._active_by_collection[job.collection_id]
+
+
+class ExportError(Exception):
+    """Expected export failure (missing files, checksum mismatch, low disk).
+
+    Carries an optional structured `detail` the status endpoint surfaces to the UI.
+    """
+    def __init__(self, message: str, detail=None):
+        super().__init__(message)
+        self.detail = detail
+
+
+# Module-level singleton shared across requests in the single backend process
+export_jobs = ExportJobRegistry()

--- a/app/core/export_service.py
+++ b/app/core/export_service.py
@@ -1,0 +1,204 @@
+"""The work a background export job runs: validate, check disk, stream the bag,
+prune old zips. Runs in a worker thread with its own DB session.
+"""
+
+import json
+import logging
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.core import config
+from app.core.bag_export import write_bag_zip
+from app.core.export_jobs import ExportError, ExportJob
+from app.core.integrity import verify_images_against_manifest
+from app.core.paths import resolve_within_storage
+from app.core.storage_ops import resolve_project_name
+from app.models.collection import Collection
+from app.models.project import Project
+from app.models.record import Record
+
+logger = logging.getLogger(__name__)
+
+# Keep the most recent N export zips per collection; older ones are pruned so the
+# SD does not fill up with archives no one downloads.
+EXPORT_KEEP = 3
+# Free-space safety margin on top of the estimated bag size.
+FREE_SPACE_MARGIN = 100 * 1024 * 1024
+
+
+def run_export(job: ExportJob, collection_id: int) -> None:
+    from app.core.db import SessionLocal
+    db = SessionLocal()
+    try:
+        _do_export(db, job, collection_id)
+    finally:
+        db.close()
+
+
+def _do_export(db, job: ExportJob, collection_id: int) -> None:
+    collection = db.query(Collection).filter(Collection.id == collection_id).first()
+    if not collection:
+        raise ExportError(f"Collection {collection_id} not found")
+
+    records = (
+        db.query(Record)
+        .filter(Record.collection_id == collection_id)
+        .order_by(Record.sequence.nulls_last(), Record.id)
+        .all()
+    )
+    project = db.query(Project).filter(Project.id == collection.project_id).first() if collection.project_id else None
+
+    exports_dir = config.settings.exports_dir
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bag_name = f"collection_{collection_id}_{timestamp}"
+
+    # Plan the payload: resolve every current image, refuse on any missing file, and give each a unique name so the payload cannot disagree with metadata.json.
+    to_copy = []   # (rel_under_data, resolved_src, img)
+    missing = []
+    used_names: dict = {}
+    for idx, rec in enumerate(records):
+        seq_label = f"{idx + 1:04d}"
+        safe_title = "".join(c if c.isalnum() or c in "-_ " else "_" for c in (rec.title or "record"))[:60]
+        rec_dir_name = f"{seq_label}_{safe_title}"
+        for img in sorted([i for i in rec.images if i.is_current], key=lambda i: (i.role or "z", i.id)):
+            resolved = resolve_within_storage(img.file_path) if img.file_path else None
+            if resolved is None or not resolved.exists():
+                missing.append({"record_id": rec.id, "record_image_id": img.id, "file_path": img.file_path})
+                continue
+            role_prefix = img.role or f"img_{img.id}"
+            dest_name = f"{role_prefix}{resolved.suffix}"
+            seen = used_names.setdefault(rec_dir_name, set())
+            if dest_name in seen:
+                dest_name = f"{role_prefix}_{img.id}{resolved.suffix}"
+            seen.add(dest_name)
+            to_copy.append((f"{rec_dir_name}/{dest_name}", resolved, img))
+
+    if missing:
+        raise ExportError(
+            f"{len(missing)} image file(s) missing from disk.",
+            detail={"reason": "missing_files", "missing_image_ids": [m["record_image_id"] for m in missing], "missing": missing},
+        )
+
+    # Fixity gate: refuse to bag bytes that no longer match their capture-time sha256.
+    mismatches = verify_images_against_manifest([img for _, _, img in to_copy])
+    if mismatches:
+        raise ExportError(
+            f"{len(mismatches)} file(s) fail their capture-time checksum (possible corruption).",
+            detail={"reason": "checksum_mismatch", "mismatched_image_ids": [m["record_image_id"] for m in mismatches], "mismatches": mismatches},
+        )
+
+    # Refuse to start if the exports filesystem can't hold the archive.
+    total_src = sum(resolved.stat().st_size for _, resolved, _ in to_copy)
+    free = shutil.disk_usage(exports_dir).free
+    if free < total_src + FREE_SPACE_MARGIN:
+        raise ExportError(
+            "Not enough free space on the exports filesystem to build this archive.",
+            detail={"reason": "low_disk", "needed_bytes": total_src + FREE_SPACE_MARGIN, "free_bytes": free},
+        )
+
+    metadata_payload = _metadata_payload(collection, project, records, timestamp)
+    blobs = [(json.dumps(metadata_payload, indent=2, ensure_ascii=False).encode("utf-8"), "metadata.json")]
+    manifest_blob = _filtered_manifest_blob(db, collection, records)
+    if manifest_blob:
+        blobs.append((manifest_blob, "metadata/manifest.jsonl"))
+
+    payload_files = [(resolved, rel) for rel, resolved, _ in to_copy]
+    bag_info = {
+        "Source-Organization": project.name if project else "Digitization Toolkit",
+        "External-Description": collection.description or collection.name,
+        "Bagging-Date": timestamp[:8],
+        "External-Identifier": f"collection-{collection_id}",
+        "Bag-Count": "1 of 1",
+        "Record-Count": str(len(records)),
+    }
+
+    # Write the zip straight into the exports dir, atomically via a .part file so a
+    # crash mid-write never leaves a truncated zip that download would serve.
+    job.set_progress(0, len(payload_files) + len(blobs))
+    zip_path = exports_dir / f"{bag_name}.zip"
+    part_path = exports_dir / f"{bag_name}.zip.part"
+    try:
+        write_bag_zip(part_path, bag_name, bag_info, payload_files, blobs,
+                      progress_cb=job.set_progress)
+        part_path.replace(zip_path)
+    except Exception:
+        part_path.unlink(missing_ok=True)
+        raise
+
+    job.zip_filename = zip_path.name
+    _prune_exports(exports_dir, collection_id)
+    logger.info(f"BagIt export created: {zip_path} ({zip_path.stat().st_size} bytes)")
+
+
+def _metadata_payload(collection, project, records, timestamp) -> dict:
+    return {
+        "exported_at": timestamp,
+        "collection": {
+            "id": collection.id,
+            "name": collection.name,
+            "description": collection.description,
+            "collection_type": collection.collection_type,
+            "archival_metadata": collection.archival_metadata,
+            "created_by": collection.created_by,
+            "created_at": collection.created_at.isoformat() if collection.created_at else None,
+        },
+        "project": {"id": project.id, "name": project.name} if project else None,
+        "records": [
+            {
+                "id": r.id, "sequence": r.sequence, "title": r.title, "description": r.description,
+                "object_typology": r.object_typology, "author": r.author, "material": r.material,
+                "date": r.date, "status": r.status, "created_by": r.created_by,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+                "images": [
+                    {
+                        "id": img.id, "filename": img.filename, "role": img.role, "sequence": img.sequence,
+                        "format": img.format, "resolution_width": img.resolution_width,
+                        "resolution_height": img.resolution_height, "file_size": img.file_size,
+                    }
+                    for img in r.images if img.is_current
+                ],
+            }
+            for r in records
+        ],
+    }
+
+
+def _filtered_manifest_blob(db, collection, records):
+    """The project's capture manifest, filtered to this collection's captures."""
+    from capture.project_manager import secure_project_filename
+    capture_ids = {img.capture_id for rec in records for img in rec.images if img.is_current and img.capture_id}
+    if not capture_ids:
+        return None
+    proj_name = resolve_project_name(db, collection)
+    if not proj_name:
+        return None
+    manifest_src = config.settings.projects_dir / secure_project_filename(proj_name) / "metadata" / "manifest.jsonl"
+    if not manifest_src.exists():
+        return None
+    kept = []
+    for line in manifest_src.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            entry = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if entry.get("capture_id") in capture_ids:
+            kept.append(stripped)
+    return ("\n".join(kept) + "\n").encode("utf-8") if kept else None
+
+
+def _prune_exports(exports_dir: Path, collection_id: int, keep: int = EXPORT_KEEP) -> None:
+    """Keep the newest `keep` zips for this collection; delete older zips and any
+    stale .part files left by an interrupted export."""
+    for part in exports_dir.glob(f"collection_{collection_id}_*.zip.part"):
+        part.unlink(missing_ok=True)
+    zips = sorted(exports_dir.glob(f"collection_{collection_id}_*.zip"), reverse=True)
+    for old in zips[keep:]:
+        try:
+            old.unlink()
+        except OSError:
+            logger.warning(f"Could not prune old export {old}")

--- a/app/core/integrity.py
+++ b/app/core/integrity.py
@@ -106,6 +106,44 @@ def _build_manifest_index(projects_dir: Path) -> Tuple[Dict[str, Dict[str, str]]
     return by_path, by_name
 
 
+def verify_images_against_manifest(images) -> List[dict]:
+    """Re-hash each image and compare it to its capture-time manifest sha256.
+
+    Returns the list of mismatches: files whose bytes on disk differ from what was
+    recorded when they were captured. Images with no capture_id, no manifest entry,
+    or a missing file are skipped, as there is no capture-time fixity to check, and a
+    missing file is a separate failure the caller handles. Read-only.
+    """
+    by_path, by_name = _build_manifest_index(config.settings.projects_dir.resolve())
+    mismatches: List[dict] = []
+    for img in images:
+        if not img.capture_id:
+            continue
+        resolved = resolve_within_storage(img.file_path)
+        if resolved is None or not resolved.exists():
+            continue
+        paths = by_path.get(img.capture_id)
+        names = by_name.get(img.capture_id)
+        expected = paths.get(str(resolved)) if paths else None
+        if expected is None and names:
+            expected = names.get(resolved.name)
+        if expected is None:
+            continue
+        try:
+            actual = _sha256(resolved)
+        except OSError:
+            continue
+        if actual != expected:
+            mismatches.append({
+                "record_image_id": img.id,
+                "record_id": img.record_id,
+                "file_path": img.file_path,
+                "expected_sha256": expected,
+                "actual_sha256": actual,
+            })
+    return mismatches
+
+
 def run_integrity_check(db: Session, verify_hashes: bool = True,
                         max_hash_checks: Optional[int] = None) -> dict:
     """Reconcile the database, the image files, and the capture manifest.

--- a/app/core/integrity.py
+++ b/app/core/integrity.py
@@ -12,6 +12,7 @@ deletes, or rewrites anything.
 import hashlib
 import json
 import logging
+import random
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -202,7 +203,13 @@ def run_integrity_check(db: Session, verify_hashes: bool = True,
     manifest_mismatches: List[dict] = []
     manifest_missing_entry: List[dict] = []
     hashes_checked = 0
+    hashes_eligible = 0
     if verify_hashes:
+        # Finding the manifest entry is cheap, so it runs over every image (a
+        # missing entry is worth reporting for all). Only the sha256 recompute is
+        # expensive, so when capped it hashes a random sample of the eligible
+        # files rather than the first N - a bounded but representative sweep.
+        eligible: List[Tuple] = []
         for img in images:
             if not img.capture_id:
                 continue
@@ -221,8 +228,14 @@ def run_integrity_check(db: Session, verify_hashes: bool = True,
                     "file_path": img.file_path,
                 })
                 continue
-            if max_hash_checks is not None and hashes_checked >= max_hash_checks:
-                continue
+            eligible.append((img, resolved, expected))
+
+        hashes_eligible = len(eligible)
+        to_hash = eligible
+        if max_hash_checks is not None and hashes_eligible > max_hash_checks:
+            to_hash = random.sample(eligible, max_hash_checks)
+
+        for img, resolved, expected in to_hash:
             try:
                 actual = _sha256(resolved)
             except OSError:
@@ -249,6 +262,8 @@ def run_integrity_check(db: Session, verify_hashes: bool = True,
         "missing_thumbnails": len(missing_thumbnails),
         "orphan_files": len(orphan_files),
         "hashes_checked": hashes_checked,
+        "hashes_eligible": hashes_eligible,
+        "hash_sampled": hashes_checked < hashes_eligible,
         "manifest_mismatches": len(manifest_mismatches),
         "manifest_missing_entry": len(manifest_missing_entry),
         "orphan_records": len(orphan_records),

--- a/app/core/login_throttle.py
+++ b/app/core/login_throttle.py
@@ -1,0 +1,67 @@
+"""In-memory login throttle for the single-process appliance.
+
+Deliberately in-memory, not DB-backed: writing a row per failed login would hammer
+the SD card, and the backend runs as one uvicorn process, so
+process-local state is shared across all requests. State resets on restart, which
+is acceptable — an attacker can't restart the service, and a restart only clears
+lockouts, it never grants access.
+
+Keys are opaque strings; the caller throttles per account and per client IP by
+passing both keys, so brute force is bounded whether it targets one account from
+many IPs or many accounts from one IP.
+"""
+
+import math
+import time
+from threading import Lock
+from typing import Callable
+
+
+class LoginThrottle:
+    def __init__(
+        self,
+        max_failures: int = 5,
+        lockout_seconds: int = 300,
+        window_seconds: int = 900,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self._max = max_failures
+        self._lockout = lockout_seconds
+        self._window = window_seconds
+        self._clock = clock
+        self._lock = Lock()
+        self._state: dict[str, dict] = {}
+
+    def retry_after(self, *keys: str) -> int:
+        """Seconds until the soonest-unlocking key frees up, or 0 if none are locked."""
+        now = self._clock()
+        remaining = 0
+        with self._lock:
+            for key in keys:
+                st = self._state.get(key)
+                if st and st["locked_until"] > now:
+                    remaining = max(remaining, math.ceil(st["locked_until"] - now))
+        return remaining
+
+    def record_failure(self, *keys: str) -> None:
+        """Count a failed attempt against each key; lock the key once it crosses
+        max_failures within the sliding window."""
+        now = self._clock()
+        with self._lock:
+            for key in keys:
+                st = self._state.setdefault(key, {"failures": [], "locked_until": 0.0})
+                st["failures"] = [t for t in st["failures"] if t > now - self._window]
+                st["failures"].append(now)
+                if len(st["failures"]) >= self._max:
+                    st["locked_until"] = now + self._lockout
+                    st["failures"] = []
+
+    def reset(self, *keys: str) -> None:
+        """Clear all state for the given keys (called on a successful login)."""
+        with self._lock:
+            for key in keys:
+                self._state.pop(key, None)
+
+
+# Module-level singleton shared across requests in the single backend process.
+login_throttle = LoginThrottle()

--- a/app/core/schema.py
+++ b/app/core/schema.py
@@ -57,13 +57,20 @@ def assert_schema_at_head() -> None:
             current = set(MigrationContext.configure(conn).get_current_heads())
     except Exception as e:
         # An unreachable database is a distinct failure; surface it rather than mask it.
-        raise SchemaOutOfDateError(f"Could not read the database schema revision: {e}") from e
+        msg = (
+            f"Cannot start: the database is unreachable, so its schema revision could not be read ({e}). "
+            "Check that the database service is running and DATABASE_* settings are correct, then restart the backend."
+        )
+        logger.error(f"[ERROR] {msg}")
+        raise SchemaOutOfDateError(msg) from e
 
     if current == heads:
         logger.info(f"[OK] Database schema at head ({', '.join(sorted(heads)) or 'none'})")
         return
 
-    raise SchemaOutOfDateError(
-        f"Database schema is out of date: database at {sorted(current) or 'no revision'}, "
+    msg = (
+        f"Cannot start: database schema is out of date - database at {sorted(current) or 'no revision'}, "
         f"code expects head {sorted(heads)}. Run 'alembic upgrade head' (or update.sh) before starting the backend."
     )
+    logger.error(f"[ERROR] {msg}")
+    raise SchemaOutOfDateError(msg)

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -22,19 +22,47 @@ def _b64u_decode(data: str) -> bytes:
     return base64.urlsafe_b64decode(data + padding)
 
 
+# PBKDF2-HMAC-SHA256 work factor. Self-describing hashes allow future increases;
+# login upgrades weaker hashes when the plaintext is available.
+_ALGO = "pbkdf2_sha256"
+PBKDF2_ITERATIONS = 600_000
+_LEGACY_ITERATIONS = 100_000  # original hashes were stored bare as "salt$hash"
+
+
+def _pbkdf2(password: str, salt: str, iterations: int) -> str:
+    return hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt.encode("utf-8"), iterations).hex()
+
+
 def hash_password(password: str) -> str:
     salt = secrets.token_hex(16)
-    dk = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt.encode("utf-8"), 100_000)
-    return f"{salt}${dk.hex()}"
+    return f"{_ALGO}${PBKDF2_ITERATIONS}${salt}${_pbkdf2(password, salt, PBKDF2_ITERATIONS)}"
 
 
 def verify_password(password: str, hashed: str) -> bool:
     try:
-        salt, hash_hex = hashed.split("$", 1)
+        parts = hashed.split("$")
+        if len(parts) == 4 and parts[0] == _ALGO:
+            _, iters, salt, digest = parts
+            return hmac.compare_digest(_pbkdf2(password, salt, int(iters)), digest)
+        if len(parts) == 2:
+            # Legacy format: "salt$hash" at the original fixed iteration count.
+            salt, digest = parts
+            return hmac.compare_digest(_pbkdf2(password, salt, _LEGACY_ITERATIONS), digest)
     except Exception:
         return False
-    dk = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt.encode("utf-8"), 100_000)
-    return hmac.compare_digest(dk.hex(), hash_hex)
+    return False
+
+
+def needs_rehash(hashed: str) -> bool:
+    """True when a stored hash uses a weaker scheme than the current default, so a
+    successful login can transparently re-hash the password at full strength."""
+    parts = hashed.split("$")
+    if len(parts) == 4 and parts[0] == _ALGO:
+        try:
+            return int(parts[1]) < PBKDF2_ITERATIONS
+        except ValueError:
+            return True
+    return True  # legacy 2-part or anything unrecognized
 
 
 def create_access_token(subject: str, expires_seconds: Optional[int] = None) -> str:

--- a/app/core/storage_ops.py
+++ b/app/core/storage_ops.py
@@ -6,6 +6,7 @@ records are re-parented (move) or their container is removed (delete), and
 provide the guard that stops a delete from erasing files still referenced by surviving records.
 """
 
+import json
 import logging
 import os
 import shutil
@@ -178,6 +179,105 @@ def rebase_stored_path(stored: Optional[str], old_root: Path, new_root: Path) ->
     except (OSError, ValueError):
         return None
     return str(new_root / rel)
+
+
+# ---------------------------------------------------------------------------
+# Crash-safe project rename
+#
+# A rename moves the on-disk tree and then commits the new name/paths to the DB
+# - two steps that cannot share one transaction. On this power-loss-prone
+# appliance a crash between them would leave files at the new path while the DB
+# still points at the old one, dangling every record path. write_rename_journal
+# records intent durably before the move; reconcile_pending_rename replays or
+# discards it at startup so recovery is mechanical, not a manual SSH repair.
+# ---------------------------------------------------------------------------
+
+def _rename_journal_file() -> Path:
+    from app.core.config import settings
+    return settings.data_dir / "project-rename.journal"
+
+
+def write_rename_journal(project_id: int, old_name: str, new_name: str, old_root: Path, new_root: Path) -> None:
+    """Durably record intent to rename, before the on-disk move happens."""
+    from capture.utils import atomic_write
+
+    path = _rename_journal_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps({
+        "project_id": project_id,
+        "old_name": old_name,
+        "new_name": new_name,
+        "old_root": str(old_root),
+        "new_root": str(new_root),
+    }, indent=2)
+    atomic_write(path, lambda tmp: Path(tmp).write_text(payload, encoding="utf-8"))
+
+
+def clear_rename_journal() -> None:
+    """Remove the journal once the rename has fully committed (or been undone)."""
+    try:
+        _rename_journal_file().unlink(missing_ok=True)
+    except OSError:
+        logger.exception("[ERROR] Failed to clear project rename journal")
+
+
+def read_rename_journal() -> Optional[dict]:
+    path = _rename_journal_file()
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        logger.exception("[ERROR] Project rename journal is unreadable; discarding it")
+        clear_rename_journal()
+        return None
+
+
+def reconcile_pending_rename(db: Session) -> None:
+    """Replay or discard a rename interrupted by a crash. Idempotent; safe at every startup."""
+    j = read_rename_journal()
+    if not j:
+        return
+
+    project = db.query(Project).filter(Project.id == j["project_id"]).first()
+    old_root = Path(j["old_root"])
+    new_root = Path(j["new_root"])
+
+    if project is None:
+        clear_rename_journal()
+        return
+
+    # DB already carries the new name, so the move preceded the commit and files
+    # belong at new_root; repair only if a crash left them at old_root.
+    if project.name == j["new_name"]:
+        if old_root.exists() and not new_root.exists():
+            try:
+                move_project_tree(old_root, new_root)
+            except OSError:
+                logger.exception("[ERROR] Rename reconciliation could not move %s -> %s", old_root, new_root)
+                return  # keep the journal so the next startup retries
+        clear_rename_journal()
+        return
+
+    # DB still carries the old name: finish the DB side only if the files already moved.
+    if project.name == j["old_name"]:
+        if new_root.exists() and not old_root.exists():
+            project.name = j["new_name"]
+            for img in db.query(RecordImage).all():
+                new_fp = rebase_stored_path(img.file_path, old_root, new_root)
+                if new_fp:
+                    img.file_path = new_fp
+                new_tp = rebase_stored_path(img.thumbnail_path, old_root, new_root)
+                if new_tp:
+                    img.thumbnail_path = new_tp
+            db.commit()
+            logger.warning("Completed interrupted project rename %r -> %r after restart", j["old_name"], j["new_name"])
+        # Otherwise the move never happened and the DB is consistent at the old name.
+        clear_rename_journal()
+        return
+
+    # Name matches neither side (renamed again since): the journal is stale.
+    clear_rename_journal()
 
 
 def _do_renames(moves: List[Tuple[Path, Path]]) -> List[Tuple[Path, Path]]:

--- a/app/core/storage_override.py
+++ b/app/core/storage_override.py
@@ -5,7 +5,9 @@ Stored in /var/lib/dtk/storage-override.json so it survives backend restarts
 without requiring an env var change or service restart.
 
 A missing override file means "no override" and is normal. An override file that
-exists but cannot be read raises StorageOverrideError, so a corrupt file surfaces as an error instead of a silent fallback to the internal SD.
+exists but cannot be read raises StorageOverrideError from the low-level reader;
+callers use get_storage_override_or_fallback to log it and revert to internal
+storage rather than let one corrupt file 500 the whole app.
 """
 import json
 import logging
@@ -33,6 +35,15 @@ def get_storage_override() -> str | None:
             f"[ERROR] Storage override file '{_OVERRIDE_FILE}' exists but is unreadable; the active storage path is unknown. Re-activate the storage drive or clear the override."
         ) from e
     return str(value) if value else None
+
+
+def get_storage_override_or_fallback() -> tuple[str | None, bool]:
+    """Return (override_path_or_None, corrupt). Never raises: a corrupt override file is logged and reported as corrupt=True so callers fall back to internal storage instead of turning every request into a 500."""
+    try:
+        return get_storage_override(), False
+    except StorageOverrideError:
+        logger.error("[ERROR] Storage override unreadable; falling back to internal storage")
+        return None, True
 
 
 def set_storage_override(projects_root: str) -> None:

--- a/app/core/thumbnail.py
+++ b/app/core/thumbnail.py
@@ -13,8 +13,16 @@ import uuid
 logger = logging.getLogger(__name__)
 
 # Default thumbnail dimensions
-DEFAULT_THUMBNAIL_WIDTH = 200
-DEFAULT_THUMBNAIL_HEIGHT = 200
+#
+# 600px covers the largest grid-view cell size in the frontend (GridView's
+# column-count slider goes down to 2 columns, which can render cells ~500-
+# 540px wide) with a bit of margin. At 200px, `object-fit: cover` was
+# upscaling the thumbnail to fill much larger cells, producing visibly
+# blurry grids — this only affects the display size, not the stored master
+# image, so the storage/bandwidth cost stays a small fraction of the
+# full-resolution capture either way.
+DEFAULT_THUMBNAIL_WIDTH = 600
+DEFAULT_THUMBNAIL_HEIGHT = 600
 DEFAULT_THUMBNAIL_FORMAT = "JPEG"
 DEFAULT_THUMBNAIL_QUALITY = 85
 

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,14 @@ async def lifespan(app: FastAPI):
     init_db()
     # Refuse to serve against an un-migrated schema so the failure is loud at startup rather than a later 500 in the field
     assert_schema_at_head()
+    # Finish or discard any project rename interrupted by a crash/power loss before serving requests
+    from app.core.db import SessionLocal
+    from app.core.storage_ops import reconcile_pending_rename
+    db = SessionLocal()
+    try:
+        reconcile_pending_rename(db)
+    finally:
+        db.close()
     yield
 
 # Create FastAPI app with lifespan

--- a/app/main.py
+++ b/app/main.py
@@ -26,15 +26,15 @@ async def lifespan(app: FastAPI):
 # Create FastAPI app with lifespan
 app = FastAPI(lifespan=lifespan)
 
-# Allow the Svelte frontend to call the API
-# :5173 = Vite dev server, :3000 = production Node server
+# Allow Svelte frontend API access. Production is same-origin via nginx;
+# CORS applies only to the dev server. Origins use a deployment allowlist.
+# Methods and headers are restricted to those required by the app.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.CORS_ORIGINS,
     allow_credentials=True,
-    # allow_private_network=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+    allow_headers=["Authorization", "Content-Type", "X-Bootstrap-Token"],
 )
 
 app.include_router(records_router, prefix="/records", tags=["records"])

--- a/app/models/record.py
+++ b/app/models/record.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from sqlalchemy import Column, Integer, String, DateTime, Text, ForeignKey, CheckConstraint, JSON
+from sqlalchemy import Column, Integer, String, DateTime, Text, ForeignKey, CheckConstraint, JSON, Boolean
 from sqlalchemy.orm import relationship
 
 from app.core.db import Base
@@ -27,22 +27,29 @@ class Record(Base):
 	project_id = Column(Integer, ForeignKey("projects.id", ondelete="SET NULL"), nullable=True, index=True)
 	collection_id = Column(Integer, ForeignKey("collections.id", ondelete="SET NULL"), nullable=True, index=True)
 	
-	# QA workflow
-	status = Column(String(20), nullable=False, default="captured")  # captured, in_review, rejected, approved
+	# QA workflow — a record enters the queue as "in_review" as soon as it's
+	# captured; there is no separate "captured" resting state (NEH-208).
+	status = Column(String(20), nullable=False, default="in_review")  # in_review, rejected, approved
 	sequence = Column(Integer, nullable=True)  # ordering within a collection
-	rejection_note = Column(Text, nullable=True)  # optional note when status=rejected
+
+	# Which camera setup produced this document: "single" (one image) or
+	# "dual" (an L+R pair fired together on one shutter press). Set once at
+	# capture time and never changed — it's what rejection scope resolution
+	# and the recapture mode-match guard key off of (NEH-208).
+	capture_mode = Column(String(10), nullable=False)  # single, dual
 
 	# Audit fields
 	created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
 	modified_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 	created_by = Column(String(255), nullable=True)
-	
+
 	# Relationships
 	images = relationship("RecordImage", back_populates="record", cascade="all, delete-orphan")
 	project = relationship("Project", back_populates="records")
 	collection = relationship("Collection", back_populates="records")
 	annotations = relationship("RecordAnnotation", back_populates="record", cascade="all, delete-orphan", order_by="RecordAnnotation.created_at.desc()")
-	
+	rejections = relationship("RecordRejection", back_populates="record", cascade="all, delete-orphan", order_by="RecordRejection.rejected_at.desc()")
+
 	# Constraint: must have either project_id OR collection_id (or neither, but not both)
 	__table_args__ = (
 		CheckConstraint(
@@ -50,8 +57,12 @@ class Record(Base):
 			name='check_record_single_parent'
 		),
 		CheckConstraint(
-			"status IN ('captured','in_review','rejected','approved')",
+			"status IN ('in_review','rejected','approved')",
 			name='check_record_status'
+		),
+		CheckConstraint(
+			"capture_mode IN ('single','dual')",
+			name='check_record_capture_mode'
 		),
 	)
 
@@ -90,11 +101,21 @@ class RecordImage(Base):
 	# Audit fields
 	created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
 	uploaded_by = Column(String(255), nullable=True)
-	
+
+	# Rejection/recapture audit trail (NEH-208). A rejected image is never
+	# deleted or overwritten: it stays in place with is_current flipped to
+	# False and rejection_id pointing at the RecordRejection that flagged
+	# it, so it remains queryable via GET /records/{id}/rejections after a
+	# recapture installs its replacement as the new current image.
+	is_current = Column(Boolean, nullable=False, default=True)
+	superseded_at = Column(DateTime, nullable=True)
+	rejection_id = Column(Integer, ForeignKey("record_rejections.id", ondelete="SET NULL"), nullable=True, index=True)
+
 	# Relationships
 	record = relationship("Record", back_populates="images")
 	camera_settings = relationship("CameraSettings", back_populates="record_image", uselist=False, cascade="all, delete-orphan")
 	exif_data = relationship("ExifData", back_populates="record_image", uselist=False, cascade="all, delete-orphan")
+	rejection = relationship("RecordRejection", back_populates="images")
 
 
 class RecordAnnotation(Base):
@@ -114,6 +135,40 @@ class RecordAnnotation(Base):
 	created_by = Column(String(255), nullable=True)
 
 	record = relationship("Record", back_populates="annotations")
+
+
+class RecordRejection(Base):
+	"""
+	Audit record of a single rejection event on a Record (NEH-208).
+
+	Created once per rejection with a mandatory predefined reason (the same
+	list the annotation feature's "Marcar error" uses) plus an optional
+	free-text comment. Links to every RecordImage that was current at the
+	time of rejection via RecordImage.rejection_id — those images are never
+	deleted; a later recapture supersedes them (is_current=False) without
+	touching this row, so the rejected file(s) + reason + timestamp + user
+	stay queryable indefinitely via GET /records/{id}/rejections.
+	"""
+	__tablename__ = "record_rejections"
+
+	id = Column(Integer, primary_key=True, index=True)
+	record_id = Column(Integer, ForeignKey("records.id", ondelete="CASCADE"), nullable=False, index=True)
+
+	predefined_reason = Column(String(20), nullable=False)  # blur, glare, shadow, focus, exposure, dirt
+	comment = Column(Text, nullable=True)
+
+	rejected_by = Column(String(255), nullable=True)
+	rejected_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+
+	record = relationship("Record", back_populates="rejections")
+	images = relationship("RecordImage", back_populates="rejection")
+
+	__table_args__ = (
+		CheckConstraint(
+			"predefined_reason IN ('blur','glare','shadow','focus','exposure','dirt')",
+			name='check_record_rejection_reason'
+		),
+	)
 
 
 class ExifData(Base):

--- a/app/schemas/collection.py
+++ b/app/schemas/collection.py
@@ -44,6 +44,9 @@ class CollectionRead(CollectionBase):
     created_by: Optional[str] = None
     created_at: datetime
     updated_at: Optional[datetime] = None
+    # Direct record count (Record.collection_id == this collection's id).
+    # None unless the endpoint explicitly populates it (list/hierarchy).
+    record_count: Optional[int] = None
 
     class Config:
         from_attributes = True
@@ -52,7 +55,6 @@ class CollectionRead(CollectionBase):
 class CollectionWithChildren(CollectionRead):
     """Collection with nested child collections (for hierarchical views)."""
     child_collections: List["CollectionRead"] = []
-    record_count: Optional[int] = None
 
     class Config:
         from_attributes = True

--- a/app/schemas/record.py
+++ b/app/schemas/record.py
@@ -3,19 +3,32 @@ from typing import Optional, List, Literal
 from pydantic import BaseModel, field_validator, model_validator
 from datetime import datetime
 
-# Valid status values
-RecordStatus = Literal["captured", "in_review", "rejected", "approved"]
+# Valid status values. A record has no "captured" resting state — it enters
+# the queue as "in_review" the moment it's captured (NEH-208). "approved" is
+# terminal: the only way back to "in_review" is rejecting first, then
+# recapturing (see the dedicated reject endpoint and cameras.py).
+RecordStatus = Literal["in_review", "rejected", "approved"]
 
-# Allowed status transitions: (from_status, to_status) -> set of roles that can perform it
+# Allowed status transitions: (from_status, to_status) -> set of roles that can perform it.
+# Rejection is deliberately NOT here — it's its own endpoint (POST
+# /records/{id}/reject) with a mandatory predefined_reason, not reachable
+# through the generic status-update path. Recapture (rejected -> in_review)
+# is likewise not here — it only ever happens as a side effect of the
+# capture endpoints (app/api/cameras.py) actually receiving new image(s).
 STATUS_TRANSITIONS: dict[tuple[str, str], set[str]] = {
-	("captured",  "in_review"): {"operator", "admin", "reviewer"},
-	("in_review", "rejected"):  {"reviewer", "admin"},
-	("in_review", "approved"):  {"reviewer", "admin"},
-	("in_review", "captured"):  {"operator", "admin"},
-	("rejected",  "captured"):  {"operator", "admin"},
-	("approved",  "rejected"):  {"reviewer", "admin"},
-	("approved",  "captured"):  {"admin"},
+	("in_review", "approved"): {"reviewer", "admin"},
 }
+
+# The predefined rejection reasons, mirroring the list the annotation
+# feature's "Marcar error" already uses client-side
+# (LeftSidebar.svelte ERROR_TYPES) — this is the first place either list is
+# enforced server-side.
+PREDEFINED_REJECTION_REASONS = ("blur", "glare", "shadow", "focus", "exposure", "dirt")
+PredefinedRejectionReason = Literal["blur", "glare", "shadow", "focus", "exposure", "dirt"]
+
+# Which camera setup produced a document: one image, or an L+R pair fired
+# together on a single shutter press. Set once at capture time.
+CaptureMode = Literal["single", "dual"]
 
 
 # ==============================================================================
@@ -110,6 +123,11 @@ class RecordImageRead(RecordImageBase):
 	created_at: Optional[datetime]
 	camera_settings: Optional[CameraSettingsRead] = None
 	exif_data: Optional[ExifDataRead] = None
+	# Audit trail (NEH-208): False once a recapture has superseded this
+	# image — it stays queryable via GET /records/{id}/rejections but drops
+	# out of the default image list/gallery/export.
+	is_current: bool = True
+	superseded_at: Optional[datetime] = None
 
 	class Config:
 		from_attributes = True
@@ -127,9 +145,13 @@ class RecordBase(BaseModel):
 	material: Optional[str] = None
 	date: Optional[str] = None
 	custom_attributes: Optional[str] = None  # JSON string for custom fields
-	status: RecordStatus = "captured"
+	status: RecordStatus = "in_review"
 	sequence: Optional[int] = None
-	rejection_note: Optional[str] = None
+	# Required: the camera capture endpoints always set this explicitly;
+	# manual record creation (POST /records/) must declare it up front since
+	# rejection scope resolution and the recapture mode-match guard both
+	# depend on it (NEH-208).
+	capture_mode: CaptureMode
 
 
 class RecordCreate(RecordBase):
@@ -169,13 +191,11 @@ class RecordRead(RecordBase):
 
 class RecordStatusUpdate(BaseModel):
 	status: RecordStatus
-	rejection_note: Optional[str] = None
 
 
 class BulkStatusUpdate(BaseModel):
 	record_ids: List[int]
 	status: RecordStatus
-	rejection_note: Optional[str] = None
 
 	@field_validator("record_ids")
 	@classmethod
@@ -183,6 +203,30 @@ class BulkStatusUpdate(BaseModel):
 		if not v:
 			raise ValueError("record_ids must not be empty")
 		return v
+
+
+# ==============================================================================
+# Rejection schemas (NEH-208)
+# ==============================================================================
+
+class RecordRejectRequest(BaseModel):
+	predefined_reason: PredefinedRejectionReason
+	comment: Optional[str] = None
+
+
+class RecordRejectionRead(BaseModel):
+	id: int
+	record_id: int
+	predefined_reason: str
+	comment: Optional[str] = None
+	rejected_by: Optional[str] = None
+	rejected_at: Optional[datetime]
+	# The image(s) this specific rejection flagged — both L and R for a
+	# dual-mode document, the one image for single-mode.
+	images: List[RecordImageRead] = []
+
+	class Config:
+		from_attributes = True
 
 
 # ==============================================================================

--- a/app/schemas/record.py
+++ b/app/schemas/record.py
@@ -169,6 +169,12 @@ class RecordCreate(RecordBase):
 	collection_id: Optional[int] = None
 	created_by: Optional[str] = None
 
+	@model_validator(mode="after")
+	def _single_parent(self):
+		if self.project_id is not None and self.collection_id is not None:
+			raise ValueError("A record belongs to either a project or a collection, not both.")
+		return self
+
 
 class RecordUpdate(BaseModel):
 	title: Optional[str] = None

--- a/app/schemas/record.py
+++ b/app/schemas/record.py
@@ -4,19 +4,29 @@ from pydantic import BaseModel, field_validator, model_validator
 from datetime import datetime
 
 # Valid status values. A record has no "captured" resting state — it enters
-# the queue as "in_review" the moment it's captured (NEH-208). "approved" is
-# terminal: the only way back to "in_review" is rejecting first, then
-# recapturing (see the dedicated reject endpoint and cameras.py).
+# the queue as "in_review" the moment it's captured (NEH-208). A reviewer can
+# undo a mistaken approve/reject back to "in_review" (see STATUS_TRANSITIONS
+# below) — that's a plain status reset, not a recapture and not a formal
+# rejection, so it carries no reason/audit entry.
 RecordStatus = Literal["in_review", "rejected", "approved"]
 
 # Allowed status transitions: (from_status, to_status) -> set of roles that can perform it.
-# Rejection is deliberately NOT here — it's its own endpoint (POST
+#
+# Formal rejection is deliberately NOT here — it's its own endpoint (POST
 # /records/{id}/reject) with a mandatory predefined_reason, not reachable
-# through the generic status-update path. Recapture (rejected -> in_review)
-# is likewise not here — it only ever happens as a side effect of the
-# capture endpoints (app/api/cameras.py) actually receiving new image(s).
+# through this generic status-update path. Recapture (rejected -> in_review
+# as a side effect of a new capture actually arriving) is also not here —
+# that's driven entirely by app/api/cameras.py, not a client-chosen status
+# value.
+#
+# approved -> in_review and rejected -> in_review ARE here: these are the
+# "undo my mistake" resets a reviewer can trigger directly from the record
+# view (NEH-209) — no reason required since nothing formal is being
+# recorded, just moving the record back into the review queue.
 STATUS_TRANSITIONS: dict[tuple[str, str], set[str]] = {
 	("in_review", "approved"): {"reviewer", "admin"},
+	("approved", "in_review"): {"reviewer", "admin"},
+	("rejected", "in_review"): {"reviewer", "admin"},
 }
 
 # The predefined rejection reasons, mirroring the list the annotation

--- a/pixi.toml
+++ b/pixi.toml
@@ -55,6 +55,13 @@ db-upgrade = "alembic upgrade head"
 db-migrate = { cmd = "alembic revision --autogenerate -m", depends-on = [] }
 db-downgrade = "alembic downgrade -1"
 db-history = "alembic history"
+# Schema drift guard (NEH-105): fails if the ORM models and a
+# migrated database disagree, i.e. if `db-migrate` would emit a
+# non-empty migration. Run it against a database already at head —
+# `pixi run db-upgrade` first. Drift is how collections acquired three
+# columns no model declared (dda9bc1bc608), and how project_members was
+# once dropped by an unreviewed autogenerate.
+db-check-drift = { cmd = "alembic check", depends-on = ["db-upgrade"] }
 
 # Testing
 test-cameras = "python test/test_cameras.py"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,33 @@
+"""Shared fixtures for the hardware-gated capture integration tests."""
+import pytest
+
+
+@pytest.fixture
+def authed_client(client, db_session):
+    """TestClient authenticated as a real contributor via a get_current_user override.
+
+    The capture endpoints sit behind allow_contributor, which resolves the caller
+    through get_current_user; verify_access_token rejects the literal
+    "Bearer test_token" these tests used to send, giving a 401 before the endpoint
+    ran. Overriding the dependency is the pattern used in
+    tests/unit/test_delete_user_guards.py. The `client` fixture clears
+    dependency_overrides on teardown.
+    """
+    from app.main import app
+    from app.api.auth import get_current_user
+    from app.models.user import User
+    from app.core.security import hash_password
+
+    user = User(
+        username="capture_user",
+        email="capture_user@example.com",
+        hashed_password=hash_password("x"),
+        role="contributor",
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    app.dependency_overrides[get_current_user] = lambda: user
+    yield client

--- a/tests/integration/test_camera_capture_recapture_hardware.py
+++ b/tests/integration/test_camera_capture_recapture_hardware.py
@@ -1,0 +1,146 @@
+"""
+Hardware-gated integration tests for NEH-208 recapture through the real
+/cameras/capture and /cameras/capture/dual endpoints.
+
+Mirrors the skip pattern in test_capture_integration.py: these require real
+camera hardware (Linux/Raspberry Pi) and are not the primary coverage for
+this ticket — the non-hardware-gated test_reject_recapture_full_flow.py
+carries the required assertions on this dev machine. This file verifies the
+part only the real endpoints can exercise: the capture-mode mismatch guard,
+and that a recapture leaves the original file on disk untouched.
+Run with: python -m pytest tests/integration/test_camera_capture_recapture_hardware.py
+"""
+import pytest
+import sys
+
+# Skip on non-Linux platforms
+if sys.platform != 'linux':
+    pytest.skip("Integration tests require Linux/Raspberry Pi environment", allow_module_level=True)
+
+
+from pathlib import Path
+
+from app.models.record import Record, RecordImage
+
+
+@pytest.mark.integration
+def test_single_capture_recapture_flips_rejected_back_to_in_review(client, db_session, test_project):
+    project_name = test_project.name
+
+    response = client.post(
+        "/cameras/capture",
+        json={
+            "project_name": project_name,
+            "camera_index": 0,
+            "resolution": "medium",
+            "include_resolution_in_filename": False
+        },
+        headers={"Authorization": "Bearer test_token"}
+    )
+    assert response.status_code == 200
+    record_id = response.json()["record_id"]
+    first_image_path = Path(response.json()["file_path"])
+
+    record = db_session.query(Record).filter(Record.id == record_id).first()
+    record.status = "rejected"
+    db_session.commit()
+
+    response = client.post(
+        "/cameras/capture",
+        json={
+            "project_name": project_name,
+            "camera_index": 0,
+            "resolution": "medium",
+            "include_resolution_in_filename": False,
+            "record_id": record_id,
+        },
+        headers={"Authorization": "Bearer test_token"}
+    )
+    assert response.status_code == 200, response.text
+
+    db_session.refresh(record)
+    assert record.status == "in_review"
+
+    # The original file is preserved on disk — a rejected capture is never deleted.
+    assert first_image_path.exists()
+
+    images = db_session.query(RecordImage).filter(RecordImage.record_id == record_id).all()
+    old_images = [i for i in images if str(i.file_path) == str(first_image_path)]
+    assert old_images and old_images[0].is_current is False
+
+
+@pytest.mark.integration
+def test_dual_capture_recapture_supersedes_both_sides(client, db_session, test_project):
+    project_name = test_project.name
+
+    response = client.post(
+        "/cameras/capture/dual",
+        json={
+            "project_name": project_name,
+            "resolution": "medium",
+            "include_resolution_in_filename": False,
+            "stagger_ms": 20
+        },
+        headers={"Authorization": "Bearer test_token"}
+    )
+    assert response.status_code == 200
+    record_id = response.json()["record_id"]
+
+    record = db_session.query(Record).filter(Record.id == record_id).first()
+    assert record.capture_mode == "dual"
+    record.status = "rejected"
+    db_session.commit()
+
+    old_images = db_session.query(RecordImage).filter(RecordImage.record_id == record_id).all()
+    assert len(old_images) == 2
+
+    response = client.post(
+        "/cameras/capture/dual",
+        json={
+            "project_name": project_name,
+            "resolution": "medium",
+            "include_resolution_in_filename": False,
+            "stagger_ms": 20,
+            "record_id": record_id,
+        },
+        headers={"Authorization": "Bearer test_token"}
+    )
+    assert response.status_code == 200, response.text
+
+    db_session.refresh(record)
+    assert record.status == "in_review"
+
+    for img in old_images:
+        db_session.refresh(img)
+        assert img.is_current is False
+
+    current_images = db_session.query(RecordImage).filter(
+        RecordImage.record_id == record_id, RecordImage.is_current.is_(True)
+    ).all()
+    assert len(current_images) == 2
+
+
+@pytest.mark.integration
+def test_single_capture_recapture_rejects_mode_mismatch(client, db_session, test_project):
+    """A dual-mode record can't be recaptured through the single-camera endpoint."""
+    project_name = test_project.name
+
+    rec = Record(title="dual doc", status="rejected", capture_mode="dual", project_id=test_project.id)
+    db_session.add(rec)
+    db_session.commit()
+
+    response = client.post(
+        "/cameras/capture",
+        json={
+            "project_name": project_name,
+            "camera_index": 0,
+            "resolution": "medium",
+            "record_id": rec.id,
+        },
+        headers={"Authorization": "Bearer test_token"}
+    )
+    assert response.status_code == 422, response.text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/integration/test_camera_capture_recapture_hardware.py
+++ b/tests/integration/test_camera_capture_recapture_hardware.py
@@ -1,13 +1,14 @@
 """
-Hardware-gated integration tests for NEH-208 recapture through the real
+Hardware-gated integration tests for recapture through the real
 /cameras/capture and /cameras/capture/dual endpoints.
 
 Mirrors the skip pattern in test_capture_integration.py: these require real
-camera hardware (Linux/Raspberry Pi) and are not the primary coverage for
-this ticket — the non-hardware-gated test_reject_recapture_full_flow.py
-carries the required assertions on this dev machine. This file verifies the
-part only the real endpoints can exercise: the capture-mode mismatch guard,
-and that a recapture leaves the original file on disk untouched.
+camera hardware (Linux/Raspberry Pi) and skip when none is connected. They are
+not the primary coverage for recapture — the non-hardware-gated
+test_reject_recapture_full_flow.py carries the required assertions on a dev
+machine. This file verifies the part only the real endpoints can exercise: the
+capture-mode mismatch guard, and that a recapture leaves the original file on
+disk untouched.
 Run with: python -m pytest tests/integration/test_camera_capture_recapture_hardware.py
 """
 import pytest
@@ -24,10 +25,10 @@ from app.models.record import Record, RecordImage
 
 
 @pytest.mark.integration
-def test_single_capture_recapture_flips_rejected_back_to_in_review(client, db_session, test_project):
+def test_single_capture_recapture_flips_rejected_back_to_in_review(authed_client, db_session, test_project, skip_if_no_camera):
     project_name = test_project.name
 
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture",
         json={
             "project_name": project_name,
@@ -35,7 +36,6 @@ def test_single_capture_recapture_flips_rejected_back_to_in_review(client, db_se
             "resolution": "medium",
             "include_resolution_in_filename": False
         },
-        headers={"Authorization": "Bearer test_token"}
     )
     assert response.status_code == 200
     record_id = response.json()["record_id"]
@@ -45,7 +45,7 @@ def test_single_capture_recapture_flips_rejected_back_to_in_review(client, db_se
     record.status = "rejected"
     db_session.commit()
 
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture",
         json={
             "project_name": project_name,
@@ -54,7 +54,6 @@ def test_single_capture_recapture_flips_rejected_back_to_in_review(client, db_se
             "include_resolution_in_filename": False,
             "record_id": record_id,
         },
-        headers={"Authorization": "Bearer test_token"}
     )
     assert response.status_code == 200, response.text
 
@@ -70,10 +69,10 @@ def test_single_capture_recapture_flips_rejected_back_to_in_review(client, db_se
 
 
 @pytest.mark.integration
-def test_dual_capture_recapture_supersedes_both_sides(client, db_session, test_project):
+def test_dual_capture_recapture_supersedes_both_sides(authed_client, db_session, test_project, skip_if_no_camera):
     project_name = test_project.name
 
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture/dual",
         json={
             "project_name": project_name,
@@ -81,7 +80,6 @@ def test_dual_capture_recapture_supersedes_both_sides(client, db_session, test_p
             "include_resolution_in_filename": False,
             "stagger_ms": 20
         },
-        headers={"Authorization": "Bearer test_token"}
     )
     assert response.status_code == 200
     record_id = response.json()["record_id"]
@@ -94,7 +92,7 @@ def test_dual_capture_recapture_supersedes_both_sides(client, db_session, test_p
     old_images = db_session.query(RecordImage).filter(RecordImage.record_id == record_id).all()
     assert len(old_images) == 2
 
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture/dual",
         json={
             "project_name": project_name,
@@ -103,7 +101,6 @@ def test_dual_capture_recapture_supersedes_both_sides(client, db_session, test_p
             "stagger_ms": 20,
             "record_id": record_id,
         },
-        headers={"Authorization": "Bearer test_token"}
     )
     assert response.status_code == 200, response.text
 
@@ -121,7 +118,7 @@ def test_dual_capture_recapture_supersedes_both_sides(client, db_session, test_p
 
 
 @pytest.mark.integration
-def test_single_capture_recapture_rejects_mode_mismatch(client, db_session, test_project):
+def test_single_capture_recapture_rejects_mode_mismatch(authed_client, db_session, test_project, skip_if_no_camera):
     """A dual-mode record can't be recaptured through the single-camera endpoint."""
     project_name = test_project.name
 
@@ -129,7 +126,7 @@ def test_single_capture_recapture_rejects_mode_mismatch(client, db_session, test
     db_session.add(rec)
     db_session.commit()
 
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture",
         json={
             "project_name": project_name,
@@ -137,7 +134,6 @@ def test_single_capture_recapture_rejects_mode_mismatch(client, db_session, test
             "resolution": "medium",
             "record_id": rec.id,
         },
-        headers={"Authorization": "Bearer test_token"}
     )
     assert response.status_code == 422, response.text
 

--- a/tests/integration/test_capture_integration.py
+++ b/tests/integration/test_capture_integration.py
@@ -2,8 +2,7 @@
 Integration tests for capture API endpoints wired to database.
 
 Tests the full flow: capture image -> save to microSD -> create database record.
-These need real camera hardware (Linux/Raspberry Pi); they skip on other
-platforms and when no camera is connected.
+These need camera hardware (Linux/Raspberry Pi); they skip on other platforms and when no camera is connected.
 Run with: python -m pytest tests/integration/test_capture_integration.py
 """
 import pytest

--- a/tests/integration/test_capture_integration.py
+++ b/tests/integration/test_capture_integration.py
@@ -57,7 +57,9 @@ def test_single_capture_creates_database_record(client, db_session, test_project
     record = db_session.query(Record).filter(Record.id == doc.record_id).first()
     assert record is not None
     assert record.project_id == test_project.id
-    
+    assert record.status == "in_review"
+    assert record.capture_mode == "single"
+
     # Verify camera settings were saved
     cs = db_session.query(CameraSettings).filter(
         CameraSettings.record_image_id == doc.id
@@ -99,7 +101,11 @@ def test_dual_capture_creates_two_database_records(client, db_session, test_proj
     ).all()
     
     assert len(docs) >= 2
-    
+
+    dual_record = db_session.query(Record).filter(Record.id == docs[-1].record_id).first()
+    assert dual_record.status == "in_review"
+    assert dual_record.capture_mode == "dual"
+
     # Check both have camera settings
     for doc in docs[-2:]:
         cs = db_session.query(CameraSettings).filter(

--- a/tests/integration/test_capture_integration.py
+++ b/tests/integration/test_capture_integration.py
@@ -2,6 +2,8 @@
 Integration tests for capture API endpoints wired to database.
 
 Tests the full flow: capture image -> save to microSD -> create database record.
+These need real camera hardware (Linux/Raspberry Pi); they skip on other
+platforms and when no camera is connected.
 Run with: python -m pytest tests/integration/test_capture_integration.py
 """
 import pytest
@@ -19,15 +21,15 @@ from app.models.project import Project
 
 
 @pytest.mark.integration
-def test_single_capture_creates_database_record(client, db_session, test_project):
+def test_single_capture_creates_database_record(authed_client, db_session, test_project, skip_if_no_camera):
     """
     Test that /cameras/capture creates a RecordImage record in database.
     """
     # Ensure project exists
     project_name = test_project.name
-    
+
     # Call capture endpoint
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture",
         json={
             "project_name": project_name,
@@ -35,20 +37,19 @@ def test_single_capture_creates_database_record(client, db_session, test_project
             "resolution": "medium",
             "include_resolution_in_filename": False
         },
-        headers={"Authorization": "Bearer test_token"}
     )
-    
+
     # Check response
     assert response.status_code == 200
     data = response.json()
     assert data["success"] is True
     assert data["file_path"] is not None
-    
+
     # Verify database record was created
     doc = db_session.query(RecordImage).filter(
         RecordImage.file_path == data["file_path"]
     ).first()
-    
+
     assert doc is not None
     assert doc.format == "jpg"
     assert doc.resolution_width is not None
@@ -69,14 +70,14 @@ def test_single_capture_creates_database_record(client, db_session, test_project
 
 
 @pytest.mark.integration
-def test_dual_capture_creates_two_database_records(client, db_session, test_project):
+def test_dual_capture_creates_two_database_records(authed_client, db_session, test_project, skip_if_no_camera):
     """
     Test that /cameras/capture/dual creates two RecordImage records.
     """
     project_name = test_project.name
-    
+
     # Call dual capture endpoint
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture/dual",
         json={
             "project_name": project_name,
@@ -84,22 +85,21 @@ def test_dual_capture_creates_two_database_records(client, db_session, test_proj
             "include_resolution_in_filename": False,
             "stagger_ms": 20
         },
-        headers={"Authorization": "Bearer test_token"}
     )
-    
+
     # Check response
     assert response.status_code == 200
     data = response.json()
     assert data["success"] is True
     assert len(data["file_paths"]) == 2
-    
+
     # Verify both database records were created
     # RecordImage has no project_id — images belong to a Record, which
     # belongs to the project.
     docs = db_session.query(RecordImage).join(Record).filter(
         Record.project_id == test_project.id
     ).all()
-    
+
     assert len(docs) >= 2
 
     dual_record = db_session.query(Record).filter(Record.id == docs[-1].record_id).first()
@@ -115,26 +115,25 @@ def test_dual_capture_creates_two_database_records(client, db_session, test_proj
 
 
 @pytest.mark.integration
-def test_captured_images_stored_locally(client, test_project, tmp_path):
+def test_captured_images_stored_locally(authed_client, test_project, tmp_path, skip_if_no_camera):
     """
     Test that captured images are actually stored on the filesystem (microSD).
     """
     project_name = test_project.name
-    
+
     # Call capture endpoint
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture",
         json={
             "project_name": project_name,
             "camera_index": 0,
             "resolution": "medium"
         },
-        headers={"Authorization": "Bearer test_token"}
     )
-    
+
     data = response.json()
     file_path = Path(data["file_path"])
-    
+
     # Verify file exists
     assert file_path.exists()
     assert file_path.stat().st_size > 0
@@ -142,37 +141,36 @@ def test_captured_images_stored_locally(client, test_project, tmp_path):
 
 
 @pytest.mark.integration
-def test_exif_data_extracted_and_saved(client, db_session, test_project):
+def test_exif_data_extracted_and_saved(authed_client, db_session, test_project, skip_if_no_camera):
     """
     Test that EXIF data from captured image is extracted and saved to database.
     """
     project_name = test_project.name
-    
-    response = client.post(
+
+    response = authed_client.post(
         "/cameras/capture",
         json={
             "project_name": project_name,
             "camera_index": 0,
             "resolution": "high"
         },
-        headers={"Authorization": "Bearer test_token"}
     )
-    
+
     assert response.status_code == 200
     data = response.json()
-    
+
     # Get database record
     doc = db_session.query(RecordImage).filter(
         RecordImage.file_path == data["file_path"]
     ).first()
-    
+
     assert doc is not None
-    
+
     # Check if EXIF data was created
     exif = db_session.query(ExifData).filter(
         ExifData.record_image_id == doc.id
     ).first()
-    
+
     # EXIF might not be present if PIL can't read it, but raw_exif should have data
     if exif:
         assert exif.raw_exif is not None or exif.make is None

--- a/tests/integration/test_reject_recapture_full_flow.py
+++ b/tests/integration/test_reject_recapture_full_flow.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Integration tests for the full NEH-208 reject -> recapture -> re-review flow,
+covering both capture modes end to end against the real API + DB layer.
+
+These don't go through the hardware-gated /cameras/capture(/dual) endpoints
+(no mock capture backend exists in this repo — see
+tests/integration/test_capture_integration.py, which skips outright on
+non-Linux). Instead, "capture" and "recapture" are simulated the same way
+cameras.py implements them: RecordImage rows are created directly, and
+recapture calls the same _supersede_current_images helper cameras.py calls
+before adding the replacement image(s). The mode-mismatch guard and the
+actual capture-endpoint wiring are covered separately by the hardware-gated
+test_camera_capture_recapture_hardware.py.
+Run with: python -m pytest tests/integration/test_reject_recapture_full_flow.py
+"""
+
+import pytest
+
+
+def _user(username, role):
+    from app.models.user import User
+    return User(username=username, email=f"{username}@example.com",
+                hashed_password="x", role=role, is_active=True)
+
+
+def _client_as(client, username, role):
+    from app.main import app
+    from app.api.auth import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: _user(username, role)
+    return client
+
+
+@pytest.mark.integration
+def test_full_single_mode_reject_recapture_approve_flow(client, db_session):
+    from app.models.record import Record, RecordImage
+    from app.api.records import _supersede_current_images
+
+    rec = Record(title="doc", status="in_review", capture_mode="single")
+    db_session.add(rec)
+    db_session.commit()
+
+    old_img = RecordImage(record_id=rec.id, filename="a.jpg", file_path="/tmp/a.jpg", format="jpg", role="single")
+    db_session.add(old_img)
+    db_session.commit()
+
+    api = _client_as(client, "u", "reviewer")
+
+    # Reject with a mandatory reason.
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "blur", "comment": "shaky hand"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "rejected"
+
+    # Recapture: supersede the old image, add the replacement, flip back to in_review
+    # (exactly what cameras.py's trigger_capture does on a rejected record).
+    db_session.refresh(rec)
+    _supersede_current_images(rec)
+    new_img = RecordImage(record_id=rec.id, filename="a2.jpg", file_path="/tmp/a2.jpg", format="jpg", role="single")
+    db_session.add(new_img)
+    rec.status = "in_review"
+    db_session.commit()
+
+    # Only the new image is "current".
+    resp = api.get(f"/records/{rec.id}/images")
+    assert resp.status_code == 200, resp.text
+    assert [i["id"] for i in resp.json()] == [new_img.id]
+
+    # The old image's rejection record is still queryable, with the old image attached.
+    resp = api.get(f"/records/{rec.id}/rejections")
+    assert resp.status_code == 200, resp.text
+    rejections = resp.json()
+    assert len(rejections) == 1
+    assert rejections[0]["predefined_reason"] == "blur"
+    assert [i["id"] for i in rejections[0]["images"]] == [old_img.id]
+    assert rejections[0]["images"][0]["is_current"] is False
+
+    # Back in in_review, so it can now be approved.
+    resp = api.get(f"/records/{rec.id}")
+    assert resp.json()["status"] == "in_review"
+
+    resp = api.patch(f"/records/{rec.id}/status", json={"status": "approved"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "approved"
+
+
+@pytest.mark.integration
+def test_full_dual_mode_reject_recapture_flow(client, db_session):
+    from app.models.record import Record, RecordImage
+    from app.api.records import _supersede_current_images
+
+    rec = Record(title="book", status="in_review", capture_mode="dual")
+    db_session.add(rec)
+    db_session.commit()
+
+    old_left = RecordImage(record_id=rec.id, filename="l.jpg", file_path="/tmp/l.jpg", format="jpg",
+                            role="left", pair_id="p1")
+    old_right = RecordImage(record_id=rec.id, filename="r.jpg", file_path="/tmp/r.jpg", format="jpg",
+                             role="right", pair_id="p1")
+    db_session.add_all([old_left, old_right])
+    db_session.commit()
+
+    api = _client_as(client, "u", "reviewer")
+
+    # A defect on only one side still rejects the whole pair — physically,
+    # dual capture can only ever be redone together.
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "exposure"})
+    assert resp.status_code == 200, resp.text
+
+    resp = api.get(f"/records/{rec.id}/rejections")
+    flagged_ids = {i["id"] for i in resp.json()[0]["images"]}
+    assert flagged_ids == {old_left.id, old_right.id}
+
+    # Recapture both sides.
+    db_session.refresh(rec)
+    _supersede_current_images(rec)
+    new_left = RecordImage(record_id=rec.id, filename="l2.jpg", file_path="/tmp/l2.jpg", format="jpg",
+                            role="left", pair_id="p2")
+    new_right = RecordImage(record_id=rec.id, filename="r2.jpg", file_path="/tmp/r2.jpg", format="jpg",
+                             role="right", pair_id="p2")
+    db_session.add_all([new_left, new_right])
+    rec.status = "in_review"
+    db_session.commit()
+
+    resp = api.get(f"/records/{rec.id}/images")
+    assert resp.status_code == 200, resp.text
+    assert {i["id"] for i in resp.json()} == {new_left.id, new_right.id}
+
+    # Old pair still fully queryable via the audit endpoint after recapture.
+    resp = api.get(f"/records/{rec.id}/rejections")
+    assert resp.status_code == 200, resp.text
+    rejections = resp.json()
+    assert len(rejections) == 1
+    assert {i["id"] for i in rejections[0]["images"]} == {old_left.id, old_right.id}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_annotation_delete_creator_check.py
+++ b/tests/unit/test_annotation_delete_creator_check.py
@@ -29,7 +29,7 @@ def _client_as(client, username, role):
 def _make_annotation(db_session, created_by):
     from app.models.record import Record, RecordAnnotation
 
-    rec = Record(title="r", created_by="someone")
+    rec = Record(title="r", created_by="someone", capture_mode="single")
     db_session.add(rec)
     db_session.commit()
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -126,7 +126,8 @@ def test_schemas():
             object_typology="book",
             author="John Doe",
             material="paper",
-            date="2024-01-01"
+            date="2024-01-01",
+            capture_mode="single"
         )
         assert doc.object_typology == "book"
         assert doc.author == "John Doe"

--- a/tests/unit/test_bootstrap_token_guard.py
+++ b/tests/unit/test_bootstrap_token_guard.py
@@ -1,0 +1,41 @@
+"""Gate first-user admin bootstrap behind a local bootstrap token."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.auth import _authorize_bootstrap
+
+
+def _cfg(app_env: str, bootstrap_token: str) -> SimpleNamespace:
+    """Minimal stand-in for Settings with just the fields the gate reads."""
+    return SimpleNamespace(APP_ENV=app_env, BOOTSTRAP_TOKEN=bootstrap_token)
+
+
+def test_dev_without_configured_token_allows_bootstrap():
+    # Dev keeps the tokenless first-user flow so local setup needs no configuration
+    _authorize_bootstrap(None, config=_cfg("dev", ""))
+
+
+def test_production_without_configured_token_fails_closed():
+    with pytest.raises(HTTPException) as exc:
+        _authorize_bootstrap("anything", config=_cfg("production", ""))
+    assert exc.value.status_code == 503
+
+
+def test_production_with_matching_token_allows_bootstrap():
+    _authorize_bootstrap("s3cret-token", config=_cfg("production", "s3cret-token"))
+
+
+@pytest.mark.parametrize("provided", [None, "", "wrong-token"])
+def test_production_rejects_missing_or_wrong_token(provided):
+    with pytest.raises(HTTPException) as exc:
+        _authorize_bootstrap(provided, config=_cfg("production", "s3cret-token"))
+    assert exc.value.status_code == 401
+
+
+def test_configured_token_is_enforced_even_in_dev():
+    # If an operator sets a token, dev enforces it too (opt-in)
+    with pytest.raises(HTTPException):
+        _authorize_bootstrap("wrong", config=_cfg("dev", "s3cret-token"))

--- a/tests/unit/test_collections_hierarchy.py
+++ b/tests/unit/test_collections_hierarchy.py
@@ -41,7 +41,7 @@ def test_hierarchy_returns_200_with_record_count(read_client, db_session):
     db_session.commit()
     db_session.add(Collection(name="child", parent_collection_id=col.id))
     for i in range(3):
-        db_session.add(Record(title=f"r{i}", collection_id=col.id))
+        db_session.add(Record(title=f"r{i}", collection_id=col.id, capture_mode="single"))
     db_session.commit()
 
     resp = read_client.get(f"/collections/{col.id}/hierarchy")

--- a/tests/unit/test_collections_order_count_export_detail.py
+++ b/tests/unit/test_collections_order_count_export_detail.py
@@ -157,11 +157,11 @@ def test_list_records_orders_by_sequence_nulls_last_then_id_within_collection(re
 
     # Insert out of sequence order, mixing NULL and non-NULL sequence values.
     # Expected order: sequence 0, 1, 2 first (ascending), then NULLs by id.
-    r_null_a = Record(title="null-a", collection_id=col.id, sequence=None)
-    r_seq2 = Record(title="seq-2", collection_id=col.id, sequence=2)
-    r_null_b = Record(title="null-b", collection_id=col.id, sequence=None)
-    r_seq0 = Record(title="seq-0", collection_id=col.id, sequence=0)
-    r_seq1 = Record(title="seq-1", collection_id=col.id, sequence=1)
+    r_null_a = Record(title="null-a", collection_id=col.id, sequence=None, capture_mode="single")
+    r_seq2 = Record(title="seq-2", collection_id=col.id, sequence=2, capture_mode="single")
+    r_null_b = Record(title="null-b", collection_id=col.id, sequence=None, capture_mode="single")
+    r_seq0 = Record(title="seq-0", collection_id=col.id, sequence=0, capture_mode="single")
+    r_seq1 = Record(title="seq-1", collection_id=col.id, sequence=1, capture_mode="single")
     db_session.add_all([r_null_a, r_seq2, r_null_b, r_seq0, r_seq1])
     db_session.commit()
     for r in (r_null_a, r_seq2, r_null_b, r_seq0, r_seq1):
@@ -188,9 +188,9 @@ def test_list_records_without_collection_id_orders_by_id_only(read_client, db_se
 
     # Sequence values that would sort differently than id if honored;
     # project-wide listing must ignore them and use pure id order.
-    r1 = Record(title="r1", project_id=proj.id, sequence=5)
-    r2 = Record(title="r2", project_id=proj.id, sequence=1)
-    r3 = Record(title="r3", project_id=proj.id, sequence=None)
+    r1 = Record(title="r1", project_id=proj.id, sequence=5, capture_mode="single")
+    r2 = Record(title="r2", project_id=proj.id, sequence=1, capture_mode="single")
+    r3 = Record(title="r3", project_id=proj.id, sequence=None, capture_mode="single")
     db_session.add_all([r1, r2, r3])
     db_session.commit()
     for r in (r1, r2, r3):
@@ -255,9 +255,9 @@ def test_export_non_approved_records_returns_structured_422(contributor_client, 
     db_session.add(col)
     db_session.commit()
 
-    r1 = Record(title="r1", collection_id=col.id, status="captured")
-    r2 = Record(title="r2", collection_id=col.id, status="approved")
-    r3 = Record(title="r3", collection_id=col.id, status="in_review")
+    r1 = Record(title="r1", collection_id=col.id, status="rejected", capture_mode="single")
+    r2 = Record(title="r2", collection_id=col.id, status="approved", capture_mode="single")
+    r3 = Record(title="r3", collection_id=col.id, status="in_review", capture_mode="single")
     db_session.add_all([r1, r2, r3])
     db_session.commit()
     for r in (r1, r2, r3):

--- a/tests/unit/test_collections_order_count_export_detail.py
+++ b/tests/unit/test_collections_order_count_export_detail.py
@@ -273,3 +273,27 @@ def test_export_non_approved_records_returns_structured_422(contributor_client, 
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+@pytest.mark.unit
+def test_export_blocks_approved_record_with_no_image(contributor_client, db_session):
+    from app.models.project import Project
+    from app.models.collection import Collection
+    from app.models.record import Record, RecordImage
+
+    proj = Project(name="P"); db_session.add(proj); db_session.commit()
+    col = Collection(name="C", project_id=proj.id); db_session.add(col); db_session.commit()
+
+    r_ok = Record(title="ok", collection_id=col.id, status="approved", capture_mode="single")
+    r_empty = Record(title="empty", collection_id=col.id, status="approved", capture_mode="single")
+    db_session.add_all([r_ok, r_empty]); db_session.commit()
+    db_session.refresh(r_ok); db_session.refresh(r_empty)
+    db_session.add(RecordImage(record_id=r_ok.id, filename="x.jpg", file_path="/x.jpg",
+                               format="jpg", role="single", is_current=True))
+    db_session.commit()
+
+    resp = contributor_client.post(f"/collections/{col.id}/export")
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert r_empty.id in detail["blocking_record_ids"]
+    assert r_ok.id not in detail["blocking_record_ids"]

--- a/tests/unit/test_database_password_guard.py
+++ b/tests/unit/test_database_password_guard.py
@@ -1,0 +1,33 @@
+"""Guard against booting outside dev with a placeholder DATABASE_PASSWORD"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.config import _guard_database_password
+
+
+def _cfg(app_env: str, db_password: str) -> SimpleNamespace:
+    """Minimal stand-in for Settings with just the fields the guard reads."""
+    return SimpleNamespace(APP_ENV=app_env, DATABASE_PASSWORD=db_password)
+
+
+@pytest.mark.parametrize("app_env", ["dev", "development", "test", "testing", "local", "DEV"])
+def test_dev_environments_allow_placeholder(app_env):
+    # Dev must keep booting on the shipped placeholder so nothing needs configuring locally
+    _guard_database_password(_cfg(app_env, "password"))
+
+
+@pytest.mark.parametrize("bad_pw", ["", "   ", "password", "change-this-in-production"])
+def test_production_rejects_placeholder_or_empty(bad_pw):
+    with pytest.raises(RuntimeError):
+        _guard_database_password(_cfg("production", bad_pw))
+
+
+def test_unknown_environment_is_treated_as_production():
+    with pytest.raises(RuntimeError):
+        _guard_database_password(_cfg("staging", "password"))
+
+
+def test_production_with_strong_password_boots():
+    _guard_database_password(_cfg("production", "b2d84605f1c9a7e3b5d02f18a3f9c1e7"))

--- a/tests/unit/test_delete_user_guards.py
+++ b/tests/unit/test_delete_user_guards.py
@@ -1,0 +1,62 @@
+"""Critical NEH-57 guards on DELETE /auth/users/{id}: no self-delete, no
+last-active-admin delete (both would strand a headless unit), and an audit trail."""
+
+import pytest
+
+
+def _make_user(db_session, username, role, is_active=True):
+    from app.models.user import User
+    from app.core.security import hash_password
+    u = User(username=username, email=f"{username}@example.com",
+             hashed_password=hash_password("x"), role=role, is_active=is_active)
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture
+def admin_client(client, db_session):
+    """TestClient authenticated as a real admin row, with a second admin present
+    so ordinary deletions aren't blocked by the last-admin guard."""
+    from app.main import app
+    from app.api.auth import get_current_user
+    admin = _make_user(db_session, "admin_caller", "admin")
+    _make_user(db_session, "admin_other", "admin")
+    app.dependency_overrides[get_current_user] = lambda: admin
+    yield client, admin
+    # the `client` fixture clears dependency_overrides on teardown
+
+
+def test_admin_cannot_delete_self(admin_client):
+    client, admin = admin_client
+    resp = client.delete(f"/auth/users/{admin.id}")
+    assert resp.status_code == 400
+    assert "own account" in resp.json()["detail"]
+
+
+def test_delete_user_writes_audit_entry(admin_client, db_session):
+    from app.models.system_log import SystemLog
+    client, _ = admin_client
+    victim = _make_user(db_session, "victim", "reviewer")
+    assert client.delete(f"/auth/users/{victim.id}").status_code == 200
+    logged = db_session.query(SystemLog).filter(
+        SystemLog.action == "user_deleted", SystemLog.subject == "victim"
+    ).first()
+    assert logged is not None
+
+
+def test_cannot_delete_last_active_admin(client, db_session):
+    # Exactly one active admin in the DB; the caller is a stand-in admin that is
+    # not persisted, so the DB holds no *other* active admin — this exercises the
+    # last-admin guard's count without the self-guard short-circuiting first.
+    from app.main import app
+    from app.api.auth import get_current_user
+    from app.models.user import User
+    sole_admin = _make_user(db_session, "sole_admin", "admin")
+    caller = User(id=99999, username="ghost_admin", email="g@example.com",
+                  hashed_password="x", role="admin", is_active=True)
+    app.dependency_overrides[get_current_user] = lambda: caller
+    resp = client.delete(f"/auth/users/{sole_admin.id}")
+    assert resp.status_code == 400
+    assert "last active admin" in resp.json()["detail"]

--- a/tests/unit/test_export_integrity.py
+++ b/tests/unit/test_export_integrity.py
@@ -1,0 +1,78 @@
+"""Export refuses to produce a misleading bag: a missing source file or a file
+whose bytes no longer match its capture-time checksum both hard-fail the export."""
+
+import json
+
+import pytest
+
+
+def _contributor():
+    from app.models.user import User
+    return User(username="op", email="op@example.com",
+                hashed_password="x", role="operator", is_active=True)
+
+
+@pytest.fixture
+def export_client(client, db_session):
+    from app.main import app
+    import app.api.collections as collections
+    app.dependency_overrides[collections.allow_read_only] = lambda: _contributor()
+    yield client
+
+
+def _approved_collection(db_session):
+    from app.models.project import Project
+    from app.models.collection import Collection
+    from app.models.record import Record
+    proj = Project(name="P")
+    db_session.add(proj)
+    db_session.commit()
+    col = Collection(name="C", project_id=proj.id)
+    db_session.add(col)
+    db_session.commit()
+    rec = Record(title="r", collection_id=col.id, status="approved", capture_mode="single")
+    db_session.add(rec)
+    db_session.commit()
+    db_session.refresh(rec)
+    return col, rec
+
+
+def test_export_rejects_missing_source_file(export_client, db_session):
+    from app.models.record import RecordImage
+    col, rec = _approved_collection(db_session)
+    img = RecordImage(record_id=rec.id, filename="x.jpg", file_path="/nowhere/x.jpg",
+                      format="jpg", role="single", is_current=True)
+    db_session.add(img)
+    db_session.commit()
+    db_session.refresh(img)
+
+    resp = export_client.post(f"/collections/{col.id}/export")
+    assert resp.status_code == 422, resp.text
+    assert img.id in resp.json()["detail"]["missing_image_ids"]
+
+
+def test_export_rejects_file_that_fails_capture_time_checksum(export_client, db_session, override_projects_root):
+    from app.models.record import RecordImage
+    projects_dir = override_projects_root
+    proj_root = projects_dir / "P"
+    (proj_root / "images").mkdir(parents=True)
+    img_file = proj_root / "images" / "cap.jpg"
+    img_file.write_bytes(b"the real captured bytes")
+    (proj_root / "metadata").mkdir(parents=True)
+    (proj_root / "metadata" / "manifest.jsonl").write_text(
+        json.dumps({"capture_id": "cid1", "files": [
+            {"role": "single", "relative_path": "images/cap.jpg", "sha256": "0" * 64}
+        ]}) + "\n",
+        encoding="utf-8",
+    )
+
+    col, rec = _approved_collection(db_session)
+    img = RecordImage(record_id=rec.id, filename="cap.jpg", file_path=str(img_file),
+                      format="jpg", role="single", capture_id="cid1", is_current=True)
+    db_session.add(img)
+    db_session.commit()
+    db_session.refresh(img)
+
+    resp = export_client.post(f"/collections/{col.id}/export")
+    assert resp.status_code == 422, resp.text
+    assert img.id in resp.json()["detail"]["mismatched_image_ids"]

--- a/tests/unit/test_export_integrity.py
+++ b/tests/unit/test_export_integrity.py
@@ -1,7 +1,9 @@
 """Export refuses to produce a misleading bag: a missing source file or a file
-whose bytes no longer match its capture-time checksum both hard-fail the export."""
+whose bytes no longer match its capture-time checksum both fail the export. 
+The export runs as a background job, so these surface as a failed job with detail."""
 
 import json
+import time
 
 import pytest
 
@@ -37,6 +39,18 @@ def _approved_collection(db_session):
     return col, rec
 
 
+def _run_to_completion(client, collection_id, job_id, timeout=15.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        r = client.get(f"/collections/{collection_id}/export/status/{job_id}")
+        assert r.status_code == 200, r.text
+        st = r.json()
+        if st["state"] in ("done", "failed"):
+            return st
+        time.sleep(0.05)
+    raise AssertionError("export job did not finish in time")
+
+
 def test_export_rejects_missing_source_file(export_client, db_session):
     from app.models.record import RecordImage
     col, rec = _approved_collection(db_session)
@@ -47,8 +61,11 @@ def test_export_rejects_missing_source_file(export_client, db_session):
     db_session.refresh(img)
 
     resp = export_client.post(f"/collections/{col.id}/export")
-    assert resp.status_code == 422, resp.text
-    assert img.id in resp.json()["detail"]["missing_image_ids"]
+    assert resp.status_code == 202, resp.text
+    st = _run_to_completion(export_client, col.id, resp.json()["job_id"])
+    assert st["state"] == "failed"
+    assert st["detail"]["reason"] == "missing_files"
+    assert img.id in st["detail"]["missing_image_ids"]
 
 
 def test_export_rejects_file_that_fails_capture_time_checksum(export_client, db_session, override_projects_root):
@@ -74,5 +91,67 @@ def test_export_rejects_file_that_fails_capture_time_checksum(export_client, db_
     db_session.refresh(img)
 
     resp = export_client.post(f"/collections/{col.id}/export")
-    assert resp.status_code == 422, resp.text
-    assert img.id in resp.json()["detail"]["mismatched_image_ids"]
+    assert resp.status_code == 202, resp.text
+    st = _run_to_completion(export_client, col.id, resp.json()["job_id"])
+    assert st["state"] == "failed"
+    assert st["detail"]["reason"] == "checksum_mismatch"
+    assert img.id in st["detail"]["mismatched_image_ids"]
+
+
+def test_export_produces_valid_bag_with_manifest(export_client, db_session, override_projects_root, monkeypatch, tmp_path):
+    import hashlib, zipfile, bagit
+    from app.core import config
+    from app.models.record import RecordImage
+
+    exports = tmp_path / "exp"
+    exports.mkdir()
+    monkeypatch.setattr(config.settings, "EXPORTS_ROOT", str(exports))
+
+    proot = override_projects_root / "P"
+    (proot / "images").mkdir(parents=True)
+    (proot / "metadata").mkdir(parents=True)
+    f = proot / "images" / "cap.jpg"
+    f.write_bytes(b"captured bytes here")
+    sha = hashlib.sha256(b"captured bytes here").hexdigest()
+    (proot / "metadata" / "manifest.jsonl").write_text(
+        json.dumps({"capture_id": "cid1", "files": [
+            {"role": "single", "relative_path": "images/cap.jpg", "sha256": sha}]}) + "\n")
+
+    col, rec = _approved_collection(db_session)
+    db_session.add(RecordImage(record_id=rec.id, filename="cap.jpg", file_path=str(f),
+                               format="jpg", role="single", capture_id="cid1", is_current=True))
+    db_session.commit()
+
+    resp = export_client.post(f"/collections/{col.id}/export")
+    assert resp.status_code == 202, resp.text
+    st = _run_to_completion(export_client, col.id, resp.json()["job_id"])
+    assert st["state"] == "done", st
+    assert "download_url" in st
+
+    zname = st["zip_filename"]
+    zpath = exports / zname
+    ext = tmp_path / "ext"
+    with zipfile.ZipFile(zpath) as zf:
+        names = zf.namelist()
+        zf.extractall(ext)
+    assert any(n.endswith("data/metadata/manifest.jsonl") for n in names), names
+    # The manually built archive validates as a real BagIt bag.
+    bagit.Bag(str(ext / zname[:-4])).validate()
+
+
+def test_prune_exports_keeps_newest(tmp_path):
+    from app.core.export_service import _prune_exports
+    import time as _t
+    for i in range(5):
+        (tmp_path / f"collection_7_2026010{i}T000000Z.zip").write_bytes(b"z")
+        _t.sleep(0.01)
+    (tmp_path / "collection_7_20260109T000000Z.zip.part").write_bytes(b"partial")
+    _prune_exports(tmp_path, 7, keep=3)
+    remaining = sorted(p.name for p in tmp_path.glob("collection_7_*.zip"))
+    assert len(remaining) == 3
+    # newest kept
+    assert remaining == ["collection_7_20260102T000000Z.zip",
+                         "collection_7_20260103T000000Z.zip",
+                         "collection_7_20260104T000000Z.zip"]
+    # stale .part cleaned
+    assert list(tmp_path.glob("*.part")) == []

--- a/tests/unit/test_integrity_error_sanitization.py
+++ b/tests/unit/test_integrity_error_sanitization.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Constraint-violation responses must never echo SQL or bound parameters.
+
+Guards the sanitized 409 helper and the schema-level single-parent rule that
+keeps a record's project/collection conflict from reaching the database at all.
+"""
+import pytest
+from sqlalchemy.exc import IntegrityError
+from pydantic import ValidationError
+
+from app.core.db_errors import integrity_conflict, constraint_name
+from app.schemas.record import RecordCreate
+
+
+class _SqliteOrig(Exception):
+    def __str__(self):
+        return "CHECK constraint failed: check_record_single_parent"
+
+
+def _integrity_error():
+    return IntegrityError(
+        "INSERT INTO records (project_id, collection_id) VALUES (?, ?)",
+        [1, 2],
+        _SqliteOrig(),
+    )
+
+
+@pytest.mark.unit
+def test_integrity_conflict_never_leaks_sql_or_params():
+    exc = integrity_conflict(_integrity_error())
+    assert exc.status_code == 409
+    body = str(exc.detail)
+    assert "INSERT" not in body
+    assert "VALUES" not in body
+    assert "records" not in body
+
+
+@pytest.mark.unit
+def test_integrity_conflict_reports_constraint_name():
+    exc = integrity_conflict(_integrity_error())
+    assert exc.detail["constraint"] == "check_record_single_parent"
+    assert constraint_name(_integrity_error()) == "check_record_single_parent"
+
+
+@pytest.mark.unit
+def test_sqlite_unique_message_maps_to_canonical_name():
+    class _UniqueOrig(Exception):
+        def __str__(self):
+            return "UNIQUE constraint failed: camera_settings.record_image_id"
+
+    exc = integrity_conflict(IntegrityError("INSERT ...", [1], _UniqueOrig()))
+    assert exc.status_code == 409
+    assert exc.detail["constraint"] == "camera_settings_record_image_id_key"
+    assert "INSERT" not in str(exc.detail)
+
+
+@pytest.mark.unit
+def test_record_create_rejects_two_parents_before_db():
+    with pytest.raises(ValidationError):
+        RecordCreate(title="x", capture_mode="single", project_id=1, collection_id=2)

--- a/tests/unit/test_integrity_hash_sampling.py
+++ b/tests/unit/test_integrity_hash_sampling.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""The integrity check's hash verification must be bounded by default.
+
+A full sweep re-hashes every stored image, which is I/O-punishing on a unit
+holding tens of thousands of captures. run_integrity_check must hash only a
+bounded (random) sample when max_hash_checks is set, and everything eligible
+only when it is None (the explicit full-sweep opt-in).
+"""
+import hashlib
+import json
+
+import pytest
+
+from app.core.integrity import run_integrity_check
+from app.models.project import Project
+from app.models.record import Record, RecordImage
+
+
+def _seed_captures(db_session, projects_dir, n):
+    proj_dir = projects_dir / "proj"
+    (proj_dir / "images").mkdir(parents=True, exist_ok=True)
+    (proj_dir / "metadata").mkdir(parents=True, exist_ok=True)
+
+    project = Project(name="proj")
+    db_session.add(project)
+    db_session.commit()
+    record = Record(title="r", project_id=project.id, status="in_review", capture_mode="single")
+    db_session.add(record)
+    db_session.commit()
+
+    manifest_lines = []
+    for i in range(n):
+        rel = f"images/img_{i}.jpg"
+        fpath = proj_dir / rel
+        fpath.write_bytes(f"data-{i}".encode())
+        sha = hashlib.sha256(fpath.read_bytes()).hexdigest()
+        manifest_lines.append(json.dumps({
+            "capture_id": f"c{i}",
+            "files": [{"sha256": sha, "relative_path": rel}],
+        }))
+        db_session.add(RecordImage(
+            record_id=record.id,
+            filename=f"img_{i}.jpg",
+            file_path=str(fpath),
+            capture_id=f"c{i}",
+            format="jpg",
+            file_size=1,
+        ))
+    (proj_dir / "metadata" / "manifest.jsonl").write_text("\n".join(manifest_lines), encoding="utf-8")
+    db_session.commit()
+
+
+@pytest.mark.unit
+def test_hash_check_is_bounded_and_sampled(db_session, override_projects_root):
+    _seed_captures(db_session, override_projects_root, n=8)
+
+    report = run_integrity_check(db_session, verify_hashes=True, max_hash_checks=3)
+    summary = report["summary"]
+
+    assert summary["hashes_eligible"] == 8
+    assert summary["hashes_checked"] == 3
+    assert summary["hash_sampled"] is True
+
+
+@pytest.mark.unit
+def test_full_sweep_hashes_everything(db_session, override_projects_root):
+    _seed_captures(db_session, override_projects_root, n=8)
+
+    report = run_integrity_check(db_session, verify_hashes=True, max_hash_checks=None)
+    summary = report["summary"]
+
+    assert summary["hashes_eligible"] == 8
+    assert summary["hashes_checked"] == 8
+    assert summary["hash_sampled"] is False

--- a/tests/unit/test_login_throttle.py
+++ b/tests/unit/test_login_throttle.py
@@ -1,0 +1,55 @@
+"""Login throttle: lockout after repeated failures, reset on success, and that the /auth/login endpoint is actually wired to it."""
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 1000.0
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, seconds):
+        self.t += seconds
+
+
+def test_locks_after_max_failures_then_unlocks_after_timeout():
+    from app.core.login_throttle import LoginThrottle
+    clk = FakeClock()
+    th = LoginThrottle(max_failures=3, lockout_seconds=60, window_seconds=300, clock=clk)
+    key = "user:alice"
+    assert th.retry_after(key) == 0
+    for _ in range(3):
+        th.record_failure(key)
+    assert 0 < th.retry_after(key) <= 60
+    clk.advance(61)
+    assert th.retry_after(key) == 0
+
+
+def test_reset_clears_lockout():
+    from app.core.login_throttle import LoginThrottle
+    clk = FakeClock()
+    th = LoginThrottle(max_failures=2, lockout_seconds=60, clock=clk)
+    key = "ip:1.2.3.4"
+    th.record_failure(key)
+    th.record_failure(key)
+    assert th.retry_after(key) > 0
+    th.reset(key)
+    assert th.retry_after(key) == 0
+
+
+def test_login_endpoint_returns_429_after_repeated_failures(client, db_session, monkeypatch):
+    import app.api.auth as auth_mod
+    from app.core.login_throttle import LoginThrottle
+    from app.models.user import User
+    from app.core.security import hash_password
+
+    monkeypatch.setattr(auth_mod, "login_throttle", LoginThrottle(max_failures=3, lockout_seconds=60))
+    db_session.add(User(username="alice", email="a@example.com",
+                        hashed_password=hash_password("rightpw"), role="admin", is_active=True))
+    db_session.commit()
+
+    for _ in range(3):
+        assert client.post("/auth/login", json={"username": "alice", "password": "wrong"}).status_code == 401
+    resp = client.post("/auth/login", json={"username": "alice", "password": "wrong"})
+    assert resp.status_code == 429
+    assert "Retry-After" in resp.headers

--- a/tests/unit/test_password_hash_upgrade.py
+++ b/tests/unit/test_password_hash_upgrade.py
@@ -1,0 +1,28 @@
+"""PBKDF2 hashing: new-format + legacy verify, and rehash-on-upgrade detection."""
+
+from app.core.security import (
+    hash_password, verify_password, needs_rehash, _pbkdf2, _LEGACY_ITERATIONS,
+)
+
+
+def test_new_hash_roundtrip():
+    h = hash_password("correct horse")
+    assert verify_password("correct horse", h)
+    assert not verify_password("wrong", h)
+    assert not needs_rehash(h)
+
+
+def test_legacy_hash_verifies_and_flags_rehash():
+    # Reconstruct an original-format hash: "salt$hash" at the old 100k iterations.
+    salt = "a" * 32
+    legacy = f"{salt}${_pbkdf2('pw', salt, _LEGACY_ITERATIONS)}"
+    assert verify_password("pw", legacy)
+    assert not verify_password("nope", legacy)
+    assert needs_rehash(legacy)
+
+
+def test_lower_iteration_new_format_flags_rehash():
+    salt = "b" * 32
+    weak = f"pbkdf2_sha256$1000${salt}${_pbkdf2('pw', salt, 1000)}"
+    assert verify_password("pw", weak)
+    assert needs_rehash(weak)

--- a/tests/unit/test_project_rename_recovery.py
+++ b/tests/unit/test_project_rename_recovery.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Crash-safe recovery for an interrupted project rename.
+
+Power loss is this appliance's defining failure mode, so a rename that moves the
+on-disk tree and then commits new paths must survive a crash between the two
+steps without leaving records dangling. reconcile_pending_rename replays or
+discards the intent journal at startup; these tests cover its three branches.
+"""
+import pytest
+
+import app.core.storage_ops as so
+from app.models.project import Project
+from app.models.record import Record, RecordImage
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    """Point the journal at a writable temp data dir (default /var/lib/dtk is not writable in tests)."""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "DTK_DATA_DIR", str(tmp_path / "data"))
+    return tmp_path
+
+
+def _add_project(db, name):
+    p = Project(name=name)
+    db.add(p)
+    db.commit()
+    return p
+
+
+def _add_image(db, record_id, path):
+    img = RecordImage(
+        record_id=record_id,
+        filename=path.name,
+        file_path=str(path),
+        thumbnail_path=str(path.with_suffix(".thumb.jpg")),
+        capture_id="c1",
+        format="jpg",
+        file_size=1,
+    )
+    db.add(img)
+    db.commit()
+    return img
+
+
+@pytest.mark.unit
+def test_reconcile_finishes_db_when_files_already_moved(db_session, data_dir):
+    """Crash after the FS move but before the commit: DB still old, files at new_root -> finish the DB side."""
+    root = data_dir / "projects"
+    old_root, new_root = root / "old", root / "new"
+    new_root.mkdir(parents=True)
+    (new_root / "img.jpg").write_text("x")
+
+    p = _add_project(db_session, "old")
+    rec = Record(title="r", project_id=p.id, status="in_review", capture_mode="single")
+    db_session.add(rec)
+    db_session.commit()
+    _add_image(db_session, rec.id, old_root / "img.jpg")
+
+    so.write_rename_journal(p.id, "old", "new", old_root, new_root)
+    so.reconcile_pending_rename(db_session)
+
+    db_session.refresh(p)
+    img = db_session.query(RecordImage).first()
+    assert p.name == "new"
+    assert img.file_path == str(new_root / "img.jpg")
+    assert so.read_rename_journal() is None
+
+
+@pytest.mark.unit
+def test_reconcile_aborts_when_move_never_happened(db_session, data_dir):
+    """Crash before the FS move: DB and disk are both still old -> discard the journal, change nothing."""
+    root = data_dir / "projects"
+    old_root, new_root = root / "p", root / "p_ren"
+    old_root.mkdir(parents=True)
+
+    p = _add_project(db_session, "p")
+    so.write_rename_journal(p.id, "p", "p_ren", old_root, new_root)
+    so.reconcile_pending_rename(db_session)
+
+    db_session.refresh(p)
+    assert p.name == "p"
+    assert so.read_rename_journal() is None
+
+
+@pytest.mark.unit
+def test_reconcile_completes_move_when_db_already_renamed(db_session, data_dir):
+    """Crash after the commit but before clearing the journal: DB new, files still old -> finish the FS move."""
+    root = data_dir / "projects"
+    old_root, new_root = root / "old2", root / "new2"
+    old_root.mkdir(parents=True)
+    (old_root / "f").write_text("y")
+
+    p = _add_project(db_session, "new2")
+    so.write_rename_journal(p.id, "old2", "new2", old_root, new_root)
+    so.reconcile_pending_rename(db_session)
+
+    assert new_root.exists() and not old_root.exists()
+    assert so.read_rename_journal() is None

--- a/tests/unit/test_record_reject_endpoint.py
+++ b/tests/unit/test_record_reject_endpoint.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Tests for POST /records/{id}/reject and GET /records/{id}/rejections (NEH-208).
+
+Rejection requires a mandatory predefined_reason from a fixed 6-value list,
+plus an optional free-text comment; it's only valid from 'in_review'; and
+only reviewer/admin may perform it.
+Run with: python -m pytest tests/unit/test_record_reject_endpoint.py
+"""
+
+import pytest
+
+
+def _user(username, role):
+    from app.models.user import User
+    return User(username=username, email=f"{username}@example.com",
+                hashed_password="x", role=role, is_active=True)
+
+
+def _client_as(client, username, role):
+    from app.main import app
+    from app.api.auth import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: _user(username, role)
+    return client
+
+
+def _make_record(db_session, status="in_review", capture_mode="single"):
+    from app.models.record import Record
+
+    rec = Record(title="r", status=status, capture_mode=capture_mode)
+    db_session.add(rec)
+    db_session.commit()
+    db_session.refresh(rec)
+    return rec
+
+
+@pytest.mark.unit
+def test_reject_requires_predefined_reason(client, db_session):
+    rec = _make_record(db_session)
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.post(f"/records/{rec.id}/reject", json={})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.unit
+def test_reject_rejects_unknown_reason(client, db_session):
+    rec = _make_record(db_session)
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "bogus"})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.unit
+def test_reject_accepts_valid_reason_and_optional_comment(client, db_session):
+    rec = _make_record(db_session)
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "blur", "comment": "too fuzzy"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "rejected"
+
+
+@pytest.mark.unit
+def test_reject_only_valid_from_in_review(client, db_session):
+    rec = _make_record(db_session, status="approved")
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "blur"})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.unit
+def test_operator_cannot_reject(client, db_session):
+    rec = _make_record(db_session)
+    api = _client_as(client, "op", "operator")
+
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "blur"})
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.unit
+def test_rejection_appears_in_rejections_history_and_image_drops_from_images_list(client, db_session):
+    from app.models.record import RecordImage
+
+    rec = _make_record(db_session)
+    img = RecordImage(record_id=rec.id, filename="a.jpg", file_path="/tmp/a.jpg", format="jpg")
+    db_session.add(img)
+    db_session.commit()
+
+    api = _client_as(client, "rev", "reviewer")
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "glare", "comment": "window reflection"})
+    assert resp.status_code == 200, resp.text
+
+    resp = api.get(f"/records/{rec.id}/rejections")
+    assert resp.status_code == 200, resp.text
+    rejections = resp.json()
+    assert len(rejections) == 1
+    assert rejections[0]["predefined_reason"] == "glare"
+    assert rejections[0]["comment"] == "window reflection"
+    assert [i["id"] for i in rejections[0]["images"]] == [img.id]
+
+    # The rejected image is still "current" until a recapture supersedes it,
+    # so it still appears in the default images listing.
+    resp = api.get(f"/records/{rec.id}/images")
+    assert resp.status_code == 200, resp.text
+    assert [i["id"] for i in resp.json()] == [img.id]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_record_status_transitions.py
+++ b/tests/unit/test_record_status_transitions.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Tests for NEH-208's narrowed status state machine.
+
+Only in_review -> approved remains reachable through PATCH /{id}/status and
+POST /records/bulk-status. Rejection has its own endpoint (see
+test_record_reject_endpoint.py); approved is terminal; "captured" is not a
+valid status anywhere anymore.
+Run with: python -m pytest tests/unit/test_record_status_transitions.py
+"""
+
+import pytest
+
+
+def _user(username, role):
+    from app.models.user import User
+    return User(username=username, email=f"{username}@example.com",
+                hashed_password="x", role=role, is_active=True)
+
+
+def _client_as(client, username, role):
+    from app.main import app
+    from app.api.auth import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: _user(username, role)
+    return client
+
+
+def _make_record(db_session, status="in_review", capture_mode="single"):
+    from app.models.record import Record
+
+    rec = Record(title="r", status=status, capture_mode=capture_mode)
+    db_session.add(rec)
+    db_session.commit()
+    db_session.refresh(rec)
+    return rec
+
+
+@pytest.mark.unit
+def test_in_review_to_approved_allowed_for_reviewer(client, db_session):
+    rec = _make_record(db_session, status="in_review")
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.patch(f"/records/{rec.id}/status", json={"status": "approved"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "approved"
+
+
+@pytest.mark.unit
+def test_in_review_to_approved_forbidden_for_operator(client, db_session):
+    rec = _make_record(db_session, status="in_review")
+    api = _client_as(client, "op", "operator")
+
+    resp = api.patch(f"/records/{rec.id}/status", json={"status": "approved"})
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.unit
+def test_approved_to_rejected_no_longer_allowed(client, db_session):
+    """approved is terminal (NEH-208) — the old 'flag for rework' walk-back is gone."""
+    rec = _make_record(db_session, status="approved")
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.patch(f"/records/{rec.id}/status", json={"status": "rejected"})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.unit
+def test_rejected_is_not_reachable_via_generic_status_endpoint(client, db_session):
+    """Rejection must go through POST /{id}/reject with a mandatory reason, not this endpoint."""
+    rec = _make_record(db_session, status="in_review")
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.patch(f"/records/{rec.id}/status", json={"status": "rejected"})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.unit
+def test_captured_is_not_a_valid_status_value(client, db_session):
+    rec = _make_record(db_session, status="in_review")
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.patch(f"/records/{rec.id}/status", json={"status": "captured"})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.unit
+def test_bulk_status_update_skips_invalid_transitions_and_updates_valid_ones(client, db_session):
+    rec_ok = _make_record(db_session, status="in_review")
+    rec_blocked = _make_record(db_session, status="rejected")
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.post("/records/bulk-status", json={
+        "record_ids": [rec_ok.id, rec_blocked.id],
+        "status": "approved",
+    })
+    assert resp.status_code == 200, resp.text
+    updated_ids = {r["id"] for r in resp.json()}
+    assert rec_ok.id in updated_ids
+    assert rec_blocked.id not in updated_ids
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_rejection_scope_resolution.py
+++ b/tests/unit/test_rejection_scope_resolution.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Tests for NEH-208 rejection scope: a dual-mode record's rejection must flag
+BOTH images (a dual-camera pair can only ever be redone together), while a
+single-mode record's rejection flags exactly the one image.
+Run with: python -m pytest tests/unit/test_rejection_scope_resolution.py
+"""
+
+import pytest
+
+
+def _user(username, role):
+    from app.models.user import User
+    return User(username=username, email=f"{username}@example.com",
+                hashed_password="x", role=role, is_active=True)
+
+
+def _client_as(client, username, role):
+    from app.main import app
+    from app.api.auth import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: _user(username, role)
+    return client
+
+
+@pytest.mark.unit
+def test_dual_mode_rejection_flags_both_images(client, db_session):
+    from app.models.record import Record, RecordImage
+
+    rec = Record(title="r", status="in_review", capture_mode="dual")
+    db_session.add(rec)
+    db_session.commit()
+
+    left = RecordImage(record_id=rec.id, filename="l.jpg", file_path="/tmp/l.jpg", format="jpg",
+                        role="left", pair_id="p1")
+    right = RecordImage(record_id=rec.id, filename="r.jpg", file_path="/tmp/r.jpg", format="jpg",
+                         role="right", pair_id="p1")
+    db_session.add_all([left, right])
+    db_session.commit()
+
+    api = _client_as(client, "rev", "reviewer")
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "shadow"})
+    assert resp.status_code == 200, resp.text
+
+    resp = api.get(f"/records/{rec.id}/rejections")
+    assert resp.status_code == 200, resp.text
+    rejections = resp.json()
+    assert len(rejections) == 1
+    flagged_ids = {i["id"] for i in rejections[0]["images"]}
+    assert flagged_ids == {left.id, right.id}
+
+
+@pytest.mark.unit
+def test_single_mode_rejection_flags_exactly_one_image(client, db_session):
+    from app.models.record import Record, RecordImage
+
+    rec = Record(title="r", status="in_review", capture_mode="single")
+    db_session.add(rec)
+    db_session.commit()
+
+    img = RecordImage(record_id=rec.id, filename="a.jpg", file_path="/tmp/a.jpg", format="jpg", role="single")
+    db_session.add(img)
+    db_session.commit()
+
+    api = _client_as(client, "rev", "reviewer")
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "focus"})
+    assert resp.status_code == 200, resp.text
+
+    resp = api.get(f"/records/{rec.id}/rejections")
+    assert resp.status_code == 200, resp.text
+    rejections = resp.json()
+    assert len(rejections) == 1
+    assert [i["id"] for i in rejections[0]["images"]] == [img.id]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_schema_constraints.py
+++ b/tests/unit/test_schema_constraints.py
@@ -91,7 +91,7 @@ def test_second_exif_data_row_for_same_record_image_raises_integrity_error(db_se
     db_session.add(proj)
     db_session.commit()
 
-    rec = Record(title="r", project_id=proj.id)
+    rec = Record(title="r", project_id=proj.id, capture_mode="single")
     db_session.add(rec)
     db_session.commit()
 
@@ -134,7 +134,7 @@ def test_valid_rows_commit_fine(db_session):
 
     pm = ProjectMember(project_id=proj.id, user_id=user.id, role="operator")
     log = SystemLog(level="ERR", category="capture", action="capture_failed")
-    rec = Record(title="r", project_id=proj.id, status="approved")
+    rec = Record(title="r", project_id=proj.id, status="approved", capture_mode="single")
     db_session.add_all([pm, log, rec])
     db_session.commit()
 

--- a/tests/unit/test_secret_key_guard.py
+++ b/tests/unit/test_secret_key_guard.py
@@ -18,7 +18,7 @@ def test_dev_environments_allow_default_key(app_env):
     _guard_secret_key(_cfg(app_env, "dev-secret-change-me"))
 
 
-@pytest.mark.parametrize("bad_key", ["", "   ", "dev-secret-change-me", "your-secret-key-here-change-in-production"])
+@pytest.mark.parametrize("bad_key", ["", "   ", "dev-secret-change-me", "secret-key-here-change-in-production"])
 def test_production_rejects_default_or_empty_key(bad_key):
     with pytest.raises(RuntimeError):
         _guard_secret_key(_cfg("production", bad_key))

--- a/tests/unit/test_secret_key_guard.py
+++ b/tests/unit/test_secret_key_guard.py
@@ -1,0 +1,33 @@
+"""Guard against booting outside dev with a default/empty SECRET_KEY (NEH-54)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.config import _guard_secret_key
+
+
+def _cfg(app_env: str, secret_key: str) -> SimpleNamespace:
+    """Minimal stand-in for Settings with just the fields the guard reads."""
+    return SimpleNamespace(APP_ENV=app_env, SECRET_KEY=secret_key)
+
+
+@pytest.mark.parametrize("app_env", ["dev", "development", "test", "testing", "local", "DEV"])
+def test_dev_environments_allow_default_key(app_env):
+    # Dev must keep booting on the shipped default so nothing needs configuring locally.
+    _guard_secret_key(_cfg(app_env, "dev-secret-change-me"))
+
+
+@pytest.mark.parametrize("bad_key", ["", "   ", "dev-secret-change-me", "your-secret-key-here-change-in-production"])
+def test_production_rejects_default_or_empty_key(bad_key):
+    with pytest.raises(RuntimeError):
+        _guard_secret_key(_cfg("production", bad_key))
+
+
+def test_unknown_environment_is_treated_as_production():
+    with pytest.raises(RuntimeError):
+        _guard_secret_key(_cfg("staging", "dev-secret-change-me"))
+
+
+def test_production_with_strong_key_boots():
+    _guard_secret_key(_cfg("production", "a3f9c1e7b2d84605f1c9a7e3b5d02f18"))


### PR DESCRIPTION
## Summary

Completes and ships the **NEH-32 Authentication & secrets (backend)** epic, addressing the authentication, authorization, and secret-handling vulnerabilities exposed on the untrusted venue LAN during the Rionegro deployment. All nine sub-issues are resolved on `dev`; this PR promotes them to `main`.

## What's included (NEH-32)

**Secrets & production guards**
- **NEH-54:** Fail fast on a default/empty `SECRET_KEY` outside development (import-time guard; `APP_ENV` wired into settings).
- **NEH-55:** Fail fast on a placeholder `DATABASE_PASSWORD` outside development.
- **NEH-56:** Protect first-user admin bootstrap with a per-unit `BOOTSTRAP_TOKEN` (available only through local access); development keeps the tokenless flow.

**Authorization & account safety**
- **NEH-52:** Closes authenticated arbitrary file read (LFI) via client-controlled `thumbnail_path`.
- **NEH-53:** `get_current_user` rejects deactivated users, revoking access on the next request.
- **NEH-57:** `delete_user` prevents self-deletion and deletion of the last active admin, records a `user_deleted` audit event, and moves to `DELETE /auth/users/{id}`.

**Brute force & transport**
- **NEH-58:** Adds per-account/per-IP login throttling, raises PBKDF2 from 100k to 600k iterations with self-describing hashes, and upgrades weaker hashes on login.
- **NEH-59:** Removes Private Network Access preflight support and restricts `allow_methods`/`allow_headers`.
- **NEH-128:** Closes authenticated path traversal via an unsanitized `project_name` in the manifest path.


## Deployment / on-device acceptance

Before promoting to production, validate on real hardware:

- Provisioning generates per-unit `SECRET_KEY`, `DATABASE_PASSWORD`, and `BOOTSTRAP_TOKEN` at first boot and writes them to `.env` (via the companion superproject PR).
- Units run with `APP_ENV=production`; otherwise production guards are not enforced.
- First-user setup succeeds using the device bootstrap token collected by the frontend `/setup` page.
- Two-card clone test: verify cloned images generate different secrets and the second boot is a no-op.
- Login: verify throttling triggers after repeated failures and PBKDF2 (600k iterations) keeps login latency acceptable on the Raspberry Pi.

## Companion PRs

- Superproject: first-boot `BOOTSTRAP_TOKEN` generation, `.env.example` updates, plus the submodule bump to this backend commit.

Closes **NEH-32** (including NEH-52, NEH-53, NEH-54, NEH-55, NEH-56, NEH-57, NEH-58, NEH-59, and NEH-128).

### Notes
The current information architecture (roles, dashboard navigation, auth flow) is documented in Notion, [ Information architecture document](https://app.notion.com/p/neogranadina/Arquitectura-de-la-informaci-n-19151a0e5ec580c786f5f3d946ad992e?v=17751a0e5ec5815ebe71000c37478625&source=copy_link) section Version 1.2 (July 2026).