### PR TITLE
test(capture): fix 401 auth in capture integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,33 @@
+"""Shared fixtures for the hardware-gated capture integration tests."""
+import pytest
+
+
+@pytest.fixture
+def authed_client(client, db_session):
+    """TestClient authenticated as a real contributor via a get_current_user override.
+
+    The capture endpoints sit behind allow_contributor, which resolves the caller
+    through get_current_user; verify_access_token rejects the literal
+    "Bearer test_token" these tests used to send, giving a 401 before the endpoint
+    ran. Overriding the dependency is the pattern used in
+    tests/unit/test_delete_user_guards.py. The `client` fixture clears
+    dependency_overrides on teardown.
+    """
+    from app.main import app
+    from app.api.auth import get_current_user
+    from app.models.user import User
+    from app.core.security import hash_password
+
+    user = User(
+        username="capture_user",
+        email="capture_user@example.com",
+        hashed_password=hash_password("x"),
+        role="contributor",
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    app.dependency_overrides[get_current_user] = lambda: user
+    yield client

--- a/tests/integration/test_camera_capture_recapture_hardware.py
+++ b/tests/integration/test_camera_capture_recapture_hardware.py
@@ -1,13 +1,14 @@
 """
-Hardware-gated integration tests for NEH-208 recapture through the real
+Hardware-gated integration tests for recapture through the real
 /cameras/capture and /cameras/capture/dual endpoints.
 
 Mirrors the skip pattern in test_capture_integration.py: these require real
-camera hardware (Linux/Raspberry Pi) and are not the primary coverage for
-this ticket — the non-hardware-gated test_reject_recapture_full_flow.py
-carries the required assertions on this dev machine. This file verifies the
-part only the real endpoints can exercise: the capture-mode mismatch guard,
-and that a recapture leaves the original file on disk untouched.
+camera hardware (Linux/Raspberry Pi) and skip when none is connected. They are
+not the primary coverage for recapture — the non-hardware-gated
+test_reject_recapture_full_flow.py carries the required assertions on a dev
+machine. This file verifies the part only the real endpoints can exercise: the
+capture-mode mismatch guard, and that a recapture leaves the original file on
+disk untouched.
 Run with: python -m pytest tests/integration/test_camera_capture_recapture_hardware.py
 """
 import pytest
@@ -24,10 +25,10 @@ from app.models.record import Record, RecordImage
 
 
 @pytest.mark.integration
-def test_single_capture_recapture_flips_rejected_back_to_in_review(client, db_session, test_project):
+def test_single_capture_recapture_flips_rejected_back_to_in_review(authed_client, db_session, test_project, skip_if_no_camera):
     project_name = test_project.name
 
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture",
         json={
             "project_name": project_name,
@@ -35,7 +36,6 @@ def test_single_capture_recapture_flips_rejected_back_to_in_review(client, db_se
             "resolution": "medium",
             "include_resolution_in_filename": False
         },
-        headers={"Authorization": "Bearer test_token"}
     )
     assert response.status_code == 200
     record_id = response.json()["record_id"]
@@ -45,7 +45,7 @@ def test_single_capture_recapture_flips_rejected_back_to_in_review(client, db_se
     record.status = "rejected"
     db_session.commit()
 
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture",
         json={
             "project_name": project_name,
@@ -54,7 +54,6 @@ def test_single_capture_recapture_flips_rejected_back_to_in_review(client, db_se
             "include_resolution_in_filename": False,
             "record_id": record_id,
         },
-        headers={"Authorization": "Bearer test_token"}
     )
     assert response.status_code == 200, response.text
 
@@ -70,10 +69,10 @@ def test_single_capture_recapture_flips_rejected_back_to_in_review(client, db_se
 
 
 @pytest.mark.integration
-def test_dual_capture_recapture_supersedes_both_sides(client, db_session, test_project):
+def test_dual_capture_recapture_supersedes_both_sides(authed_client, db_session, test_project, skip_if_no_camera):
     project_name = test_project.name
 
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture/dual",
         json={
             "project_name": project_name,
@@ -81,7 +80,6 @@ def test_dual_capture_recapture_supersedes_both_sides(client, db_session, test_p
             "include_resolution_in_filename": False,
             "stagger_ms": 20
         },
-        headers={"Authorization": "Bearer test_token"}
     )
     assert response.status_code == 200
     record_id = response.json()["record_id"]
@@ -94,7 +92,7 @@ def test_dual_capture_recapture_supersedes_both_sides(client, db_session, test_p
     old_images = db_session.query(RecordImage).filter(RecordImage.record_id == record_id).all()
     assert len(old_images) == 2
 
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture/dual",
         json={
             "project_name": project_name,
@@ -103,7 +101,6 @@ def test_dual_capture_recapture_supersedes_both_sides(client, db_session, test_p
             "stagger_ms": 20,
             "record_id": record_id,
         },
-        headers={"Authorization": "Bearer test_token"}
     )
     assert response.status_code == 200, response.text
 
@@ -121,7 +118,7 @@ def test_dual_capture_recapture_supersedes_both_sides(client, db_session, test_p
 
 
 @pytest.mark.integration
-def test_single_capture_recapture_rejects_mode_mismatch(client, db_session, test_project):
+def test_single_capture_recapture_rejects_mode_mismatch(authed_client, db_session, test_project, skip_if_no_camera):
     """A dual-mode record can't be recaptured through the single-camera endpoint."""
     project_name = test_project.name
 
@@ -129,7 +126,7 @@ def test_single_capture_recapture_rejects_mode_mismatch(client, db_session, test
     db_session.add(rec)
     db_session.commit()
 
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture",
         json={
             "project_name": project_name,
@@ -137,7 +134,6 @@ def test_single_capture_recapture_rejects_mode_mismatch(client, db_session, test
             "resolution": "medium",
             "record_id": rec.id,
         },
-        headers={"Authorization": "Bearer test_token"}
     )
     assert response.status_code == 422, response.text
 

--- a/tests/integration/test_capture_integration.py
+++ b/tests/integration/test_capture_integration.py
@@ -2,6 +2,8 @@
 Integration tests for capture API endpoints wired to database.
 
 Tests the full flow: capture image -> save to microSD -> create database record.
+These need real camera hardware (Linux/Raspberry Pi); they skip on other
+platforms and when no camera is connected.
 Run with: python -m pytest tests/integration/test_capture_integration.py
 """
 import pytest
@@ -19,15 +21,15 @@ from app.models.project import Project
 
 
 @pytest.mark.integration
-def test_single_capture_creates_database_record(client, db_session, test_project):
+def test_single_capture_creates_database_record(authed_client, db_session, test_project, skip_if_no_camera):
     """
     Test that /cameras/capture creates a RecordImage record in database.
     """
     # Ensure project exists
     project_name = test_project.name
-    
+
     # Call capture endpoint
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture",
         json={
             "project_name": project_name,
@@ -35,20 +37,19 @@ def test_single_capture_creates_database_record(client, db_session, test_project
             "resolution": "medium",
             "include_resolution_in_filename": False
         },
-        headers={"Authorization": "Bearer test_token"}
     )
-    
+
     # Check response
     assert response.status_code == 200
     data = response.json()
     assert data["success"] is True
     assert data["file_path"] is not None
-    
+
     # Verify database record was created
     doc = db_session.query(RecordImage).filter(
         RecordImage.file_path == data["file_path"]
     ).first()
-    
+
     assert doc is not None
     assert doc.format == "jpg"
     assert doc.resolution_width is not None
@@ -69,14 +70,14 @@ def test_single_capture_creates_database_record(client, db_session, test_project
 
 
 @pytest.mark.integration
-def test_dual_capture_creates_two_database_records(client, db_session, test_project):
+def test_dual_capture_creates_two_database_records(authed_client, db_session, test_project, skip_if_no_camera):
     """
     Test that /cameras/capture/dual creates two RecordImage records.
     """
     project_name = test_project.name
-    
+
     # Call dual capture endpoint
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture/dual",
         json={
             "project_name": project_name,
@@ -84,22 +85,21 @@ def test_dual_capture_creates_two_database_records(client, db_session, test_proj
             "include_resolution_in_filename": False,
             "stagger_ms": 20
         },
-        headers={"Authorization": "Bearer test_token"}
     )
-    
+
     # Check response
     assert response.status_code == 200
     data = response.json()
     assert data["success"] is True
     assert len(data["file_paths"]) == 2
-    
+
     # Verify both database records were created
     # RecordImage has no project_id — images belong to a Record, which
     # belongs to the project.
     docs = db_session.query(RecordImage).join(Record).filter(
         Record.project_id == test_project.id
     ).all()
-    
+
     assert len(docs) >= 2
 
     dual_record = db_session.query(Record).filter(Record.id == docs[-1].record_id).first()
@@ -115,26 +115,25 @@ def test_dual_capture_creates_two_database_records(client, db_session, test_proj
 
 
 @pytest.mark.integration
-def test_captured_images_stored_locally(client, test_project, tmp_path):
+def test_captured_images_stored_locally(authed_client, test_project, tmp_path, skip_if_no_camera):
     """
     Test that captured images are actually stored on the filesystem (microSD).
     """
     project_name = test_project.name
-    
+
     # Call capture endpoint
-    response = client.post(
+    response = authed_client.post(
         "/cameras/capture",
         json={
             "project_name": project_name,
             "camera_index": 0,
             "resolution": "medium"
         },
-        headers={"Authorization": "Bearer test_token"}
     )
-    
+
     data = response.json()
     file_path = Path(data["file_path"])
-    
+
     # Verify file exists
     assert file_path.exists()
     assert file_path.stat().st_size > 0
@@ -142,37 +141,36 @@ def test_captured_images_stored_locally(client, test_project, tmp_path):
 
 
 @pytest.mark.integration
-def test_exif_data_extracted_and_saved(client, db_session, test_project):
+def test_exif_data_extracted_and_saved(authed_client, db_session, test_project, skip_if_no_camera):
     """
     Test that EXIF data from captured image is extracted and saved to database.
     """
     project_name = test_project.name
-    
-    response = client.post(
+
+    response = authed_client.post(
         "/cameras/capture",
         json={
             "project_name": project_name,
             "camera_index": 0,
             "resolution": "high"
         },
-        headers={"Authorization": "Bearer test_token"}
     )
-    
+
     assert response.status_code == 200
     data = response.json()
-    
+
     # Get database record
     doc = db_session.query(RecordImage).filter(
         RecordImage.file_path == data["file_path"]
     ).first()
-    
+
     assert doc is not None
-    
+
     # Check if EXIF data was created
     exif = db_session.query(ExifData).filter(
         ExifData.record_image_id == doc.id
     ).first()
-    
+
     # EXIF might not be present if PIL can't read it, but raw_exif should have data
     if exif:
         assert exif.raw_exif is not None or exif.make is None


### PR DESCRIPTION
## Summary

Fixes the pre-existing 401 failures in the camera-capture integration tests. They authenticated with a hardcoded `Authorization: Bearer test_token`, a literal string instead of a JWT, which `verify_access_token` rejects. As a result, every request returned 401 before reaching the endpoint. The failures were invisible on dev machines because both files use `pytest.skip` at module level on non-Linux systems.

## Changes

* Added `tests/integration/conftest.py` with an `authed_client` fixture that overrides `get_current_user` with a real contributor row, following the pattern in `tests/unit/test_delete_user_guards.py`. Removed the hardcoded auth header from all 7 tests.
* Gated every capture test on the existing `skip_if_no_camera` fixture. Without a camera, the endpoint returns `CaptureResponse(success=False)` with HTTP 200, so authentication alone would still cause the assertions to fail. The tests now run on real hardware and skip cleanly when no camera is connected.

Closes NEH-213.