### PR TITLE
Feature/neh 176 a corrupt storage override file must not 500 the whole app

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -180,43 +180,34 @@ class ActivateStorageRequest(BaseModel):
 def get_storage_info(current_user: User = Depends(allow_read_only)):
     """Return current projects path and disk usage figures."""
     from app.core.config import settings
-    from app.core.storage_override import get_storage_override, StorageOverrideError
+    from app.core.storage_override import get_storage_override_or_fallback
 
-    # An unreadable override is surfaced as an error, not treated as "no override"
-    try:
-        projects_path = settings.projects_dir
-        is_override = get_storage_override() is not None
-    except StorageOverrideError as e:
-        return {
-            "projects_path": None,
-            "is_override":   True,
-            "error":         str(e),
-            "total_bytes":   0,
-            "used_bytes":    0,
-            "free_bytes":    0,
-            "available":     False,
-        }
+    # A corrupt override reverts to internal storage; override_invalid flags the fallback for a UI warning.
+    override, override_invalid = get_storage_override_or_fallback()
+    projects_path = settings.projects_dir
 
     try:
         projects_path.mkdir(parents=True, exist_ok=True)
         usage = shutil.disk_usage(projects_path)
     except OSError:
         return {
-            "projects_path": str(projects_path),
-            "is_override":   is_override,
-            "total_bytes":   0,
-            "used_bytes":    0,
-            "free_bytes":    0,
-            "available":     False,
+            "projects_path":    str(projects_path),
+            "is_override":      override is not None,
+            "override_invalid": override_invalid,
+            "total_bytes":      0,
+            "used_bytes":       0,
+            "free_bytes":       0,
+            "available":        False,
         }
 
     return {
-        "projects_path": str(projects_path),
-        "is_override":   is_override,
-        "total_bytes":   usage.total,
-        "used_bytes":    usage.used,
-        "free_bytes":    usage.free,
-        "available":     True,
+        "projects_path":    str(projects_path),
+        "is_override":      override is not None,
+        "override_invalid": override_invalid,
+        "total_bytes":      usage.total,
+        "used_bytes":       usage.used,
+        "free_bytes":       usage.free,
+        "available":        True,
     }
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -43,8 +43,10 @@ class Settings(BaseSettings):
     
     @property
     def projects_dir(self) -> Path:
-        from app.core.storage_override import get_storage_override
-        override = get_storage_override()
+        # A corrupt override value (e.g. a path to a non-existent disk) is treated as "no override" so the fallback root is used instead. 
+        # This avoids splitting a project across two disks if the operator accidentally removes the external drive.
+        from app.core.storage_override import get_storage_override_or_fallback
+        override, _corrupt = get_storage_override_or_fallback()
         if override:
             return Path(override)
         return Path(self.PROJECTS_ROOT) if self.PROJECTS_ROOT else (self.data_dir / "projects")

--- a/app/core/storage_override.py
+++ b/app/core/storage_override.py
@@ -5,7 +5,9 @@ Stored in /var/lib/dtk/storage-override.json so it survives backend restarts
 without requiring an env var change or service restart.
 
 A missing override file means "no override" and is normal. An override file that
-exists but cannot be read raises StorageOverrideError, so a corrupt file surfaces as an error instead of a silent fallback to the internal SD.
+exists but cannot be read raises StorageOverrideError from the low-level reader;
+callers use get_storage_override_or_fallback to log it and revert to internal
+storage rather than let one corrupt file 500 the whole app.
 """
 import json
 import logging
@@ -33,6 +35,15 @@ def get_storage_override() -> str | None:
             f"[ERROR] Storage override file '{_OVERRIDE_FILE}' exists but is unreadable; the active storage path is unknown. Re-activate the storage drive or clear the override."
         ) from e
     return str(value) if value else None
+
+
+def get_storage_override_or_fallback() -> tuple[str | None, bool]:
+    """Return (override_path_or_None, corrupt). Never raises: a corrupt override file is logged and reported as corrupt=True so callers fall back to internal storage instead of turning every request into a 500."""
+    try:
+        return get_storage_override(), False
+    except StorageOverrideError:
+        logger.error("[ERROR] Storage override unreadable; falling back to internal storage")
+        return None, True
 
 
 def set_storage_override(projects_root: str) -> None:


### PR DESCRIPTION
projects_dir consulted a low-level reader that raised on an unreadable override file, so one corrupt file 500'd every request. Read it through a wrapper that logs and reverts to internal storage, and surface override_invalid on GET /system/storage for a UI warning.