### PR TITLE
feat(records): redesign review/rejection state machine (NEH-208)

### DIFF
--- a/alembic/versions/7e0b2c73bda1_add_capture_mode_and_rejection_audit.py
+++ b/alembic/versions/7e0b2c73bda1_add_capture_mode_and_rejection_audit.py
@@ -1,0 +1,100 @@
+"""add capture_mode and rejection audit trail (NEH-208)
+
+Revision ID: 7e0b2c73bda1
+Revises: f6a7b8c9d0e1
+Create Date: 2026-07-28 12:00:00.000000
+
+Part 1 of the NEH-208 review-workflow redesign. This migration:
+
+1. Creates `record_rejections`: one row per rejection event (mandatory
+   predefined_reason from the same 6-value list the annotation feature
+   already uses, optional free-text comment, who/when).
+2. Adds `record_images.is_current` / `superseded_at` / `rejection_id` so a
+   rejected image is never deleted or overwritten — it stays in place,
+   flagged as superseded once a recapture installs its replacement, and
+   stays linked to the rejection that flagged it.
+3. Adds `records.capture_mode` ("single" | "dual") and backfills it for
+   every existing record by inferring from its images: dual capture always
+   writes RecordImage.role in ('left','right') with a shared pair_id
+   (cameras.py), so any record with such images is 'dual'; everything else
+   (including records with zero images) is 'single'.
+4. Drops `records.rejection_note` — superseded by
+   record_rejections.predefined_reason/comment, which now carries this
+   information instead. Downgrade restores it empty (nullable); the text
+   itself is not recoverable, same as this repo's other lossy downgrades.
+
+The second half of the redesign (captured -> in_review data migration and
+narrowing the status CHECK constraint) is a separate migration
+(b2a1f9c4d3e6) chained after this one, so the judgment-call backfill here
+stays isolated from that mechanical rewrite.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7e0b2c73bda1'
+down_revision: Union[str, None] = 'f6a7b8c9d0e1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Rejection audit table.
+    op.create_table(
+        'record_rejections',
+        sa.Column('id', sa.Integer(), primary_key=True, index=True),
+        sa.Column('record_id', sa.Integer(), sa.ForeignKey('records.id', ondelete='CASCADE'), nullable=False, index=True),
+        sa.Column('predefined_reason', sa.String(length=20), nullable=False),
+        sa.Column('comment', sa.Text(), nullable=True),
+        sa.Column('rejected_by', sa.String(length=255), nullable=True),
+        sa.Column('rejected_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_check_constraint(
+        'check_record_rejection_reason',
+        'record_rejections',
+        "predefined_reason IN ('blur','glare','shadow','focus','exposure','dirt')",
+    )
+
+    # 2. RecordImage audit-trail columns.
+    op.add_column('record_images', sa.Column('is_current', sa.Boolean(), nullable=False, server_default=sa.true()))
+    op.add_column('record_images', sa.Column('superseded_at', sa.DateTime(), nullable=True))
+    op.add_column('record_images', sa.Column('rejection_id', sa.Integer(), sa.ForeignKey('record_rejections.id', ondelete='SET NULL'), nullable=True))
+    op.create_index(op.f('ix_record_images_rejection_id'), 'record_images', ['rejection_id'])
+
+    # 3. capture_mode: add nullable, backfill, then lock down.
+    op.add_column('records', sa.Column('capture_mode', sa.String(length=10), nullable=True))
+    op.execute("""
+        UPDATE records SET capture_mode = 'dual'
+        WHERE id IN (
+            SELECT DISTINCT record_id FROM record_images
+            WHERE role IN ('left', 'right') OR pair_id IS NOT NULL
+        )
+    """)
+    op.execute("UPDATE records SET capture_mode = 'single' WHERE capture_mode IS NULL")
+    op.alter_column('records', 'capture_mode', nullable=False)
+    op.create_check_constraint(
+        'check_record_capture_mode',
+        'records',
+        "capture_mode IN ('single','dual')",
+    )
+
+    # 4. rejection_note is superseded by record_rejections.
+    op.drop_column('records', 'rejection_note')
+
+
+def downgrade() -> None:
+    op.add_column('records', sa.Column('rejection_note', sa.Text(), nullable=True))
+
+    op.drop_constraint('check_record_capture_mode', 'records', type_='check')
+    op.drop_column('records', 'capture_mode')
+
+    op.drop_index(op.f('ix_record_images_rejection_id'), table_name='record_images')
+    op.drop_column('record_images', 'rejection_id')
+    op.drop_column('record_images', 'superseded_at')
+    op.drop_column('record_images', 'is_current')
+
+    op.drop_constraint('check_record_rejection_reason', 'record_rejections', type_='check')
+    op.drop_table('record_rejections')

--- a/alembic/versions/e11b1fbb07e1_migrate_captured_status_to_in_review.py
+++ b/alembic/versions/e11b1fbb07e1_migrate_captured_status_to_in_review.py
@@ -1,0 +1,48 @@
+"""migrate 'captured' record status to 'in_review' (NEH-208)
+
+Revision ID: e11b1fbb07e1
+Revises: 7e0b2c73bda1
+Create Date: 2026-07-28 12:05:00.000000
+
+Part 2 of the NEH-208 review-workflow redesign. "captured" stops being a
+persisted/exposed status entirely — a record now enters the queue as
+"in_review" the instant it's captured (see app/api/cameras.py), with no
+manual promotion step. This maps every existing 'captured' row to
+'in_review' and narrows the CHECK constraint accordingly.
+
+Downgrade restores the wider constraint but does not attempt to reverse
+the data migration — which rows were 'captured' vs. legitimately already
+'in_review' is not recoverable, same reasoning as this repo's other lossy
+downgrades (e.g. f6a7b8c9d0e1).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e11b1fbb07e1'
+down_revision: Union[str, None] = '7e0b2c73bda1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE records SET status = 'in_review' WHERE status = 'captured'")
+    op.drop_constraint('check_record_status', 'records', type_='check')
+    op.create_check_constraint(
+        'check_record_status',
+        'records',
+        "status IN ('in_review','rejected','approved')",
+    )
+    op.alter_column('records', 'status', server_default='in_review')
+
+
+def downgrade() -> None:
+    op.drop_constraint('check_record_status', 'records', type_='check')
+    op.create_check_constraint(
+        'check_record_status',
+        'records',
+        "status IN ('captured','in_review','rejected','approved')",
+    )
+    op.alter_column('records', 'status', server_default='captured')

--- a/app/api/cameras.py
+++ b/app/api/cameras.py
@@ -528,11 +528,24 @@ def trigger_capture(
 		effective_project_id = None if request.collection_id else project_id
 
 		# Get or create Record
+		is_recapture = False
 		if request.record_id:
 			# Link to existing record
 			record = db.query(Record).filter(Record.id == request.record_id).first()
 			if not record:
 				raise HTTPException(status_code=404, detail=f"Record {request.record_id} not found")
+			if record.status == "rejected":
+				# Recapture (NEH-208): a rejected record can only be redone with
+				# the same capture mode it was originally taken with — a single
+				# capture can't turn a dual-mode record's pair back into one image.
+				if record.capture_mode != "single":
+					raise HTTPException(
+						status_code=422,
+						detail=f"Record {record.id} was captured in '{record.capture_mode}' mode; use the dual-capture endpoint to recapture it."
+					)
+				is_recapture = True
+				from app.api.records import _supersede_current_images
+				_supersede_current_images(record)
 		else:
 			# Create new record for this capture
 			record = Record(
@@ -543,6 +556,7 @@ def trigger_capture(
 				collection_id=request.collection_id,
 				sequence=_next_record_sequence(db, effective_project_id, request.collection_id),
 				created_by=current_user.username,
+				capture_mode="single",
 			)
 			db.add(record)
 			db.flush()  # Get the ID
@@ -600,11 +614,14 @@ def trigger_capture(
 				raw_exif=str(exif_dict),
 			)
 			db.add(ex)
-		
+
+		if is_recapture:
+			record.status = "in_review"
+
 		db.commit()
 		db.refresh(record)
 		db.refresh(img)
-		
+
 		logger.info(f"Created record {record.id}, image {img.id}, capture_id={capture_id}")
 		
 		return CaptureResponse(
@@ -689,11 +706,24 @@ def trigger_dual_capture(
 		effective_project_id = None if request.collection_id else project_id
 		
 		# Get or create Record
+		is_recapture = False
 		if request.record_id:
 			# Link to existing record (adding new pages to multi-page document)
 			record = db.query(Record).filter(Record.id == request.record_id).first()
 			if not record:
 				raise HTTPException(status_code=404, detail=f"Record {request.record_id} not found")
+			if record.status == "rejected":
+				# Recapture (NEH-208): a rejected record can only be redone with
+				# the same capture mode it was originally taken with — a dual
+				# pair can't turn a single-mode record into two images.
+				if record.capture_mode != "dual":
+					raise HTTPException(
+						status_code=422,
+						detail=f"Record {record.id} was captured in '{record.capture_mode}' mode; use the single-capture endpoint to recapture it."
+					)
+				is_recapture = True
+				from app.api.records import _supersede_current_images
+				_supersede_current_images(record)
 		else:
 			# Create new record for this dual capture
 			record = Record(
@@ -704,6 +734,7 @@ def trigger_dual_capture(
 				collection_id=request.collection_id,
 				sequence=_next_record_sequence(db, effective_project_id, request.collection_id),
 				created_by=current_user.username,
+				capture_mode="dual",
 			)
 			db.add(record)
 			db.flush()  # Get the ID
@@ -796,7 +827,10 @@ def trigger_dual_capture(
 		role1 = "right" if request.left_camera_index == 0 else "left"
 		img0 = create_image_record(str(path0), 0, role0)
 		img1 = create_image_record(str(path1), 1, role1)
-		
+
+		if is_recapture:
+			record.status = "in_review"
+
 		db.commit()
 		db.refresh(record)
 		

--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -507,7 +507,8 @@ def export_collection_bagit(
             rec_dir = data_dir / f"{seq_label}_{safe_title}"
             rec_dir.mkdir(exist_ok=True)
 
-            for img in sorted(rec.images, key=lambda i: (i.role or "z", i.id)):
+            # Only current images: a rejected-then-superseded file must never land in an export bag (NEH-208)
+            for img in sorted([i for i in rec.images if i.is_current], key=lambda i: (i.role or "z", i.id)):
                 if not img.file_path:
                     continue
                 src = _Path(img.file_path)
@@ -558,7 +559,7 @@ def export_collection_bagit(
                             "resolution_height": img.resolution_height,
                             "file_size": img.file_size,
                         }
-                        for img in r.images
+                        for img in r.images if img.is_current
                     ],
                 }
                 for r in records

--- a/app/api/records.py
+++ b/app/api/records.py
@@ -9,7 +9,9 @@ import logging
 
 from app.api.deps import get_db_dependency
 from app.api.auth import get_current_user, RoleChecker
-from app.models.record import Record, RecordImage, ExifData, RecordAnnotation
+from datetime import datetime, timezone
+
+from app.models.record import Record, RecordImage, ExifData, RecordAnnotation, RecordRejection
 from app.models.camera import CameraSettings
 from app.models.user import User
 from app.schemas.record import (
@@ -17,6 +19,7 @@ from app.schemas.record import (
 	RecordImageCreate, RecordImageRead, RecordImageUpdate,
 	RecordStatusUpdate, BulkStatusUpdate, STATUS_TRANSITIONS,
 	RecordAnnotationCreate, RecordAnnotationRead,
+	RecordRejectRequest, RecordRejectionRead,
 )
 from app.core.config import settings
 from app.core.paths import resolve_within_storage
@@ -28,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 allow_contributor = RoleChecker(["admin", "operator"])
 allow_read_only = RoleChecker(["admin", "operator", "reviewer"])
+allow_reviewer = RoleChecker(["admin", "reviewer"])
 
 # Streamed uploads are copied in 1 MiB chunks so the size cap is enforced as bytes arrive, even when Content-Length is missing or wrong (e.g. chunked encoding).
 _UPLOAD_CHUNK = 1024 * 1024
@@ -52,6 +56,23 @@ def _save_upload_capped(src, dst_path: Path, max_bytes: int) -> int:
 	return total
 
 
+def _serialize_record(rec: Record, include_superseded: bool = False) -> RecordRead:
+	"""RecordRead.model_validate(rec), with images narrowed to current-only by default (NEH-208)."""
+	data = RecordRead.model_validate(rec)
+	if not include_superseded:
+		data.images = [img for img in data.images if img.is_current]
+	return data
+
+
+def _supersede_current_images(record: Record) -> None:
+	"""Flip every current image on a record to superseded. Used when a recapture is about to add new current image(s) (NEH-208)."""
+	now = datetime.now(timezone.utc)
+	for img in record.images:
+		if img.is_current:
+			img.is_current = False
+			img.superseded_at = now
+
+
 # ==============================================================================
 # Record endpoints (archival documents/objects)
 # ==============================================================================
@@ -74,6 +95,7 @@ def create_record(
 		project_id=rec_in.project_id,
 		collection_id=rec_in.collection_id,
 		created_by=rec_in.created_by or current_user.username,
+		capture_mode=rec_in.capture_mode,
 	)
 	try:
 		db.add(rec)
@@ -126,7 +148,7 @@ def list_records(
 	else:
 		query = query.order_by(Record.id)
 	recs = query.offset(skip).limit(limit).all()
-	return [RecordRead.model_validate(r) for r in recs]
+	return [_serialize_record(r) for r in recs]
 
 
 @router.get("/count")
@@ -155,7 +177,7 @@ def get_record(
 	rec = db.query(Record).options(joinedload(Record.images)).filter(Record.id == rec_id).first()
 	if not rec:
 		raise HTTPException(status_code=404, detail="Record not found")
-	return RecordRead.model_validate(rec)
+	return _serialize_record(rec)
 
 
 @router.patch("/{rec_id}", response_model=RecordRead)
@@ -192,7 +214,7 @@ def update_record(
 		db.rollback()
 		raise HTTPException(status_code=409, detail="Record parent assignment violates a database constraint")
 	db.refresh(rec)
-	return RecordRead.model_validate(rec)
+	return _serialize_record(rec)
 
 
 @router.delete("/{rec_id}")
@@ -344,19 +366,21 @@ async def add_image_to_record(
 @router.get("/{rec_id}/images", response_model=List[RecordImageRead])
 def list_record_images(
 	rec_id: int,
+	include_superseded: bool = Query(default=False, description="Include images superseded by a recapture (NEH-208)"),
 	current_user: User = Depends(allow_read_only),
 	db: Session = Depends(get_db_dependency)
 ):
-	"""Get all images for a specific record, ordered by sequence."""
+	"""Get all images for a specific record, ordered by sequence. Superseded (rejected-and-replaced) images are excluded by default."""
 	# Verify record exists
 	rec = db.query(Record).filter(Record.id == rec_id).first()
 	if not rec:
 		raise HTTPException(status_code=404, detail="Record not found")
-	
-	images = db.query(RecordImage).filter(
-		RecordImage.record_id == rec_id
-	).order_by(RecordImage.sequence.nullslast(), RecordImage.created_at).all()
-	
+
+	query = db.query(RecordImage).filter(RecordImage.record_id == rec_id)
+	if not include_superseded:
+		query = query.filter(RecordImage.is_current.is_(True))
+	images = query.order_by(RecordImage.sequence.nullslast(), RecordImage.created_at).all()
+
 	return [RecordImageRead.model_validate(img) for img in images]
 
 
@@ -596,14 +620,13 @@ def delete_record_annotation(
 def _apply_status_change(
 	rec: Record,
 	new_status: str,
-	rejection_note: Optional[str],
 	user_role: str,
 ) -> None:
 	"""
 	Validate and apply a status transition on a Record.
 	Raises HTTPException on invalid transition or insufficient role.
 	"""
-	current_status = rec.status or "captured"
+	current_status = rec.status
 	if current_status == new_status:
 		return  # no-op
 
@@ -620,7 +643,6 @@ def _apply_status_change(
 		)
 
 	rec.status = new_status
-	rec.rejection_note = rejection_note if new_status == "rejected" else None
 
 
 @router.patch("/{rec_id}/status", response_model=RecordRead)
@@ -634,23 +656,22 @@ def update_record_status(
 	Change the QA status of a record.
 
 	Valid transitions and required roles:
-	- captured  > in_review : operator, admin, reviewer
-	- in_review > rejected  : reviewer, admin
 	- in_review > approved  : reviewer, admin
-	- in_review > captured  : operator, admin  (cancel review)
-	- rejected  > captured  : operator, admin  (prepare for retake)
-	- approved  > rejected  : reviewer, admin  (flag for rework)
-	- approved  > captured  : admin only       (full reset)
+
+	Rejection is not reachable through this endpoint — use POST
+	/{rec_id}/reject, which requires a mandatory predefined_reason (NEH-208).
+	approved is terminal; recapture (rejected -> in_review) only happens as a
+	side effect of the capture endpoints in app/api/cameras.py.
 	"""
 	rec = db.query(Record).options(joinedload(Record.images)).filter(Record.id == rec_id).first()
 	if not rec:
 		raise HTTPException(status_code=404, detail="Record not found")
 
-	_apply_status_change(rec, payload.status, payload.rejection_note, current_user.role)
+	_apply_status_change(rec, payload.status, current_user.role)
 
 	db.commit()
 	db.refresh(rec)
-	return RecordRead.model_validate(rec)
+	return _serialize_record(rec)
 
 
 @router.post("/bulk-status", response_model=List[RecordRead])
@@ -678,18 +699,11 @@ def bulk_update_status(
 	updated: list[Record] = []
 
 	for rec in records:
-		current_status = rec.status or "captured"
-		if current_status == payload.status:
-			updated.append(rec)
-			continue
-
-		allowed_roles = STATUS_TRANSITIONS.get((current_status, payload.status))
-		if allowed_roles is None or current_user.role not in allowed_roles:
+		try:
+			_apply_status_change(rec, payload.status, current_user.role)
+		except HTTPException:
 			skipped.append(rec.id)
 			continue
-
-		rec.status = payload.status
-		rec.rejection_note = payload.rejection_note if payload.status == "rejected" else None
 		updated.append(rec)
 
 	db.commit()
@@ -699,4 +713,75 @@ def bulk_update_status(
 	if skipped:
 		logger.info(f"bulk-status: skipped {len(skipped)} records (invalid transition or insufficient role): {skipped}")
 
-	return [RecordRead.model_validate(r) for r in updated]
+	return [_serialize_record(r) for r in updated]
+
+
+# ==============================================================================
+# Rejection endpoints (NEH-208)
+# ==============================================================================
+
+@router.post("/{rec_id}/reject", response_model=RecordRead)
+def reject_record(
+	rec_id: int,
+	payload: RecordRejectRequest,
+	current_user: User = Depends(allow_reviewer),
+	db: Session = Depends(get_db_dependency)
+):
+	"""
+	Reject a record's current capture with a mandatory predefined reason.
+
+	Flags every current image as part of this rejection's audit trail (for a
+	dual-mode record that's both L and R — a dual-camera pair can only ever be
+	redone together, never one side alone) and moves the record to
+	'rejected'. Rejected images are never deleted or overwritten; they stay
+	queryable via GET /{rec_id}/rejections after a recapture supersedes them.
+	"""
+	rec = db.query(Record).options(joinedload(Record.images)).filter(Record.id == rec_id).first()
+	if not rec:
+		raise HTTPException(status_code=404, detail="Record not found")
+	if rec.status != "in_review":
+		raise HTTPException(
+			status_code=422,
+			detail=f"Cannot reject a record with status '{rec.status}'. Only 'in_review' records can be rejected."
+		)
+
+	current_images = [img for img in rec.images if img.is_current]
+
+	rejection = RecordRejection(
+		record_id=rec.id,
+		predefined_reason=payload.predefined_reason,
+		comment=payload.comment,
+		rejected_by=current_user.username,
+	)
+	db.add(rejection)
+	db.flush()  # assign rejection.id before linking images
+
+	for img in current_images:
+		img.rejection_id = rejection.id
+
+	rec.status = "rejected"
+
+	db.commit()
+	db.refresh(rec)
+	return _serialize_record(rec)
+
+
+@router.get("/{rec_id}/rejections", response_model=List[RecordRejectionRead])
+def list_record_rejections(
+	rec_id: int,
+	current_user: User = Depends(allow_read_only),
+	db: Session = Depends(get_db_dependency)
+):
+	"""List a record's rejection history, newest first, each with the image(s) it flagged."""
+	rec = db.query(Record).filter(Record.id == rec_id).first()
+	if not rec:
+		raise HTTPException(status_code=404, detail="Record not found")
+
+	rejections = (
+		db.query(RecordRejection)
+		.options(joinedload(RecordRejection.images))
+		.filter(RecordRejection.record_id == rec_id)
+		.order_by(RecordRejection.rejected_at.desc())
+		.all()
+	)
+	return [RecordRejectionRead.model_validate(r) for r in rejections]

--- a/app/models/record.py
+++ b/app/models/record.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from sqlalchemy import Column, Integer, String, DateTime, Text, ForeignKey, CheckConstraint, JSON
+from sqlalchemy import Column, Integer, String, DateTime, Text, ForeignKey, CheckConstraint, JSON, Boolean
 from sqlalchemy.orm import relationship
 
 from app.core.db import Base
@@ -27,22 +27,29 @@ class Record(Base):
 	project_id = Column(Integer, ForeignKey("projects.id", ondelete="SET NULL"), nullable=True, index=True)
 	collection_id = Column(Integer, ForeignKey("collections.id", ondelete="SET NULL"), nullable=True, index=True)
 	
-	# QA workflow
-	status = Column(String(20), nullable=False, default="captured")  # captured, in_review, rejected, approved
+	# QA workflow — a record enters the queue as "in_review" as soon as it's
+	# captured; there is no separate "captured" resting state (NEH-208).
+	status = Column(String(20), nullable=False, default="in_review")  # in_review, rejected, approved
 	sequence = Column(Integer, nullable=True)  # ordering within a collection
-	rejection_note = Column(Text, nullable=True)  # optional note when status=rejected
+
+	# Which camera setup produced this document: "single" (one image) or
+	# "dual" (an L+R pair fired together on one shutter press). Set once at
+	# capture time and never changed — it's what rejection scope resolution
+	# and the recapture mode-match guard key off of (NEH-208).
+	capture_mode = Column(String(10), nullable=False)  # single, dual
 
 	# Audit fields
 	created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
 	modified_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 	created_by = Column(String(255), nullable=True)
-	
+
 	# Relationships
 	images = relationship("RecordImage", back_populates="record", cascade="all, delete-orphan")
 	project = relationship("Project", back_populates="records")
 	collection = relationship("Collection", back_populates="records")
 	annotations = relationship("RecordAnnotation", back_populates="record", cascade="all, delete-orphan", order_by="RecordAnnotation.created_at.desc()")
-	
+	rejections = relationship("RecordRejection", back_populates="record", cascade="all, delete-orphan", order_by="RecordRejection.rejected_at.desc()")
+
 	# Constraint: must have either project_id OR collection_id (or neither, but not both)
 	__table_args__ = (
 		CheckConstraint(
@@ -50,8 +57,12 @@ class Record(Base):
 			name='check_record_single_parent'
 		),
 		CheckConstraint(
-			"status IN ('captured','in_review','rejected','approved')",
+			"status IN ('in_review','rejected','approved')",
 			name='check_record_status'
+		),
+		CheckConstraint(
+			"capture_mode IN ('single','dual')",
+			name='check_record_capture_mode'
 		),
 	)
 
@@ -90,11 +101,21 @@ class RecordImage(Base):
 	# Audit fields
 	created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
 	uploaded_by = Column(String(255), nullable=True)
-	
+
+	# Rejection/recapture audit trail (NEH-208). A rejected image is never
+	# deleted or overwritten: it stays in place with is_current flipped to
+	# False and rejection_id pointing at the RecordRejection that flagged
+	# it, so it remains queryable via GET /records/{id}/rejections after a
+	# recapture installs its replacement as the new current image.
+	is_current = Column(Boolean, nullable=False, default=True)
+	superseded_at = Column(DateTime, nullable=True)
+	rejection_id = Column(Integer, ForeignKey("record_rejections.id", ondelete="SET NULL"), nullable=True, index=True)
+
 	# Relationships
 	record = relationship("Record", back_populates="images")
 	camera_settings = relationship("CameraSettings", back_populates="record_image", uselist=False, cascade="all, delete-orphan")
 	exif_data = relationship("ExifData", back_populates="record_image", uselist=False, cascade="all, delete-orphan")
+	rejection = relationship("RecordRejection", back_populates="images")
 
 
 class RecordAnnotation(Base):
@@ -114,6 +135,40 @@ class RecordAnnotation(Base):
 	created_by = Column(String(255), nullable=True)
 
 	record = relationship("Record", back_populates="annotations")
+
+
+class RecordRejection(Base):
+	"""
+	Audit record of a single rejection event on a Record (NEH-208).
+
+	Created once per rejection with a mandatory predefined reason (the same
+	list the annotation feature's "Marcar error" uses) plus an optional
+	free-text comment. Links to every RecordImage that was current at the
+	time of rejection via RecordImage.rejection_id — those images are never
+	deleted; a later recapture supersedes them (is_current=False) without
+	touching this row, so the rejected file(s) + reason + timestamp + user
+	stay queryable indefinitely via GET /records/{id}/rejections.
+	"""
+	__tablename__ = "record_rejections"
+
+	id = Column(Integer, primary_key=True, index=True)
+	record_id = Column(Integer, ForeignKey("records.id", ondelete="CASCADE"), nullable=False, index=True)
+
+	predefined_reason = Column(String(20), nullable=False)  # blur, glare, shadow, focus, exposure, dirt
+	comment = Column(Text, nullable=True)
+
+	rejected_by = Column(String(255), nullable=True)
+	rejected_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+
+	record = relationship("Record", back_populates="rejections")
+	images = relationship("RecordImage", back_populates="rejection")
+
+	__table_args__ = (
+		CheckConstraint(
+			"predefined_reason IN ('blur','glare','shadow','focus','exposure','dirt')",
+			name='check_record_rejection_reason'
+		),
+	)
 
 
 class ExifData(Base):

--- a/app/schemas/record.py
+++ b/app/schemas/record.py
@@ -3,19 +3,32 @@ from typing import Optional, List, Literal
 from pydantic import BaseModel, field_validator, model_validator
 from datetime import datetime
 
-# Valid status values
-RecordStatus = Literal["captured", "in_review", "rejected", "approved"]
+# Valid status values. A record has no "captured" resting state — it enters
+# the queue as "in_review" the moment it's captured (NEH-208). "approved" is
+# terminal: the only way back to "in_review" is rejecting first, then
+# recapturing (see the dedicated reject endpoint and cameras.py).
+RecordStatus = Literal["in_review", "rejected", "approved"]
 
-# Allowed status transitions: (from_status, to_status) -> set of roles that can perform it
+# Allowed status transitions: (from_status, to_status) -> set of roles that can perform it.
+# Rejection is deliberately NOT here — it's its own endpoint (POST
+# /records/{id}/reject) with a mandatory predefined_reason, not reachable
+# through the generic status-update path. Recapture (rejected -> in_review)
+# is likewise not here — it only ever happens as a side effect of the
+# capture endpoints (app/api/cameras.py) actually receiving new image(s).
 STATUS_TRANSITIONS: dict[tuple[str, str], set[str]] = {
-	("captured",  "in_review"): {"operator", "admin", "reviewer"},
-	("in_review", "rejected"):  {"reviewer", "admin"},
-	("in_review", "approved"):  {"reviewer", "admin"},
-	("in_review", "captured"):  {"operator", "admin"},
-	("rejected",  "captured"):  {"operator", "admin"},
-	("approved",  "rejected"):  {"reviewer", "admin"},
-	("approved",  "captured"):  {"admin"},
+	("in_review", "approved"): {"reviewer", "admin"},
 }
+
+# The predefined rejection reasons, mirroring the list the annotation
+# feature's "Marcar error" already uses client-side
+# (LeftSidebar.svelte ERROR_TYPES) — this is the first place either list is
+# enforced server-side.
+PREDEFINED_REJECTION_REASONS = ("blur", "glare", "shadow", "focus", "exposure", "dirt")
+PredefinedRejectionReason = Literal["blur", "glare", "shadow", "focus", "exposure", "dirt"]
+
+# Which camera setup produced a document: one image, or an L+R pair fired
+# together on a single shutter press. Set once at capture time.
+CaptureMode = Literal["single", "dual"]
 
 
 # ==============================================================================
@@ -110,6 +123,11 @@ class RecordImageRead(RecordImageBase):
 	created_at: Optional[datetime]
 	camera_settings: Optional[CameraSettingsRead] = None
 	exif_data: Optional[ExifDataRead] = None
+	# Audit trail (NEH-208): False once a recapture has superseded this
+	# image — it stays queryable via GET /records/{id}/rejections but drops
+	# out of the default image list/gallery/export.
+	is_current: bool = True
+	superseded_at: Optional[datetime] = None
 
 	class Config:
 		from_attributes = True
@@ -127,9 +145,13 @@ class RecordBase(BaseModel):
 	material: Optional[str] = None
 	date: Optional[str] = None
 	custom_attributes: Optional[str] = None  # JSON string for custom fields
-	status: RecordStatus = "captured"
+	status: RecordStatus = "in_review"
 	sequence: Optional[int] = None
-	rejection_note: Optional[str] = None
+	# Required: the camera capture endpoints always set this explicitly;
+	# manual record creation (POST /records/) must declare it up front since
+	# rejection scope resolution and the recapture mode-match guard both
+	# depend on it (NEH-208).
+	capture_mode: CaptureMode
 
 
 class RecordCreate(RecordBase):
@@ -169,13 +191,11 @@ class RecordRead(RecordBase):
 
 class RecordStatusUpdate(BaseModel):
 	status: RecordStatus
-	rejection_note: Optional[str] = None
 
 
 class BulkStatusUpdate(BaseModel):
 	record_ids: List[int]
 	status: RecordStatus
-	rejection_note: Optional[str] = None
 
 	@field_validator("record_ids")
 	@classmethod
@@ -183,6 +203,30 @@ class BulkStatusUpdate(BaseModel):
 		if not v:
 			raise ValueError("record_ids must not be empty")
 		return v
+
+
+# ==============================================================================
+# Rejection schemas (NEH-208)
+# ==============================================================================
+
+class RecordRejectRequest(BaseModel):
+	predefined_reason: PredefinedRejectionReason
+	comment: Optional[str] = None
+
+
+class RecordRejectionRead(BaseModel):
+	id: int
+	record_id: int
+	predefined_reason: str
+	comment: Optional[str] = None
+	rejected_by: Optional[str] = None
+	rejected_at: Optional[datetime]
+	# The image(s) this specific rejection flagged — both L and R for a
+	# dual-mode document, the one image for single-mode.
+	images: List[RecordImageRead] = []
+
+	class Config:
+		from_attributes = True
 
 
 # ==============================================================================

--- a/tests/integration/test_camera_capture_recapture_hardware.py
+++ b/tests/integration/test_camera_capture_recapture_hardware.py
@@ -1,0 +1,146 @@
+"""
+Hardware-gated integration tests for NEH-208 recapture through the real
+/cameras/capture and /cameras/capture/dual endpoints.
+
+Mirrors the skip pattern in test_capture_integration.py: these require real
+camera hardware (Linux/Raspberry Pi) and are not the primary coverage for
+this ticket — the non-hardware-gated test_reject_recapture_full_flow.py
+carries the required assertions on this dev machine. This file verifies the
+part only the real endpoints can exercise: the capture-mode mismatch guard,
+and that a recapture leaves the original file on disk untouched.
+Run with: python -m pytest tests/integration/test_camera_capture_recapture_hardware.py
+"""
+import pytest
+import sys
+
+# Skip on non-Linux platforms
+if sys.platform != 'linux':
+    pytest.skip("Integration tests require Linux/Raspberry Pi environment", allow_module_level=True)
+
+
+from pathlib import Path
+
+from app.models.record import Record, RecordImage
+
+
+@pytest.mark.integration
+def test_single_capture_recapture_flips_rejected_back_to_in_review(client, db_session, test_project):
+    project_name = test_project.name
+
+    response = client.post(
+        "/cameras/capture",
+        json={
+            "project_name": project_name,
+            "camera_index": 0,
+            "resolution": "medium",
+            "include_resolution_in_filename": False
+        },
+        headers={"Authorization": "Bearer test_token"}
+    )
+    assert response.status_code == 200
+    record_id = response.json()["record_id"]
+    first_image_path = Path(response.json()["file_path"])
+
+    record = db_session.query(Record).filter(Record.id == record_id).first()
+    record.status = "rejected"
+    db_session.commit()
+
+    response = client.post(
+        "/cameras/capture",
+        json={
+            "project_name": project_name,
+            "camera_index": 0,
+            "resolution": "medium",
+            "include_resolution_in_filename": False,
+            "record_id": record_id,
+        },
+        headers={"Authorization": "Bearer test_token"}
+    )
+    assert response.status_code == 200, response.text
+
+    db_session.refresh(record)
+    assert record.status == "in_review"
+
+    # The original file is preserved on disk — a rejected capture is never deleted.
+    assert first_image_path.exists()
+
+    images = db_session.query(RecordImage).filter(RecordImage.record_id == record_id).all()
+    old_images = [i for i in images if str(i.file_path) == str(first_image_path)]
+    assert old_images and old_images[0].is_current is False
+
+
+@pytest.mark.integration
+def test_dual_capture_recapture_supersedes_both_sides(client, db_session, test_project):
+    project_name = test_project.name
+
+    response = client.post(
+        "/cameras/capture/dual",
+        json={
+            "project_name": project_name,
+            "resolution": "medium",
+            "include_resolution_in_filename": False,
+            "stagger_ms": 20
+        },
+        headers={"Authorization": "Bearer test_token"}
+    )
+    assert response.status_code == 200
+    record_id = response.json()["record_id"]
+
+    record = db_session.query(Record).filter(Record.id == record_id).first()
+    assert record.capture_mode == "dual"
+    record.status = "rejected"
+    db_session.commit()
+
+    old_images = db_session.query(RecordImage).filter(RecordImage.record_id == record_id).all()
+    assert len(old_images) == 2
+
+    response = client.post(
+        "/cameras/capture/dual",
+        json={
+            "project_name": project_name,
+            "resolution": "medium",
+            "include_resolution_in_filename": False,
+            "stagger_ms": 20,
+            "record_id": record_id,
+        },
+        headers={"Authorization": "Bearer test_token"}
+    )
+    assert response.status_code == 200, response.text
+
+    db_session.refresh(record)
+    assert record.status == "in_review"
+
+    for img in old_images:
+        db_session.refresh(img)
+        assert img.is_current is False
+
+    current_images = db_session.query(RecordImage).filter(
+        RecordImage.record_id == record_id, RecordImage.is_current.is_(True)
+    ).all()
+    assert len(current_images) == 2
+
+
+@pytest.mark.integration
+def test_single_capture_recapture_rejects_mode_mismatch(client, db_session, test_project):
+    """A dual-mode record can't be recaptured through the single-camera endpoint."""
+    project_name = test_project.name
+
+    rec = Record(title="dual doc", status="rejected", capture_mode="dual", project_id=test_project.id)
+    db_session.add(rec)
+    db_session.commit()
+
+    response = client.post(
+        "/cameras/capture",
+        json={
+            "project_name": project_name,
+            "camera_index": 0,
+            "resolution": "medium",
+            "record_id": rec.id,
+        },
+        headers={"Authorization": "Bearer test_token"}
+    )
+    assert response.status_code == 422, response.text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/integration/test_capture_integration.py
+++ b/tests/integration/test_capture_integration.py
@@ -57,7 +57,9 @@ def test_single_capture_creates_database_record(client, db_session, test_project
     record = db_session.query(Record).filter(Record.id == doc.record_id).first()
     assert record is not None
     assert record.project_id == test_project.id
-    
+    assert record.status == "in_review"
+    assert record.capture_mode == "single"
+
     # Verify camera settings were saved
     cs = db_session.query(CameraSettings).filter(
         CameraSettings.record_image_id == doc.id
@@ -99,7 +101,11 @@ def test_dual_capture_creates_two_database_records(client, db_session, test_proj
     ).all()
     
     assert len(docs) >= 2
-    
+
+    dual_record = db_session.query(Record).filter(Record.id == docs[-1].record_id).first()
+    assert dual_record.status == "in_review"
+    assert dual_record.capture_mode == "dual"
+
     # Check both have camera settings
     for doc in docs[-2:]:
         cs = db_session.query(CameraSettings).filter(

--- a/tests/integration/test_reject_recapture_full_flow.py
+++ b/tests/integration/test_reject_recapture_full_flow.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Integration tests for the full NEH-208 reject -> recapture -> re-review flow,
+covering both capture modes end to end against the real API + DB layer.
+
+These don't go through the hardware-gated /cameras/capture(/dual) endpoints
+(no mock capture backend exists in this repo — see
+tests/integration/test_capture_integration.py, which skips outright on
+non-Linux). Instead, "capture" and "recapture" are simulated the same way
+cameras.py implements them: RecordImage rows are created directly, and
+recapture calls the same _supersede_current_images helper cameras.py calls
+before adding the replacement image(s). The mode-mismatch guard and the
+actual capture-endpoint wiring are covered separately by the hardware-gated
+test_camera_capture_recapture_hardware.py.
+Run with: python -m pytest tests/integration/test_reject_recapture_full_flow.py
+"""
+
+import pytest
+
+
+def _user(username, role):
+    from app.models.user import User
+    return User(username=username, email=f"{username}@example.com",
+                hashed_password="x", role=role, is_active=True)
+
+
+def _client_as(client, username, role):
+    from app.main import app
+    from app.api.auth import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: _user(username, role)
+    return client
+
+
+@pytest.mark.integration
+def test_full_single_mode_reject_recapture_approve_flow(client, db_session):
+    from app.models.record import Record, RecordImage
+    from app.api.records import _supersede_current_images
+
+    rec = Record(title="doc", status="in_review", capture_mode="single")
+    db_session.add(rec)
+    db_session.commit()
+
+    old_img = RecordImage(record_id=rec.id, filename="a.jpg", file_path="/tmp/a.jpg", format="jpg", role="single")
+    db_session.add(old_img)
+    db_session.commit()
+
+    api = _client_as(client, "u", "reviewer")
+
+    # Reject with a mandatory reason.
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "blur", "comment": "shaky hand"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "rejected"
+
+    # Recapture: supersede the old image, add the replacement, flip back to in_review
+    # (exactly what cameras.py's trigger_capture does on a rejected record).
+    db_session.refresh(rec)
+    _supersede_current_images(rec)
+    new_img = RecordImage(record_id=rec.id, filename="a2.jpg", file_path="/tmp/a2.jpg", format="jpg", role="single")
+    db_session.add(new_img)
+    rec.status = "in_review"
+    db_session.commit()
+
+    # Only the new image is "current".
+    resp = api.get(f"/records/{rec.id}/images")
+    assert resp.status_code == 200, resp.text
+    assert [i["id"] for i in resp.json()] == [new_img.id]
+
+    # The old image's rejection record is still queryable, with the old image attached.
+    resp = api.get(f"/records/{rec.id}/rejections")
+    assert resp.status_code == 200, resp.text
+    rejections = resp.json()
+    assert len(rejections) == 1
+    assert rejections[0]["predefined_reason"] == "blur"
+    assert [i["id"] for i in rejections[0]["images"]] == [old_img.id]
+    assert rejections[0]["images"][0]["is_current"] is False
+
+    # Back in in_review, so it can now be approved.
+    resp = api.get(f"/records/{rec.id}")
+    assert resp.json()["status"] == "in_review"
+
+    resp = api.patch(f"/records/{rec.id}/status", json={"status": "approved"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "approved"
+
+
+@pytest.mark.integration
+def test_full_dual_mode_reject_recapture_flow(client, db_session):
+    from app.models.record import Record, RecordImage
+    from app.api.records import _supersede_current_images
+
+    rec = Record(title="book", status="in_review", capture_mode="dual")
+    db_session.add(rec)
+    db_session.commit()
+
+    old_left = RecordImage(record_id=rec.id, filename="l.jpg", file_path="/tmp/l.jpg", format="jpg",
+                            role="left", pair_id="p1")
+    old_right = RecordImage(record_id=rec.id, filename="r.jpg", file_path="/tmp/r.jpg", format="jpg",
+                             role="right", pair_id="p1")
+    db_session.add_all([old_left, old_right])
+    db_session.commit()
+
+    api = _client_as(client, "u", "reviewer")
+
+    # A defect on only one side still rejects the whole pair — physically,
+    # dual capture can only ever be redone together.
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "exposure"})
+    assert resp.status_code == 200, resp.text
+
+    resp = api.get(f"/records/{rec.id}/rejections")
+    flagged_ids = {i["id"] for i in resp.json()[0]["images"]}
+    assert flagged_ids == {old_left.id, old_right.id}
+
+    # Recapture both sides.
+    db_session.refresh(rec)
+    _supersede_current_images(rec)
+    new_left = RecordImage(record_id=rec.id, filename="l2.jpg", file_path="/tmp/l2.jpg", format="jpg",
+                            role="left", pair_id="p2")
+    new_right = RecordImage(record_id=rec.id, filename="r2.jpg", file_path="/tmp/r2.jpg", format="jpg",
+                             role="right", pair_id="p2")
+    db_session.add_all([new_left, new_right])
+    rec.status = "in_review"
+    db_session.commit()
+
+    resp = api.get(f"/records/{rec.id}/images")
+    assert resp.status_code == 200, resp.text
+    assert {i["id"] for i in resp.json()} == {new_left.id, new_right.id}
+
+    # Old pair still fully queryable via the audit endpoint after recapture.
+    resp = api.get(f"/records/{rec.id}/rejections")
+    assert resp.status_code == 200, resp.text
+    rejections = resp.json()
+    assert len(rejections) == 1
+    assert {i["id"] for i in rejections[0]["images"]} == {old_left.id, old_right.id}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_annotation_delete_creator_check.py
+++ b/tests/unit/test_annotation_delete_creator_check.py
@@ -29,7 +29,7 @@ def _client_as(client, username, role):
 def _make_annotation(db_session, created_by):
     from app.models.record import Record, RecordAnnotation
 
-    rec = Record(title="r", created_by="someone")
+    rec = Record(title="r", created_by="someone", capture_mode="single")
     db_session.add(rec)
     db_session.commit()
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -126,7 +126,8 @@ def test_schemas():
             object_typology="book",
             author="John Doe",
             material="paper",
-            date="2024-01-01"
+            date="2024-01-01",
+            capture_mode="single"
         )
         assert doc.object_typology == "book"
         assert doc.author == "John Doe"

--- a/tests/unit/test_collections_hierarchy.py
+++ b/tests/unit/test_collections_hierarchy.py
@@ -41,7 +41,7 @@ def test_hierarchy_returns_200_with_record_count(read_client, db_session):
     db_session.commit()
     db_session.add(Collection(name="child", parent_collection_id=col.id))
     for i in range(3):
-        db_session.add(Record(title=f"r{i}", collection_id=col.id))
+        db_session.add(Record(title=f"r{i}", collection_id=col.id, capture_mode="single"))
     db_session.commit()
 
     resp = read_client.get(f"/collections/{col.id}/hierarchy")

--- a/tests/unit/test_collections_order_count_export_detail.py
+++ b/tests/unit/test_collections_order_count_export_detail.py
@@ -157,11 +157,11 @@ def test_list_records_orders_by_sequence_nulls_last_then_id_within_collection(re
 
     # Insert out of sequence order, mixing NULL and non-NULL sequence values.
     # Expected order: sequence 0, 1, 2 first (ascending), then NULLs by id.
-    r_null_a = Record(title="null-a", collection_id=col.id, sequence=None)
-    r_seq2 = Record(title="seq-2", collection_id=col.id, sequence=2)
-    r_null_b = Record(title="null-b", collection_id=col.id, sequence=None)
-    r_seq0 = Record(title="seq-0", collection_id=col.id, sequence=0)
-    r_seq1 = Record(title="seq-1", collection_id=col.id, sequence=1)
+    r_null_a = Record(title="null-a", collection_id=col.id, sequence=None, capture_mode="single")
+    r_seq2 = Record(title="seq-2", collection_id=col.id, sequence=2, capture_mode="single")
+    r_null_b = Record(title="null-b", collection_id=col.id, sequence=None, capture_mode="single")
+    r_seq0 = Record(title="seq-0", collection_id=col.id, sequence=0, capture_mode="single")
+    r_seq1 = Record(title="seq-1", collection_id=col.id, sequence=1, capture_mode="single")
     db_session.add_all([r_null_a, r_seq2, r_null_b, r_seq0, r_seq1])
     db_session.commit()
     for r in (r_null_a, r_seq2, r_null_b, r_seq0, r_seq1):
@@ -188,9 +188,9 @@ def test_list_records_without_collection_id_orders_by_id_only(read_client, db_se
 
     # Sequence values that would sort differently than id if honored;
     # project-wide listing must ignore them and use pure id order.
-    r1 = Record(title="r1", project_id=proj.id, sequence=5)
-    r2 = Record(title="r2", project_id=proj.id, sequence=1)
-    r3 = Record(title="r3", project_id=proj.id, sequence=None)
+    r1 = Record(title="r1", project_id=proj.id, sequence=5, capture_mode="single")
+    r2 = Record(title="r2", project_id=proj.id, sequence=1, capture_mode="single")
+    r3 = Record(title="r3", project_id=proj.id, sequence=None, capture_mode="single")
     db_session.add_all([r1, r2, r3])
     db_session.commit()
     for r in (r1, r2, r3):
@@ -255,9 +255,9 @@ def test_export_non_approved_records_returns_structured_422(contributor_client, 
     db_session.add(col)
     db_session.commit()
 
-    r1 = Record(title="r1", collection_id=col.id, status="captured")
-    r2 = Record(title="r2", collection_id=col.id, status="approved")
-    r3 = Record(title="r3", collection_id=col.id, status="in_review")
+    r1 = Record(title="r1", collection_id=col.id, status="rejected", capture_mode="single")
+    r2 = Record(title="r2", collection_id=col.id, status="approved", capture_mode="single")
+    r3 = Record(title="r3", collection_id=col.id, status="in_review", capture_mode="single")
     db_session.add_all([r1, r2, r3])
     db_session.commit()
     for r in (r1, r2, r3):

--- a/tests/unit/test_record_reject_endpoint.py
+++ b/tests/unit/test_record_reject_endpoint.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Tests for POST /records/{id}/reject and GET /records/{id}/rejections (NEH-208).
+
+Rejection requires a mandatory predefined_reason from a fixed 6-value list,
+plus an optional free-text comment; it's only valid from 'in_review'; and
+only reviewer/admin may perform it.
+Run with: python -m pytest tests/unit/test_record_reject_endpoint.py
+"""
+
+import pytest
+
+
+def _user(username, role):
+    from app.models.user import User
+    return User(username=username, email=f"{username}@example.com",
+                hashed_password="x", role=role, is_active=True)
+
+
+def _client_as(client, username, role):
+    from app.main import app
+    from app.api.auth import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: _user(username, role)
+    return client
+
+
+def _make_record(db_session, status="in_review", capture_mode="single"):
+    from app.models.record import Record
+
+    rec = Record(title="r", status=status, capture_mode=capture_mode)
+    db_session.add(rec)
+    db_session.commit()
+    db_session.refresh(rec)
+    return rec
+
+
+@pytest.mark.unit
+def test_reject_requires_predefined_reason(client, db_session):
+    rec = _make_record(db_session)
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.post(f"/records/{rec.id}/reject", json={})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.unit
+def test_reject_rejects_unknown_reason(client, db_session):
+    rec = _make_record(db_session)
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "bogus"})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.unit
+def test_reject_accepts_valid_reason_and_optional_comment(client, db_session):
+    rec = _make_record(db_session)
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "blur", "comment": "too fuzzy"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "rejected"
+
+
+@pytest.mark.unit
+def test_reject_only_valid_from_in_review(client, db_session):
+    rec = _make_record(db_session, status="approved")
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "blur"})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.unit
+def test_operator_cannot_reject(client, db_session):
+    rec = _make_record(db_session)
+    api = _client_as(client, "op", "operator")
+
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "blur"})
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.unit
+def test_rejection_appears_in_rejections_history_and_image_drops_from_images_list(client, db_session):
+    from app.models.record import RecordImage
+
+    rec = _make_record(db_session)
+    img = RecordImage(record_id=rec.id, filename="a.jpg", file_path="/tmp/a.jpg", format="jpg")
+    db_session.add(img)
+    db_session.commit()
+
+    api = _client_as(client, "rev", "reviewer")
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "glare", "comment": "window reflection"})
+    assert resp.status_code == 200, resp.text
+
+    resp = api.get(f"/records/{rec.id}/rejections")
+    assert resp.status_code == 200, resp.text
+    rejections = resp.json()
+    assert len(rejections) == 1
+    assert rejections[0]["predefined_reason"] == "glare"
+    assert rejections[0]["comment"] == "window reflection"
+    assert [i["id"] for i in rejections[0]["images"]] == [img.id]
+
+    # The rejected image is still "current" until a recapture supersedes it,
+    # so it still appears in the default images listing.
+    resp = api.get(f"/records/{rec.id}/images")
+    assert resp.status_code == 200, resp.text
+    assert [i["id"] for i in resp.json()] == [img.id]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_record_status_transitions.py
+++ b/tests/unit/test_record_status_transitions.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Tests for NEH-208's narrowed status state machine.
+
+Only in_review -> approved remains reachable through PATCH /{id}/status and
+POST /records/bulk-status. Rejection has its own endpoint (see
+test_record_reject_endpoint.py); approved is terminal; "captured" is not a
+valid status anywhere anymore.
+Run with: python -m pytest tests/unit/test_record_status_transitions.py
+"""
+
+import pytest
+
+
+def _user(username, role):
+    from app.models.user import User
+    return User(username=username, email=f"{username}@example.com",
+                hashed_password="x", role=role, is_active=True)
+
+
+def _client_as(client, username, role):
+    from app.main import app
+    from app.api.auth import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: _user(username, role)
+    return client
+
+
+def _make_record(db_session, status="in_review", capture_mode="single"):
+    from app.models.record import Record
+
+    rec = Record(title="r", status=status, capture_mode=capture_mode)
+    db_session.add(rec)
+    db_session.commit()
+    db_session.refresh(rec)
+    return rec
+
+
+@pytest.mark.unit
+def test_in_review_to_approved_allowed_for_reviewer(client, db_session):
+    rec = _make_record(db_session, status="in_review")
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.patch(f"/records/{rec.id}/status", json={"status": "approved"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "approved"
+
+
+@pytest.mark.unit
+def test_in_review_to_approved_forbidden_for_operator(client, db_session):
+    rec = _make_record(db_session, status="in_review")
+    api = _client_as(client, "op", "operator")
+
+    resp = api.patch(f"/records/{rec.id}/status", json={"status": "approved"})
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.unit
+def test_approved_to_rejected_no_longer_allowed(client, db_session):
+    """approved is terminal (NEH-208) — the old 'flag for rework' walk-back is gone."""
+    rec = _make_record(db_session, status="approved")
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.patch(f"/records/{rec.id}/status", json={"status": "rejected"})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.unit
+def test_rejected_is_not_reachable_via_generic_status_endpoint(client, db_session):
+    """Rejection must go through POST /{id}/reject with a mandatory reason, not this endpoint."""
+    rec = _make_record(db_session, status="in_review")
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.patch(f"/records/{rec.id}/status", json={"status": "rejected"})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.unit
+def test_captured_is_not_a_valid_status_value(client, db_session):
+    rec = _make_record(db_session, status="in_review")
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.patch(f"/records/{rec.id}/status", json={"status": "captured"})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.unit
+def test_bulk_status_update_skips_invalid_transitions_and_updates_valid_ones(client, db_session):
+    rec_ok = _make_record(db_session, status="in_review")
+    rec_blocked = _make_record(db_session, status="rejected")
+    api = _client_as(client, "rev", "reviewer")
+
+    resp = api.post("/records/bulk-status", json={
+        "record_ids": [rec_ok.id, rec_blocked.id],
+        "status": "approved",
+    })
+    assert resp.status_code == 200, resp.text
+    updated_ids = {r["id"] for r in resp.json()}
+    assert rec_ok.id in updated_ids
+    assert rec_blocked.id not in updated_ids
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_rejection_scope_resolution.py
+++ b/tests/unit/test_rejection_scope_resolution.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Tests for NEH-208 rejection scope: a dual-mode record's rejection must flag
+BOTH images (a dual-camera pair can only ever be redone together), while a
+single-mode record's rejection flags exactly the one image.
+Run with: python -m pytest tests/unit/test_rejection_scope_resolution.py
+"""
+
+import pytest
+
+
+def _user(username, role):
+    from app.models.user import User
+    return User(username=username, email=f"{username}@example.com",
+                hashed_password="x", role=role, is_active=True)
+
+
+def _client_as(client, username, role):
+    from app.main import app
+    from app.api.auth import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: _user(username, role)
+    return client
+
+
+@pytest.mark.unit
+def test_dual_mode_rejection_flags_both_images(client, db_session):
+    from app.models.record import Record, RecordImage
+
+    rec = Record(title="r", status="in_review", capture_mode="dual")
+    db_session.add(rec)
+    db_session.commit()
+
+    left = RecordImage(record_id=rec.id, filename="l.jpg", file_path="/tmp/l.jpg", format="jpg",
+                        role="left", pair_id="p1")
+    right = RecordImage(record_id=rec.id, filename="r.jpg", file_path="/tmp/r.jpg", format="jpg",
+                         role="right", pair_id="p1")
+    db_session.add_all([left, right])
+    db_session.commit()
+
+    api = _client_as(client, "rev", "reviewer")
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "shadow"})
+    assert resp.status_code == 200, resp.text
+
+    resp = api.get(f"/records/{rec.id}/rejections")
+    assert resp.status_code == 200, resp.text
+    rejections = resp.json()
+    assert len(rejections) == 1
+    flagged_ids = {i["id"] for i in rejections[0]["images"]}
+    assert flagged_ids == {left.id, right.id}
+
+
+@pytest.mark.unit
+def test_single_mode_rejection_flags_exactly_one_image(client, db_session):
+    from app.models.record import Record, RecordImage
+
+    rec = Record(title="r", status="in_review", capture_mode="single")
+    db_session.add(rec)
+    db_session.commit()
+
+    img = RecordImage(record_id=rec.id, filename="a.jpg", file_path="/tmp/a.jpg", format="jpg", role="single")
+    db_session.add(img)
+    db_session.commit()
+
+    api = _client_as(client, "rev", "reviewer")
+    resp = api.post(f"/records/{rec.id}/reject", json={"predefined_reason": "focus"})
+    assert resp.status_code == 200, resp.text
+
+    resp = api.get(f"/records/{rec.id}/rejections")
+    assert resp.status_code == 200, resp.text
+    rejections = resp.json()
+    assert len(rejections) == 1
+    assert [i["id"] for i in rejections[0]["images"]] == [img.id]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_schema_constraints.py
+++ b/tests/unit/test_schema_constraints.py
@@ -91,7 +91,7 @@ def test_second_exif_data_row_for_same_record_image_raises_integrity_error(db_se
     db_session.add(proj)
     db_session.commit()
 
-    rec = Record(title="r", project_id=proj.id)
+    rec = Record(title="r", project_id=proj.id, capture_mode="single")
     db_session.add(rec)
     db_session.commit()
 
@@ -134,7 +134,7 @@ def test_valid_rows_commit_fine(db_session):
 
     pm = ProjectMember(project_id=proj.id, user_id=user.id, role="operator")
     log = SystemLog(level="ERR", category="capture", action="capture_failed")
-    rec = Record(title="r", project_id=proj.id, status="approved")
+    rec = Record(title="r", project_id=proj.id, status="approved", capture_mode="single")
     db_session.add_all([pm, log, rec])
     db_session.commit()
 


### PR DESCRIPTION
## Summary

Redesigns the record QA state machine per NEH-208:

- `captured` is no longer a persisted/exposed status — a record enters the
  queue as `in_review` the instant it's captured. Status is now strictly
  `in_review -> approved` (terminal) or `in_review -> rejected -> (recapture) -> in_review -> ...`.
- `capture_mode` (`single`/`dual`) is now a real, required column on `Record`,
  set at capture time and backfilled for existing rows from image
  role/pair_id.
- Rejection is its own endpoint (`POST /records/{id}/reject`) with a
  mandatory `predefined_reason` (same 6-value list the annotation feature
  already uses) plus an optional comment. Dual-mode rejections flag both
  images in the pair — a dual-camera pair can only ever be redone together.
- Rejected files are never deleted or overwritten: a new `record_rejections`
  audit table plus `RecordImage.is_current/superseded_at/rejection_id` keep
  them permanently queryable via `GET /records/{id}/rejections`, even after
  a recapture installs the replacement.
- Recapture reuses the existing `/cameras/capture` and `/cameras/capture/dual`
  endpoints (called with the same `record_id`) rather than adding a new
  route — they now detect a `rejected` record, enforce a capture-mode match,
  supersede the old image(s), and flip the record back to `in_review`.

## Breaking API changes (frontend follow-up required)

1. `status: "captured"` is no longer valid anywhere — as a filter, a
   `PATCH .../status` / `bulk-status` target, or in `RecordRead` responses.
2. `PATCH /{id}/status` and `POST /records/bulk-status` no longer accept
   `"rejected"` (422) — use `POST /{id}/reject` instead. `rejection_note` is
   dropped from both request bodies.
3. `approved -> rejected` ("flag for rework") is removed — `approved` is
   terminal.
4. `RecordCreate` (`POST /records/`) now requires `capture_mode: "single" | "dual"`.
5. `RecordRead.images` / `GET /records/{id}/images` now returns **current**
   images only by default (`include_superseded=true` opts into full history).
   A rejected-then-recaptured record's old image(s) move to the new
   `GET /{id}/rejections` endpoint instead.
6. New endpoints: `POST /records/{id}/reject`, `GET /records/{id}/rejections`.
   Today's frontend "retake" flow doesn't pass `record_id` at all — wiring
   recapture end-to-end is separate, out-of-scope follow-up work.

## Migration

Two chained migrations (`7e0b2c73bda1`, `e11b1fbb07e1`) off current head:
create `record_rejections` + new `record_images` audit columns, backfill
`capture_mode` from existing image shape, migrate `captured` rows to
`in_review`, narrow both CHECK constraints. Applied and manually verified
against the dev DB — no `captured` rows remain, every record has a
`capture_mode` consistent with its images.

## Test plan

- [x] `pytest tests/unit -q` — 116/116 passing (existing `Record(...)`
      constructions updated for the new NOT NULL `capture_mode`)
- [x] `pytest tests/integration/test_reject_recapture_full_flow.py` — 2/2
      passing (full single-mode and dual-mode reject → recapture → approve
      flows, non-hardware-gated)
- [x] New unit coverage: status-transition gating, mandatory-reason
      validation on reject, dual-vs-single rejection scope resolution
- [x] Migrations applied to the real dev Postgres DB + manual verification
      query
- [x] Live smoke test against the running dev stack: single-mode and
      dual-mode reject → audit-endpoint check → cleanup
- [ ] `test_camera_capture_recapture_hardware.py` — hardware-gated (real
      Pi + cameras), not runnable in this environment; mirrors the existing
      skip pattern in `test_capture_integration.py`
