### PR TITLE
fix(projects): crash-safe project rename via intent journal

### DIFF
--- a/app/api/projects.py
+++ b/app/api/projects.py
@@ -159,19 +159,29 @@ def update_project(
     # keyed by name, so a rename moves the entire directory as a unit and rewrites
     # the stored paths. This keeps every capture and its manifest together and
     # leaves no stranded old-name directory for delete_project to miss later.
+    moved = False
+    wrote_journal = False
+    old_root = new_root = None
     if name_changed:
         from capture.project_manager import secure_project_filename, project_capture_root
+        from app.core.storage_ops import write_rename_journal, clear_rename_journal
 
         # secure_project_filename collapses many display names onto one directory,
         # so only touch the disk when the directory name actually changes.
         if secure_project_filename(old_name) != secure_project_filename(p.name):
             old_root = project_capture_root(old_name)
             new_root = project_capture_root(p.name)
+            # Record intent durably before the move so a crash between the move
+            # and the commit is repairable at startup rather than left dangling.
+            write_rename_journal(p.id, old_name, p.name, old_root, new_root)
+            wrote_journal = True
             try:
                 moved = move_project_tree(old_root, new_root)
             except FileExistsError:
+                clear_rename_journal()
                 raise HTTPException(status_code=409, detail="A project directory with this name already exists on disk")
             except OSError as e:
+                clear_rename_journal()
                 logger.error(f"Failed to move project directory {old_root} -> {new_root}: {e}")
                 raise HTTPException(status_code=500, detail="Failed to move project files on disk")
 
@@ -187,7 +197,21 @@ def update_project(
                         img.thumbnail_path = new_tp
 
     db.add(p)
-    db.commit()
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        # Undo the on-disk move so the filesystem matches the rolled-back DB.
+        if moved and old_root is not None:
+            try:
+                move_project_tree(new_root, old_root)
+            except OSError:
+                logger.exception("Failed to roll back project directory move; startup reconciliation will repair")
+        if wrote_journal:
+            clear_rename_journal()
+        raise
+    if wrote_journal:
+        clear_rename_journal()
     db.refresh(p)
     return ProjectRead.model_validate(p)
 

--- a/app/core/storage_ops.py
+++ b/app/core/storage_ops.py
@@ -6,6 +6,7 @@ records are re-parented (move) or their container is removed (delete), and
 provide the guard that stops a delete from erasing files still referenced by surviving records.
 """
 
+import json
 import logging
 import os
 import shutil
@@ -178,6 +179,105 @@ def rebase_stored_path(stored: Optional[str], old_root: Path, new_root: Path) ->
     except (OSError, ValueError):
         return None
     return str(new_root / rel)
+
+
+# ---------------------------------------------------------------------------
+# Crash-safe project rename
+#
+# A rename moves the on-disk tree and then commits the new name/paths to the DB
+# - two steps that cannot share one transaction. On this power-loss-prone
+# appliance a crash between them would leave files at the new path while the DB
+# still points at the old one, dangling every record path. write_rename_journal
+# records intent durably before the move; reconcile_pending_rename replays or
+# discards it at startup so recovery is mechanical, not a manual SSH repair.
+# ---------------------------------------------------------------------------
+
+def _rename_journal_file() -> Path:
+    from app.core.config import settings
+    return settings.data_dir / "project-rename.journal"
+
+
+def write_rename_journal(project_id: int, old_name: str, new_name: str, old_root: Path, new_root: Path) -> None:
+    """Durably record intent to rename, before the on-disk move happens."""
+    from capture.utils import atomic_write
+
+    path = _rename_journal_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps({
+        "project_id": project_id,
+        "old_name": old_name,
+        "new_name": new_name,
+        "old_root": str(old_root),
+        "new_root": str(new_root),
+    }, indent=2)
+    atomic_write(path, lambda tmp: Path(tmp).write_text(payload, encoding="utf-8"))
+
+
+def clear_rename_journal() -> None:
+    """Remove the journal once the rename has fully committed (or been undone)."""
+    try:
+        _rename_journal_file().unlink(missing_ok=True)
+    except OSError:
+        logger.exception("[ERROR] Failed to clear project rename journal")
+
+
+def read_rename_journal() -> Optional[dict]:
+    path = _rename_journal_file()
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        logger.exception("[ERROR] Project rename journal is unreadable; discarding it")
+        clear_rename_journal()
+        return None
+
+
+def reconcile_pending_rename(db: Session) -> None:
+    """Replay or discard a rename interrupted by a crash. Idempotent; safe at every startup."""
+    j = read_rename_journal()
+    if not j:
+        return
+
+    project = db.query(Project).filter(Project.id == j["project_id"]).first()
+    old_root = Path(j["old_root"])
+    new_root = Path(j["new_root"])
+
+    if project is None:
+        clear_rename_journal()
+        return
+
+    # DB already carries the new name, so the move preceded the commit and files
+    # belong at new_root; repair only if a crash left them at old_root.
+    if project.name == j["new_name"]:
+        if old_root.exists() and not new_root.exists():
+            try:
+                move_project_tree(old_root, new_root)
+            except OSError:
+                logger.exception("[ERROR] Rename reconciliation could not move %s -> %s", old_root, new_root)
+                return  # keep the journal so the next startup retries
+        clear_rename_journal()
+        return
+
+    # DB still carries the old name: finish the DB side only if the files already moved.
+    if project.name == j["old_name"]:
+        if new_root.exists() and not old_root.exists():
+            project.name = j["new_name"]
+            for img in db.query(RecordImage).all():
+                new_fp = rebase_stored_path(img.file_path, old_root, new_root)
+                if new_fp:
+                    img.file_path = new_fp
+                new_tp = rebase_stored_path(img.thumbnail_path, old_root, new_root)
+                if new_tp:
+                    img.thumbnail_path = new_tp
+            db.commit()
+            logger.warning("Completed interrupted project rename %r -> %r after restart", j["old_name"], j["new_name"])
+        # Otherwise the move never happened and the DB is consistent at the old name.
+        clear_rename_journal()
+        return
+
+    # Name matches neither side (renamed again since): the journal is stale.
+    clear_rename_journal()
 
 
 def _do_renames(moves: List[Tuple[Path, Path]]) -> List[Tuple[Path, Path]]:

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,14 @@ async def lifespan(app: FastAPI):
     init_db()
     # Refuse to serve against an un-migrated schema so the failure is loud at startup rather than a later 500 in the field
     assert_schema_at_head()
+    # Finish or discard any project rename interrupted by a crash/power loss before serving requests
+    from app.core.db import SessionLocal
+    from app.core.storage_ops import reconcile_pending_rename
+    db = SessionLocal()
+    try:
+        reconcile_pending_rename(db)
+    finally:
+        db.close()
     yield
 
 # Create FastAPI app with lifespan

--- a/tests/unit/test_project_rename_recovery.py
+++ b/tests/unit/test_project_rename_recovery.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Crash-safe recovery for an interrupted project rename.
+
+Power loss is this appliance's defining failure mode, so a rename that moves the
+on-disk tree and then commits new paths must survive a crash between the two
+steps without leaving records dangling. reconcile_pending_rename replays or
+discards the intent journal at startup; these tests cover its three branches.
+"""
+import pytest
+
+import app.core.storage_ops as so
+from app.models.project import Project
+from app.models.record import Record, RecordImage
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    """Point the journal at a writable temp data dir (default /var/lib/dtk is not writable in tests)."""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "DTK_DATA_DIR", str(tmp_path / "data"))
+    return tmp_path
+
+
+def _add_project(db, name):
+    p = Project(name=name)
+    db.add(p)
+    db.commit()
+    return p
+
+
+def _add_image(db, record_id, path):
+    img = RecordImage(
+        record_id=record_id,
+        filename=path.name,
+        file_path=str(path),
+        thumbnail_path=str(path.with_suffix(".thumb.jpg")),
+        capture_id="c1",
+        format="jpg",
+        file_size=1,
+    )
+    db.add(img)
+    db.commit()
+    return img
+
+
+@pytest.mark.unit
+def test_reconcile_finishes_db_when_files_already_moved(db_session, data_dir):
+    """Crash after the FS move but before the commit: DB still old, files at new_root -> finish the DB side."""
+    root = data_dir / "projects"
+    old_root, new_root = root / "old", root / "new"
+    new_root.mkdir(parents=True)
+    (new_root / "img.jpg").write_text("x")
+
+    p = _add_project(db_session, "old")
+    rec = Record(title="r", project_id=p.id, status="in_review", capture_mode="single")
+    db_session.add(rec)
+    db_session.commit()
+    _add_image(db_session, rec.id, old_root / "img.jpg")
+
+    so.write_rename_journal(p.id, "old", "new", old_root, new_root)
+    so.reconcile_pending_rename(db_session)
+
+    db_session.refresh(p)
+    img = db_session.query(RecordImage).first()
+    assert p.name == "new"
+    assert img.file_path == str(new_root / "img.jpg")
+    assert so.read_rename_journal() is None
+
+
+@pytest.mark.unit
+def test_reconcile_aborts_when_move_never_happened(db_session, data_dir):
+    """Crash before the FS move: DB and disk are both still old -> discard the journal, change nothing."""
+    root = data_dir / "projects"
+    old_root, new_root = root / "p", root / "p_ren"
+    old_root.mkdir(parents=True)
+
+    p = _add_project(db_session, "p")
+    so.write_rename_journal(p.id, "p", "p_ren", old_root, new_root)
+    so.reconcile_pending_rename(db_session)
+
+    db_session.refresh(p)
+    assert p.name == "p"
+    assert so.read_rename_journal() is None
+
+
+@pytest.mark.unit
+def test_reconcile_completes_move_when_db_already_renamed(db_session, data_dir):
+    """Crash after the commit but before clearing the journal: DB new, files still old -> finish the FS move."""
+    root = data_dir / "projects"
+    old_root, new_root = root / "old2", root / "new2"
+    old_root.mkdir(parents=True)
+    (old_root / "f").write_text("y")
+
+    p = _add_project(db_session, "new2")
+    so.write_rename_journal(p.id, "old2", "new2", old_root, new_root)
+    so.reconcile_pending_rename(db_session)
+
+    assert new_root.exists() and not old_root.exists()
+    assert so.read_rename_journal() is None


### PR DESCRIPTION
Record a durable rename-intent journal before moving the on-disk tree, roll the move back if the commit fails, and reconcile any journal left by a crash at startup - so a power cut between the FS move and the DB commit no longer leaves record paths dangling.