### PR TITLE
feat(export): background, single-pass BagIt export with disk safety (NEH-90)

### DIFF
--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -15,6 +15,8 @@ from app.schemas.collection import CollectionCreate, CollectionRead, CollectionU
 from app.schemas.record import ReorderRecords
 from app.core.audit import log_event
 from app.core.config import settings
+from app.core.export_jobs import export_jobs
+from app.core.export_service import run_export
 from app.core.storage_ops import (
     collection_and_descendants,
     relocate_image,
@@ -448,19 +450,13 @@ def export_collection_bagit(
     db: Session = Depends(get_db_dependency)
 ):
     """
-    Package all approved records in this collection as a BagIt zip archive.
+    Start a background BagIt export of this collection and return a job to poll.
 
-    Requires ALL records in the collection to have status 'approved'.
-    The generated zip is saved to the exports directory and a download URL is returned.
+    Requires all records to be approved. The heavy work (integrity verification and
+    streaming the zip straight into the exports dir, with no staging copy) runs in a
+    background job, so proxied clients never hit nginx's read timeout; poll
+    GET /{collection_id}/export/status/{job_id} for progress.
     """
-    import bagit
-    import json
-    import shutil as _shutil
-    import tempfile
-    import zipfile
-    from datetime import datetime, timezone
-    from pathlib import Path as _Path
-
     collection = db.query(Collection).filter(Collection.id == collection_id).first()
     if not collection:
         raise HTTPException(status_code=404, detail=f"Collection {collection_id} not found")
@@ -474,10 +470,8 @@ def export_collection_bagit(
     if not records:
         raise HTTPException(
             status_code=422,
-            detail={"message": "Collection has no records to export.", "blocking_record_ids": []}
+            detail={"message": "Collection has no records to export.", "blocking_record_ids": []},
         )
-
-    # All records must be approved
     non_approved = [r.id for r in records if r.status != "approved"]
     if non_approved:
         raise HTTPException(
@@ -485,179 +479,37 @@ def export_collection_bagit(
             detail={
                 "message": f"Cannot export: {len(non_approved)} record(s) are not approved yet: {non_approved}",
                 "blocking_record_ids": non_approved,
-            }
-        )
-
-    # Gather project info for bag metadata
-    project = db.query(Project).filter(Project.id == collection.project_id).first() if collection.project_id else None
-
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    bag_name = f"collection_{collection_id}_{timestamp}"
-    exports_dir = settings.exports_dir
-    exports_dir.mkdir(parents=True, exist_ok=True)
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = _Path(tmpdir)
-        data_dir = tmp_path / "data"
-        data_dir.mkdir()
-
-        from app.core.paths import resolve_within_storage
-        from app.core.integrity import verify_images_against_manifest
-
-        to_copy = []  # (rec_dir_name, dest_name, resolved_src, img)
-        missing = []
-        used_names: dict = {}
-        for idx, rec in enumerate(records):
-            seq_label = f"{idx + 1:04d}"
-            safe_title = "".join(c if c.isalnum() or c in "-_ " else "_" for c in (rec.title or "record"))[:60]
-            rec_dir_name = f"{seq_label}_{safe_title}"
-            for img in sorted([i for i in rec.images if i.is_current], key=lambda i: (i.role or "z", i.id)):
-                resolved = resolve_within_storage(img.file_path) if img.file_path else None
-                if resolved is None or not resolved.exists():
-                    missing.append({"record_id": rec.id, "record_image_id": img.id, "file_path": img.file_path})
-                    continue
-                role_prefix = img.role or f"img_{img.id}"
-                dest_name = f"{role_prefix}{resolved.suffix}"
-                seen = used_names.setdefault(rec_dir_name, set())
-                if dest_name in seen:
-                    dest_name = f"{role_prefix}_{img.id}{resolved.suffix}"
-                seen.add(dest_name)
-                to_copy.append((rec_dir_name, dest_name, resolved, img))
-
-        if missing:
-            raise HTTPException(
-                status_code=422,
-                detail={
-                    "message": f"Cannot export: {len(missing)} image file(s) missing from disk.",
-                    "missing_image_ids": [m["record_image_id"] for m in missing],
-                    "missing": missing,
-                },
-            )
-
-        mismatches = verify_images_against_manifest([img for _, _, _, img in to_copy])
-        if mismatches:
-            raise HTTPException(
-                status_code=422,
-                detail={
-                    "message": f"Cannot export: {len(mismatches)} file(s) fail their capture-time checksum (possible corruption).",
-                    "mismatched_image_ids": [m["record_image_id"] for m in mismatches],
-                    "mismatches": mismatches,
-                },
-            )
-
-        # Copy the planned payload
-        for rec_dir_name, dest_name, resolved, img in to_copy:
-            rec_dir = data_dir / rec_dir_name
-            rec_dir.mkdir(exist_ok=True)
-            _shutil.copy2(resolved, rec_dir / dest_name)
-
-        expected_rows = sum(1 for rec in records for img in rec.images if img.is_current and img.file_path)
-        copied_files = sum(1 for p in data_dir.rglob("*") if p.is_file())
-        if copied_files != expected_rows or copied_files != len(to_copy):
-            raise HTTPException(
-                status_code=500,
-                detail=f"Export payload incomplete: staged {copied_files} files for {expected_rows} image rows",
-            )
-
-        # Write metadata sidecar before bagging
-        metadata_payload = {
-            "exported_at": timestamp,
-            "collection": {
-                "id": collection.id,
-                "name": collection.name,
-                "description": collection.description,
-                "collection_type": collection.collection_type,
-                "archival_metadata": collection.archival_metadata,
-                "created_by": collection.created_by,
-                "created_at": collection.created_at.isoformat() if collection.created_at else None,
             },
-            "project": {
-                "id": project.id if project else None,
-                "name": project.name if project else None,
-            } if project else None,
-            "records": [
-                {
-                    "id": r.id,
-                    "sequence": r.sequence,
-                    "title": r.title,
-                    "description": r.description,
-                    "object_typology": r.object_typology,
-                    "author": r.author,
-                    "material": r.material,
-                    "date": r.date,
-                    "status": r.status,
-                    "created_by": r.created_by,
-                    "created_at": r.created_at.isoformat() if r.created_at else None,
-                    "images": [
-                        {
-                            "id": img.id,
-                            "filename": img.filename,
-                            "role": img.role,
-                            "sequence": img.sequence,
-                            "format": img.format,
-                            "resolution_width": img.resolution_width,
-                            "resolution_height": img.resolution_height,
-                            "file_size": img.file_size,
-                        }
-                        for img in r.images if img.is_current
-                    ],
-                }
-                for r in records
-            ],
-        }
-        (data_dir / "metadata.json").write_text(
-            json.dumps(metadata_payload, indent=2, ensure_ascii=False),
-            encoding="utf-8"
         )
 
-        from app.core.storage_ops import resolve_project_name
-        from capture.project_manager import project_capture_root
-        capture_ids = {img.capture_id for rec in records for img in rec.images if img.is_current and img.capture_id}
-        if capture_ids:
-            proj_name = resolve_project_name(db, collection)
-            manifest_src = project_capture_root(proj_name) / "metadata" / "manifest.jsonl" if proj_name else None
-            if manifest_src and manifest_src.exists():
-                kept = []
-                for line in manifest_src.read_text(encoding="utf-8").splitlines():
-                    stripped = line.strip()
-                    if not stripped:
-                        continue
-                    try:
-                        entry = json.loads(stripped)
-                    except json.JSONDecodeError:
-                        continue
-                    if entry.get("capture_id") in capture_ids:
-                        kept.append(stripped)
-                if kept:
-                    meta_dir = data_dir / "metadata"
-                    meta_dir.mkdir(exist_ok=True)
-                    (meta_dir / "manifest.jsonl").write_text("\n".join(kept) + "\n", encoding="utf-8")
-
-        # Create BagIt bag in-place
-        bag_metadata = {
-            "Source-Organization": project.name if project else "Digitization Toolkit",
-            "External-Description": collection.description or collection.name,
-            "Bagging-Date": timestamp[:8],
-            "External-Identifier": f"collection-{collection_id}",
-            "Bag-Count": "1 of 1",
-            "Record-Count": str(len(records)),
-        }
-        bagit.make_bag(str(tmp_path), bag_metadata, checksum=["md5", "sha256"])
-
-        # Zip the bag
-        zip_path = exports_dir / f"{bag_name}.zip"
-        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-            for file in tmp_path.rglob("*"):
-                if file.is_file():
-                    zf.write(file, arcname=_Path(bag_name) / file.relative_to(tmp_path))
-
-    logger.info(f"BagIt export created: {zip_path} ({zip_path.stat().st_size} bytes)")
+    # One export per collection at a time: a retry returns the running job instead of
+    # stacking a second export that doubles disk pressure. Integrity checks and the
+    # zip build happen in the job, surfaced via the status endpoint.
+    job = export_jobs.start(collection_id, lambda j: run_export(j, collection_id))
+    log_event(db, level="INFO", category="activity", action="export_started",
+              actor=current_user.username, subject=collection.name)
     return {
-        "bag_name": bag_name,
-        "zip_filename": zip_path.name,
-        "size_bytes": zip_path.stat().st_size,
-        "download_url": f"/collections/{collection_id}/export/download",
+        "job_id": job.id,
+        "state": job.state,
+        "status_url": f"/collections/{collection_id}/export/status/{job.id}",
     }
+
+
+@router.get("/{collection_id}/export/status/{job_id}")
+def export_status(
+    collection_id: int,
+    job_id: str,
+    current_user: User = Depends(allow_read_only),
+    db: Session = Depends(get_db_dependency),
+):
+    """Poll the state and progress of a background export job."""
+    job = export_jobs.get(job_id)
+    if not job or job.collection_id != collection_id:
+        raise HTTPException(status_code=404, detail="Export job not found")
+    body = job.to_dict()
+    if job.state == "done" and job.zip_filename:
+        body["download_url"] = f"/collections/{collection_id}/export/download"
+    return body
 
 
 @router.get("/{collection_id}/export/download")

--- a/app/core/bag_export.py
+++ b/app/core/bag_export.py
@@ -1,0 +1,96 @@
+"""Stream a BagIt archive straight into a zip, without staging a second copy.
+
+The output validates as a BagIt 0.97 bag: unzip it and `bagit.Bag(dir).validate()`
+passes.
+"""
+
+import hashlib
+import zipfile
+from pathlib import Path
+from typing import Callable, Iterable, List, Optional, Tuple
+
+_CHUNK = 1024 * 1024
+
+# (source_path, rel_path) — rel_path is the file's location under data/
+PayloadFile = Tuple[Path, str]
+# (bytes, rel_path) — for generated sidecars (metadata.json, manifest.jsonl)
+PayloadBlob = Tuple[bytes, str]
+
+
+def _manifest_lines(entries: List[Tuple[str, str]]) -> str:
+    # BagIt manifest line: "<checksum>  <path-relative-to-bag>"
+    return "".join(f"{checksum}  {path}\n" for path, checksum in entries)
+
+
+def write_bag_zip(
+    zip_path: Path,
+    bag_name: str,
+    bag_info: dict,
+    payload_files: Iterable[PayloadFile],
+    payload_blobs: Iterable[PayloadBlob] = (),
+    progress_cb: Optional[Callable[[int, int], None]] = None,
+) -> dict:
+    """Write a BagIt bag as a zip at zip_path, reading each source once.
+    Returns a small summary (file_count, total_bytes). progress_cb(done, total) is called after each payload item if given.
+    """
+    payload_files = list(payload_files)
+    payload_blobs = list(payload_blobs)
+    total = len(payload_files) + len(payload_blobs)
+    done = 0
+
+    sha_entries: List[Tuple[str, str]] = []  # (bag-relative path, sha256)
+    md5_entries: List[Tuple[str, str]] = []
+    total_bytes = 0
+
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED, allowZip64=True) as zf:
+        for source_path, rel in payload_files:
+            rel = rel.replace("\\", "/")
+            sha, md5 = hashlib.sha256(), hashlib.md5()
+            size = 0
+            with open(source_path, "rb") as src, zf.open(f"{bag_name}/data/{rel}", "w") as dst:
+                for chunk in iter(lambda: src.read(_CHUNK), b""):
+                    dst.write(chunk)
+                    sha.update(chunk)
+                    md5.update(chunk)
+                    size += len(chunk)
+            sha_entries.append((f"data/{rel}", sha.hexdigest()))
+            md5_entries.append((f"data/{rel}", md5.hexdigest()))
+            total_bytes += size
+            done += 1
+            if progress_cb:
+                progress_cb(done, total)
+
+        for data, rel in payload_blobs:
+            rel = rel.replace("\\", "/")
+            zf.writestr(f"{bag_name}/data/{rel}", data)
+            sha_entries.append((f"data/{rel}", hashlib.sha256(data).hexdigest()))
+            md5_entries.append((f"data/{rel}", hashlib.md5(data).hexdigest()))
+            total_bytes += len(data)
+            done += 1
+            if progress_cb:
+                progress_cb(done, total)
+
+        # Tag files. Payload-Oxum lets a validator check the payload byte/file totals
+        # without reading the files, so include it.
+        info = dict(bag_info)
+        info["Payload-Oxum"] = f"{total_bytes}.{len(sha_entries)}"
+        tag_files = {
+            "bagit.txt": "BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n",
+            "bag-info.txt": "".join(f"{k}: {v}\n" for k, v in info.items()),
+            "manifest-sha256.txt": _manifest_lines(sha_entries),
+            "manifest-md5.txt": _manifest_lines(md5_entries),
+        }
+        for name, content in tag_files.items():
+            zf.writestr(f"{bag_name}/{name}", content)
+
+        # Tag manifests hash the tag files above (not themselves).
+        tag_sha = "".join(
+            f"{hashlib.sha256(c.encode('utf-8')).hexdigest()}  {n}\n" for n, c in tag_files.items()
+        )
+        tag_md5 = "".join(
+            f"{hashlib.md5(c.encode('utf-8')).hexdigest()}  {n}\n" for n, c in tag_files.items()
+        )
+        zf.writestr(f"{bag_name}/tagmanifest-sha256.txt", tag_sha)
+        zf.writestr(f"{bag_name}/tagmanifest-md5.txt", tag_md5)
+
+    return {"file_count": len(sha_entries), "total_bytes": total_bytes}

--- a/app/core/export_jobs.py
+++ b/app/core/export_jobs.py
@@ -1,0 +1,106 @@
+"""In-process registry of background export jobs for the single-process appliance"""
+
+import logging
+import threading
+import time
+import uuid
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ExportJob:
+    def __init__(self, collection_id: int):
+        self.id = uuid.uuid4().hex
+        self.collection_id = collection_id
+        self.state = "queued"        # queued | running | done | failed
+        self.done = 0
+        self.total = 0
+        self.zip_filename: Optional[str] = None
+        self.error: Optional[str] = None       # human-readable message
+        self.detail = None                      # structured detail (e.g. missing/mismatch lists)
+        self.created_at = time.time()
+        self.finished_at: Optional[float] = None
+
+    def set_progress(self, done: int, total: int) -> None:
+        self.done = done
+        self.total = total
+
+    def to_dict(self) -> dict:
+        return {
+            "job_id": self.id,
+            "collection_id": self.collection_id,
+            "state": self.state,
+            "done": self.done,
+            "total": self.total,
+            "zip_filename": self.zip_filename,
+            "error": self.error,
+            "detail": self.detail,
+        }
+
+
+class ExportJobRegistry:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._jobs: dict[str, ExportJob] = {}
+        self._active_by_collection: dict[int, str] = {}
+
+    def active_for(self, collection_id: int) -> Optional[ExportJob]:
+        with self._lock:
+            jid = self._active_by_collection.get(collection_id)
+            job = self._jobs.get(jid) if jid else None
+            if job and job.state in ("queued", "running"):
+                return job
+            return None
+
+    def get(self, job_id: str) -> Optional[ExportJob]:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def start(self, collection_id: int, work: Callable[[ExportJob], None]) -> ExportJob:
+        """Start `work(job)` in a background thread, or return the collection's
+        already-running job so a retry never stacks a second export."""
+        with self._lock:
+            existing_id = self._active_by_collection.get(collection_id)
+            existing = self._jobs.get(existing_id) if existing_id else None
+            if existing and existing.state in ("queued", "running"):
+                return existing
+            job = ExportJob(collection_id)
+            self._jobs[job.id] = job
+            self._active_by_collection[collection_id] = job.id
+        threading.Thread(target=self._run, args=(job, work), daemon=True).start()
+        return job
+
+    def _run(self, job: ExportJob, work: Callable[[ExportJob], None]) -> None:
+        job.state = "running"
+        try:
+            work(job)
+            if job.state == "running":
+                job.state = "done"
+        except ExportError as e:
+            job.state = "failed"
+            job.error = str(e)
+            job.detail = e.detail
+        except Exception as e:
+            job.state = "failed"
+            job.error = str(e)
+            logger.exception(f"Export job {job.id} for collection {job.collection_id} failed")
+        finally:
+            job.finished_at = time.time()
+            with self._lock:
+                if self._active_by_collection.get(job.collection_id) == job.id:
+                    del self._active_by_collection[job.collection_id]
+
+
+class ExportError(Exception):
+    """Expected export failure (missing files, checksum mismatch, low disk).
+
+    Carries an optional structured `detail` the status endpoint surfaces to the UI.
+    """
+    def __init__(self, message: str, detail=None):
+        super().__init__(message)
+        self.detail = detail
+
+
+# Module-level singleton shared across requests in the single backend process
+export_jobs = ExportJobRegistry()

--- a/app/core/export_service.py
+++ b/app/core/export_service.py
@@ -1,0 +1,204 @@
+"""The work a background export job runs: validate, check disk, stream the bag,
+prune old zips. Runs in a worker thread with its own DB session.
+"""
+
+import json
+import logging
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.core import config
+from app.core.bag_export import write_bag_zip
+from app.core.export_jobs import ExportError, ExportJob
+from app.core.integrity import verify_images_against_manifest
+from app.core.paths import resolve_within_storage
+from app.core.storage_ops import resolve_project_name
+from app.models.collection import Collection
+from app.models.project import Project
+from app.models.record import Record
+
+logger = logging.getLogger(__name__)
+
+# Keep the most recent N export zips per collection; older ones are pruned so the
+# SD does not fill up with archives no one downloads.
+EXPORT_KEEP = 3
+# Free-space safety margin on top of the estimated bag size.
+FREE_SPACE_MARGIN = 100 * 1024 * 1024
+
+
+def run_export(job: ExportJob, collection_id: int) -> None:
+    from app.core.db import SessionLocal
+    db = SessionLocal()
+    try:
+        _do_export(db, job, collection_id)
+    finally:
+        db.close()
+
+
+def _do_export(db, job: ExportJob, collection_id: int) -> None:
+    collection = db.query(Collection).filter(Collection.id == collection_id).first()
+    if not collection:
+        raise ExportError(f"Collection {collection_id} not found")
+
+    records = (
+        db.query(Record)
+        .filter(Record.collection_id == collection_id)
+        .order_by(Record.sequence.nulls_last(), Record.id)
+        .all()
+    )
+    project = db.query(Project).filter(Project.id == collection.project_id).first() if collection.project_id else None
+
+    exports_dir = config.settings.exports_dir
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bag_name = f"collection_{collection_id}_{timestamp}"
+
+    # Plan the payload: resolve every current image, refuse on any missing file, and give each a unique name so the payload cannot disagree with metadata.json.
+    to_copy = []   # (rel_under_data, resolved_src, img)
+    missing = []
+    used_names: dict = {}
+    for idx, rec in enumerate(records):
+        seq_label = f"{idx + 1:04d}"
+        safe_title = "".join(c if c.isalnum() or c in "-_ " else "_" for c in (rec.title or "record"))[:60]
+        rec_dir_name = f"{seq_label}_{safe_title}"
+        for img in sorted([i for i in rec.images if i.is_current], key=lambda i: (i.role or "z", i.id)):
+            resolved = resolve_within_storage(img.file_path) if img.file_path else None
+            if resolved is None or not resolved.exists():
+                missing.append({"record_id": rec.id, "record_image_id": img.id, "file_path": img.file_path})
+                continue
+            role_prefix = img.role or f"img_{img.id}"
+            dest_name = f"{role_prefix}{resolved.suffix}"
+            seen = used_names.setdefault(rec_dir_name, set())
+            if dest_name in seen:
+                dest_name = f"{role_prefix}_{img.id}{resolved.suffix}"
+            seen.add(dest_name)
+            to_copy.append((f"{rec_dir_name}/{dest_name}", resolved, img))
+
+    if missing:
+        raise ExportError(
+            f"{len(missing)} image file(s) missing from disk.",
+            detail={"reason": "missing_files", "missing_image_ids": [m["record_image_id"] for m in missing], "missing": missing},
+        )
+
+    # Fixity gate: refuse to bag bytes that no longer match their capture-time sha256.
+    mismatches = verify_images_against_manifest([img for _, _, img in to_copy])
+    if mismatches:
+        raise ExportError(
+            f"{len(mismatches)} file(s) fail their capture-time checksum (possible corruption).",
+            detail={"reason": "checksum_mismatch", "mismatched_image_ids": [m["record_image_id"] for m in mismatches], "mismatches": mismatches},
+        )
+
+    # Refuse to start if the exports filesystem can't hold the archive.
+    total_src = sum(resolved.stat().st_size for _, resolved, _ in to_copy)
+    free = shutil.disk_usage(exports_dir).free
+    if free < total_src + FREE_SPACE_MARGIN:
+        raise ExportError(
+            "Not enough free space on the exports filesystem to build this archive.",
+            detail={"reason": "low_disk", "needed_bytes": total_src + FREE_SPACE_MARGIN, "free_bytes": free},
+        )
+
+    metadata_payload = _metadata_payload(collection, project, records, timestamp)
+    blobs = [(json.dumps(metadata_payload, indent=2, ensure_ascii=False).encode("utf-8"), "metadata.json")]
+    manifest_blob = _filtered_manifest_blob(db, collection, records)
+    if manifest_blob:
+        blobs.append((manifest_blob, "metadata/manifest.jsonl"))
+
+    payload_files = [(resolved, rel) for rel, resolved, _ in to_copy]
+    bag_info = {
+        "Source-Organization": project.name if project else "Digitization Toolkit",
+        "External-Description": collection.description or collection.name,
+        "Bagging-Date": timestamp[:8],
+        "External-Identifier": f"collection-{collection_id}",
+        "Bag-Count": "1 of 1",
+        "Record-Count": str(len(records)),
+    }
+
+    # Write the zip straight into the exports dir, atomically via a .part file so a
+    # crash mid-write never leaves a truncated zip that download would serve.
+    job.set_progress(0, len(payload_files) + len(blobs))
+    zip_path = exports_dir / f"{bag_name}.zip"
+    part_path = exports_dir / f"{bag_name}.zip.part"
+    try:
+        write_bag_zip(part_path, bag_name, bag_info, payload_files, blobs,
+                      progress_cb=job.set_progress)
+        part_path.replace(zip_path)
+    except Exception:
+        part_path.unlink(missing_ok=True)
+        raise
+
+    job.zip_filename = zip_path.name
+    _prune_exports(exports_dir, collection_id)
+    logger.info(f"BagIt export created: {zip_path} ({zip_path.stat().st_size} bytes)")
+
+
+def _metadata_payload(collection, project, records, timestamp) -> dict:
+    return {
+        "exported_at": timestamp,
+        "collection": {
+            "id": collection.id,
+            "name": collection.name,
+            "description": collection.description,
+            "collection_type": collection.collection_type,
+            "archival_metadata": collection.archival_metadata,
+            "created_by": collection.created_by,
+            "created_at": collection.created_at.isoformat() if collection.created_at else None,
+        },
+        "project": {"id": project.id, "name": project.name} if project else None,
+        "records": [
+            {
+                "id": r.id, "sequence": r.sequence, "title": r.title, "description": r.description,
+                "object_typology": r.object_typology, "author": r.author, "material": r.material,
+                "date": r.date, "status": r.status, "created_by": r.created_by,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+                "images": [
+                    {
+                        "id": img.id, "filename": img.filename, "role": img.role, "sequence": img.sequence,
+                        "format": img.format, "resolution_width": img.resolution_width,
+                        "resolution_height": img.resolution_height, "file_size": img.file_size,
+                    }
+                    for img in r.images if img.is_current
+                ],
+            }
+            for r in records
+        ],
+    }
+
+
+def _filtered_manifest_blob(db, collection, records):
+    """The project's capture manifest, filtered to this collection's captures."""
+    from capture.project_manager import secure_project_filename
+    capture_ids = {img.capture_id for rec in records for img in rec.images if img.is_current and img.capture_id}
+    if not capture_ids:
+        return None
+    proj_name = resolve_project_name(db, collection)
+    if not proj_name:
+        return None
+    manifest_src = config.settings.projects_dir / secure_project_filename(proj_name) / "metadata" / "manifest.jsonl"
+    if not manifest_src.exists():
+        return None
+    kept = []
+    for line in manifest_src.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            entry = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if entry.get("capture_id") in capture_ids:
+            kept.append(stripped)
+    return ("\n".join(kept) + "\n").encode("utf-8") if kept else None
+
+
+def _prune_exports(exports_dir: Path, collection_id: int, keep: int = EXPORT_KEEP) -> None:
+    """Keep the newest `keep` zips for this collection; delete older zips and any
+    stale .part files left by an interrupted export."""
+    for part in exports_dir.glob(f"collection_{collection_id}_*.zip.part"):
+        part.unlink(missing_ok=True)
+    zips = sorted(exports_dir.glob(f"collection_{collection_id}_*.zip"), reverse=True)
+    for old in zips[keep:]:
+        try:
+            old.unlink()
+        except OSError:
+            logger.warning(f"Could not prune old export {old}")

--- a/tests/unit/test_export_integrity.py
+++ b/tests/unit/test_export_integrity.py
@@ -1,7 +1,9 @@
 """Export refuses to produce a misleading bag: a missing source file or a file
-whose bytes no longer match its capture-time checksum both hard-fail the export."""
+whose bytes no longer match its capture-time checksum both fail the export. 
+The export runs as a background job, so these surface as a failed job with detail."""
 
 import json
+import time
 
 import pytest
 
@@ -37,6 +39,18 @@ def _approved_collection(db_session):
     return col, rec
 
 
+def _run_to_completion(client, collection_id, job_id, timeout=15.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        r = client.get(f"/collections/{collection_id}/export/status/{job_id}")
+        assert r.status_code == 200, r.text
+        st = r.json()
+        if st["state"] in ("done", "failed"):
+            return st
+        time.sleep(0.05)
+    raise AssertionError("export job did not finish in time")
+
+
 def test_export_rejects_missing_source_file(export_client, db_session):
     from app.models.record import RecordImage
     col, rec = _approved_collection(db_session)
@@ -47,8 +61,11 @@ def test_export_rejects_missing_source_file(export_client, db_session):
     db_session.refresh(img)
 
     resp = export_client.post(f"/collections/{col.id}/export")
-    assert resp.status_code == 422, resp.text
-    assert img.id in resp.json()["detail"]["missing_image_ids"]
+    assert resp.status_code == 202, resp.text
+    st = _run_to_completion(export_client, col.id, resp.json()["job_id"])
+    assert st["state"] == "failed"
+    assert st["detail"]["reason"] == "missing_files"
+    assert img.id in st["detail"]["missing_image_ids"]
 
 
 def test_export_rejects_file_that_fails_capture_time_checksum(export_client, db_session, override_projects_root):
@@ -74,5 +91,67 @@ def test_export_rejects_file_that_fails_capture_time_checksum(export_client, db_
     db_session.refresh(img)
 
     resp = export_client.post(f"/collections/{col.id}/export")
-    assert resp.status_code == 422, resp.text
-    assert img.id in resp.json()["detail"]["mismatched_image_ids"]
+    assert resp.status_code == 202, resp.text
+    st = _run_to_completion(export_client, col.id, resp.json()["job_id"])
+    assert st["state"] == "failed"
+    assert st["detail"]["reason"] == "checksum_mismatch"
+    assert img.id in st["detail"]["mismatched_image_ids"]
+
+
+def test_export_produces_valid_bag_with_manifest(export_client, db_session, override_projects_root, monkeypatch, tmp_path):
+    import hashlib, zipfile, bagit
+    from app.core import config
+    from app.models.record import RecordImage
+
+    exports = tmp_path / "exp"
+    exports.mkdir()
+    monkeypatch.setattr(config.settings, "EXPORTS_ROOT", str(exports))
+
+    proot = override_projects_root / "P"
+    (proot / "images").mkdir(parents=True)
+    (proot / "metadata").mkdir(parents=True)
+    f = proot / "images" / "cap.jpg"
+    f.write_bytes(b"captured bytes here")
+    sha = hashlib.sha256(b"captured bytes here").hexdigest()
+    (proot / "metadata" / "manifest.jsonl").write_text(
+        json.dumps({"capture_id": "cid1", "files": [
+            {"role": "single", "relative_path": "images/cap.jpg", "sha256": sha}]}) + "\n")
+
+    col, rec = _approved_collection(db_session)
+    db_session.add(RecordImage(record_id=rec.id, filename="cap.jpg", file_path=str(f),
+                               format="jpg", role="single", capture_id="cid1", is_current=True))
+    db_session.commit()
+
+    resp = export_client.post(f"/collections/{col.id}/export")
+    assert resp.status_code == 202, resp.text
+    st = _run_to_completion(export_client, col.id, resp.json()["job_id"])
+    assert st["state"] == "done", st
+    assert "download_url" in st
+
+    zname = st["zip_filename"]
+    zpath = exports / zname
+    ext = tmp_path / "ext"
+    with zipfile.ZipFile(zpath) as zf:
+        names = zf.namelist()
+        zf.extractall(ext)
+    assert any(n.endswith("data/metadata/manifest.jsonl") for n in names), names
+    # The manually built archive validates as a real BagIt bag.
+    bagit.Bag(str(ext / zname[:-4])).validate()
+
+
+def test_prune_exports_keeps_newest(tmp_path):
+    from app.core.export_service import _prune_exports
+    import time as _t
+    for i in range(5):
+        (tmp_path / f"collection_7_2026010{i}T000000Z.zip").write_bytes(b"z")
+        _t.sleep(0.01)
+    (tmp_path / "collection_7_20260109T000000Z.zip.part").write_bytes(b"partial")
+    _prune_exports(tmp_path, 7, keep=3)
+    remaining = sorted(p.name for p in tmp_path.glob("collection_7_*.zip"))
+    assert len(remaining) == 3
+    # newest kept
+    assert remaining == ["collection_7_20260102T000000Z.zip",
+                         "collection_7_20260103T000000Z.zip",
+                         "collection_7_20260104T000000Z.zip"]
+    # stale .part cleaned
+    assert list(tmp_path.glob("*.part")) == []


### PR DESCRIPTION
## Summary

BagIt export ran **synchronously**, staged a **full copy of the collection through `/tmp`**, and **never pruned** old zips. On a real book of full-res JPEG+CR2, this meant:

* ~2x the collection size in transient free space (the staging copy **plus** the zip);
* the request outran nginx's `proxy_read_timeout` (120s), so every proxied client, including the kiosk on `/api`, got a **504** while the backend kept zipping, and the operator's retry **stacked a second export**, doubling the disk pressure;
* old `collection_*_*.zip` files accumulated until the SD filled, increasing the corruption risk.

This makes export a background job that streams the archive straight to disk, checks free space first, and caps how many zips it keeps.

## Changes

* **`bag_export.py` (new) - single-pass streaming BagIt.** Builds the bag *inside the final zip*, reading each source file exactly once and computing its sha256/md5 while it streams in; then writes the BagIt tag files (`bagit.txt`, `bag-info.txt` with `Payload-Oxum`, `manifest-*.txt`, `tagmanifest-*.txt`) from those hashes. **No staging directory, no second copy.** The output validates as a real BagIt 0.97 bag (`bagit.Bag(dir).validate()` passes).
* **`export_jobs.py` (new) - in-process job registry.** The endpoint returns a `job_id` immediately and the work runs in a daemon thread; the UI polls status. In-memory by design (the backend is one uvicorn process; no Celery/Redis). **One job per collection at a time**, so a retry returns the running job instead of stacking a second export.
* **`export_service.py` (new) - the job's work**, on its own DB session: plan the payload, **fail on any missing file** and **on any capture-time checksum mismatch** (carried over from NEH-123/124), **check free space** before writing, stream the zip **atomically** (`.zip.part` -> rename), and **prune** to the newest few zips.
* **`collections.py`** - `POST /{id}/export` now returns `202 {job_id, status_url}` after cheap validation (records exist, all approved -> structured `422` as before); new `GET /{id}/export/status/{job_id}` reports `state`/`done`/`total`/`error`/`detail` and the `download_url` when done. `GET .../export/download` is unchanged.

## Criteria

* [x] Export runs as a background task with progress
* [x] No proxied client 504s at 120s (POST returns immediately)
* [x] Staging is on the exports filesystem, not `/tmp` - in fact there is **no** staging
* [x] No second full copy (streamed from the sources)
* [x] Old zips pruned/capped (newest 3 per collection; stale `.part` files cleaned)
* [x] Free space checked before starting

## Testing

`tests/unit/test_export_integrity.py` (TestClient + SQLite):

* missing source file -> job **failed** with `reason: missing_files` and the image id;
* checksum mismatch -> job **failed** with `reason: checksum_mismatch`;
* happy path -> job **done**, the produced zip **validates with `bagit`** and contains `data/metadata/manifest.jsonl`;
* `_prune_exports` keeps the newest 3 and removes stale `.part` files.

Full unit suite: 115 passed, 5 skipped.

## Notes

* The runtime no longer imports `bagit` for export (the bag is built directly); `bagit` remains a dependency, now used only by the tests to validate the output.
* Companion frontend PR polls the job and shows progress.
* Builds on the NEH-123/124 integrity work (already merged in #72).

Closes NEH-90.