### PR TITLE
fix(export): block approved records with no image, reset status on last-image delete

### DIFF
--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -482,6 +482,16 @@ def export_collection_bagit(
             },
         )
 
+    image_less = [r.id for r in records if not any(i.is_current for i in r.images)]
+    if image_less:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": f"Cannot export: {len(image_less)} record(s) have no image: {image_less}",
+                "blocking_record_ids": image_less,
+            },
+        )
+
     # One export per collection at a time: a retry returns the running job instead of
     # stacking a second export that doubles disk pressure. Integrity checks and the
     # zip build happen in the job, surfaced via the status endpoint.

--- a/app/api/records.py
+++ b/app/api/records.py
@@ -440,8 +440,15 @@ def delete_image(
 	if thumbnail_path:
 		delete_thumbnail(str(thumbnail_path))
 	
+	record_id = img.record_id
 	db.delete(img)
 	db.commit()
+
+	record = db.query(Record).filter(Record.id == record_id).first()
+	if record and record.status == "approved" and not any(i.is_current for i in record.images):
+		record.status = "in_review"
+		db.add(record)
+		db.commit()
 	return {"detail": "Image deleted"}
 
 

--- a/tests/unit/test_collections_order_count_export_detail.py
+++ b/tests/unit/test_collections_order_count_export_detail.py
@@ -273,3 +273,27 @@ def test_export_non_approved_records_returns_structured_422(contributor_client, 
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+@pytest.mark.unit
+def test_export_blocks_approved_record_with_no_image(contributor_client, db_session):
+    from app.models.project import Project
+    from app.models.collection import Collection
+    from app.models.record import Record, RecordImage
+
+    proj = Project(name="P"); db_session.add(proj); db_session.commit()
+    col = Collection(name="C", project_id=proj.id); db_session.add(col); db_session.commit()
+
+    r_ok = Record(title="ok", collection_id=col.id, status="approved", capture_mode="single")
+    r_empty = Record(title="empty", collection_id=col.id, status="approved", capture_mode="single")
+    db_session.add_all([r_ok, r_empty]); db_session.commit()
+    db_session.refresh(r_ok); db_session.refresh(r_empty)
+    db_session.add(RecordImage(record_id=r_ok.id, filename="x.jpg", file_path="/x.jpg",
+                               format="jpg", role="single", is_current=True))
+    db_session.commit()
+
+    resp = contributor_client.post(f"/collections/{col.id}/export")
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert r_empty.id in detail["blocking_record_ids"]
+    assert r_ok.id not in detail["blocking_record_ids"]


### PR DESCRIPTION
An approved record whose only image was removed (e.g. a failed retake) passed the export gate and silently dropped pages from the bag. Require at least one current image per approved record in the server-side export gate (listed in blocking_record_ids), and drop an approved record back to in_review when its last current image is deleted.