### PR TITLE
fix(api): sanitize constraint-violation responses; no SQL in 409 bodies

### DIFF
--- a/app/api/API_spec.yaml
+++ b/app/api/API_spec.yaml
@@ -623,7 +623,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/RecordRead'
         '409':
-          description: Database integrity error
+          description: Sanitized constraint violation (constraint name and message, no SQL)
+        '422':
+          description: Validation error (e.g. a record given both a project and a collection)
 
     get:
       summary: List all records with optional filtering

--- a/app/api/cameras.py
+++ b/app/api/cameras.py
@@ -17,6 +17,7 @@ from app.models.collection import Collection
 from app.schemas.camera import CameraSettingsCreate, CameraSettingsRead, CameraSettingsUpdate
 from app.core.thumbnail import generate_thumbnail
 from app.core.storage_ops import resolve_project_name
+from app.core.db_errors import integrity_conflict
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -1120,9 +1121,9 @@ def create_camera_settings(
 		db.add(cs)
 		db.commit()
 		db.refresh(cs)
-	except IntegrityError:
+	except IntegrityError as e:
 		db.rollback()
-		raise HTTPException(status_code=409, detail="Camera settings already exist for this record")
+		raise integrity_conflict(e)
 	return CameraSettingsRead.model_validate(cs)
 
 

--- a/app/api/projects.py
+++ b/app/api/projects.py
@@ -25,6 +25,7 @@ from app.models.user import User
 from app.schemas.project import ProjectCreate, ProjectRead, ProjectBase, ProjectUpdate
 from app.schemas.project_member import ProjectMemberCreate, ProjectMemberRead
 from app.core.audit import log_event
+from app.core.db_errors import integrity_conflict
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -106,9 +107,9 @@ def add_record_to_project(
     db.add(r)
     try:
         db.commit()
-    except IntegrityError:
+    except IntegrityError as e:
         db.rollback()
-        raise HTTPException(status_code=409, detail="Record parent assignment violates a database constraint")
+        raise integrity_conflict(e)
     return {"detail": "record added"}
 
 

--- a/app/api/records.py
+++ b/app/api/records.py
@@ -22,6 +22,7 @@ from app.schemas.record import (
 	RecordRejectRequest, RecordRejectionRead,
 )
 from app.core.config import settings
+from app.core.db_errors import integrity_conflict
 from app.core.paths import resolve_within_storage
 from app.core.thumbnail import generate_thumbnail, delete_thumbnail
 from app.core.audit import log_event
@@ -103,7 +104,7 @@ def create_record(
 		db.refresh(rec)
 	except IntegrityError as e:
 		db.rollback()
-		raise HTTPException(status_code=409, detail=f"Database integrity error: {str(e)}")
+		raise integrity_conflict(e)
 	
 	return RecordRead.model_validate(rec)
 
@@ -210,9 +211,9 @@ def update_record(
 	db.add(rec)
 	try:
 		db.commit()
-	except IntegrityError:
+	except IntegrityError as e:
 		db.rollback()
-		raise HTTPException(status_code=409, detail="Record parent assignment violates a database constraint")
+		raise integrity_conflict(e)
 	db.refresh(rec)
 	return _serialize_record(rec)
 

--- a/app/core/db_errors.py
+++ b/app/core/db_errors.py
@@ -1,0 +1,52 @@
+"""Map SQLAlchemy IntegrityError to sanitized API responses.
+
+The appliance is LAN-exposed on port 80, so constraint-violation responses must
+never echo the offending SQL statement or its bound parameters. This module
+turns an IntegrityError into a 409 carrying only the violated constraint name
+and a human-readable message.
+"""
+from typing import Optional
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+
+# Friendly messages keyed by the canonical (Postgres) constraint name. Anything
+# not listed falls back to _DEFAULT_MESSAGE; the constraint name is still returned.
+_CONSTRAINT_MESSAGES = {
+	"check_record_single_parent": "A record belongs to either a project or a collection, not both.",
+	"camera_settings_record_image_id_key": "Camera settings already exist for this record.",
+}
+
+# SQLite names unnamed constraints differently from Postgres; map the substrings
+# it prints back to the canonical name so responses are uniform across engines.
+_SQLITE_ALIASES = {
+	"check_record_single_parent": "check_record_single_parent",
+	"camera_settings.record_image_id": "camera_settings_record_image_id_key",
+}
+
+_DEFAULT_MESSAGE = "The request conflicts with a database constraint."
+
+
+def constraint_name(exc: IntegrityError) -> Optional[str]:
+	"""Best-effort canonical name of the violated constraint, or None. Never returns SQL or bound parameters."""
+	orig = getattr(exc, "orig", None)
+	if orig is None:
+		return None
+	# Postgres (psycopg): structured diagnostics carry the constraint name directly.
+	name = getattr(getattr(orig, "diag", None), "constraint_name", None)
+	if name:
+		return name
+	# SQLite: recover the canonical name from the short message text.
+	text = str(orig)
+	for token, canonical in _SQLITE_ALIASES.items():
+		if token in text:
+			return canonical
+	return None
+
+
+def integrity_conflict(exc: IntegrityError) -> HTTPException:
+	"""Build a sanitized 409 for a DB integrity violation, exposing the constraint name and a friendly message only."""
+	name = constraint_name(exc)
+	detail = {"message": _CONSTRAINT_MESSAGES.get(name, _DEFAULT_MESSAGE)}
+	if name:
+		detail["constraint"] = name
+	return HTTPException(status_code=409, detail=detail)

--- a/app/schemas/record.py
+++ b/app/schemas/record.py
@@ -169,6 +169,12 @@ class RecordCreate(RecordBase):
 	collection_id: Optional[int] = None
 	created_by: Optional[str] = None
 
+	@model_validator(mode="after")
+	def _single_parent(self):
+		if self.project_id is not None and self.collection_id is not None:
+			raise ValueError("A record belongs to either a project or a collection, not both.")
+		return self
+
 
 class RecordUpdate(BaseModel):
 	title: Optional[str] = None

--- a/tests/unit/test_integrity_error_sanitization.py
+++ b/tests/unit/test_integrity_error_sanitization.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Constraint-violation responses must never echo SQL or bound parameters.
+
+Guards the sanitized 409 helper and the schema-level single-parent rule that
+keeps a record's project/collection conflict from reaching the database at all.
+"""
+import pytest
+from sqlalchemy.exc import IntegrityError
+from pydantic import ValidationError
+
+from app.core.db_errors import integrity_conflict, constraint_name
+from app.schemas.record import RecordCreate
+
+
+class _SqliteOrig(Exception):
+    def __str__(self):
+        return "CHECK constraint failed: check_record_single_parent"
+
+
+def _integrity_error():
+    return IntegrityError(
+        "INSERT INTO records (project_id, collection_id) VALUES (?, ?)",
+        [1, 2],
+        _SqliteOrig(),
+    )
+
+
+@pytest.mark.unit
+def test_integrity_conflict_never_leaks_sql_or_params():
+    exc = integrity_conflict(_integrity_error())
+    assert exc.status_code == 409
+    body = str(exc.detail)
+    assert "INSERT" not in body
+    assert "VALUES" not in body
+    assert "records" not in body
+
+
+@pytest.mark.unit
+def test_integrity_conflict_reports_constraint_name():
+    exc = integrity_conflict(_integrity_error())
+    assert exc.detail["constraint"] == "check_record_single_parent"
+    assert constraint_name(_integrity_error()) == "check_record_single_parent"
+
+
+@pytest.mark.unit
+def test_sqlite_unique_message_maps_to_canonical_name():
+    class _UniqueOrig(Exception):
+        def __str__(self):
+            return "UNIQUE constraint failed: camera_settings.record_image_id"
+
+    exc = integrity_conflict(IntegrityError("INSERT ...", [1], _UniqueOrig()))
+    assert exc.status_code == 409
+    assert exc.detail["constraint"] == "camera_settings_record_image_id_key"
+    assert "INSERT" not in str(exc.detail)
+
+
+@pytest.mark.unit
+def test_record_create_rejects_two_parents_before_db():
+    with pytest.raises(ValidationError):
+        RecordCreate(title="x", capture_mode="single", project_id=1, collection_id=2)


### PR DESCRIPTION
Route IntegrityError through a shared helper that returns a 409 with only the constraint name and a friendly message across records, projects and camera settings. Validate the record single-parent rule at the schema layer (422) so the conflict never reaches the database.