### PR TITLE
feat(integrity): bound hash-check workload; legible startup schema failure

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -50,15 +50,19 @@ def get_system_logs(
 @router.get("/integrity")
 def integrity_check(
     verify_hashes:  bool = Query(default=True, description="Recompute sha256 and compare against the capture manifest"),
-    max_hash_checks: int = Query(default=0, ge=0, description="Cap on files hashed (0 = no cap)"),
+    full: bool = Query(default=False, description="Hash every manifested file. Off by default: a full sweep re-hashes every capture, which is I/O-punishing on a unit holding tens of thousands of images"),
+    max_hash_checks: int = Query(default=1000, ge=1, description="Upper bound on files hashed when not running a full sweep; a random sample is taken above this many eligible files"),
     current_user: User = Depends(allow_admin),
     db: Session        = Depends(get_db_dependency),
 ):
     """Reconcile the database against the image files and the capture manifest.
 
-    Reports images whose files are missing, image files no row or manifest
-    references, bytes that no longer match the capture-time sha256, and parentless
+    Reports images whose files are missing, image files with no row or manifest
+    reference, bytes that no longer match the capture-time sha256, and parentless
     records. Read-only and admin-only. Run after an SD re-clone or DB restore.
+
+    Hash verification defaults to a bounded random sample; pass full=true for the
+    exhaustive (and much slower) sweep.
     """
     from app.core.integrity import run_integrity_check
     from app.core import audit
@@ -66,7 +70,7 @@ def integrity_check(
     report = run_integrity_check(
         db,
         verify_hashes=verify_hashes,
-        max_hash_checks=(max_hash_checks or None),
+        max_hash_checks=(None if full else max_hash_checks),
     )
     summary = report["summary"]
     audit.log_event(
@@ -77,7 +81,9 @@ def integrity_check(
         actor=current_user.username,
         detail=(
             f"missing_files={summary['missing_files']} orphan_files={summary['orphan_files']} "
-            f"manifest_mismatches={summary['manifest_mismatches']} hashes_checked={summary['hashes_checked']}"
+            f"manifest_mismatches={summary['manifest_mismatches']} "
+            f"hashes_checked={summary['hashes_checked']}/{summary['hashes_eligible']} "
+            f"sampled={summary['hash_sampled']}"
         ),
     )
     return report

--- a/app/core/integrity.py
+++ b/app/core/integrity.py
@@ -12,6 +12,7 @@ deletes, or rewrites anything.
 import hashlib
 import json
 import logging
+import random
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -202,7 +203,13 @@ def run_integrity_check(db: Session, verify_hashes: bool = True,
     manifest_mismatches: List[dict] = []
     manifest_missing_entry: List[dict] = []
     hashes_checked = 0
+    hashes_eligible = 0
     if verify_hashes:
+        # Finding the manifest entry is cheap, so it runs over every image (a
+        # missing entry is worth reporting for all). Only the sha256 recompute is
+        # expensive, so when capped it hashes a random sample of the eligible
+        # files rather than the first N - a bounded but representative sweep.
+        eligible: List[Tuple] = []
         for img in images:
             if not img.capture_id:
                 continue
@@ -221,8 +228,14 @@ def run_integrity_check(db: Session, verify_hashes: bool = True,
                     "file_path": img.file_path,
                 })
                 continue
-            if max_hash_checks is not None and hashes_checked >= max_hash_checks:
-                continue
+            eligible.append((img, resolved, expected))
+
+        hashes_eligible = len(eligible)
+        to_hash = eligible
+        if max_hash_checks is not None and hashes_eligible > max_hash_checks:
+            to_hash = random.sample(eligible, max_hash_checks)
+
+        for img, resolved, expected in to_hash:
             try:
                 actual = _sha256(resolved)
             except OSError:
@@ -249,6 +262,8 @@ def run_integrity_check(db: Session, verify_hashes: bool = True,
         "missing_thumbnails": len(missing_thumbnails),
         "orphan_files": len(orphan_files),
         "hashes_checked": hashes_checked,
+        "hashes_eligible": hashes_eligible,
+        "hash_sampled": hashes_checked < hashes_eligible,
         "manifest_mismatches": len(manifest_mismatches),
         "manifest_missing_entry": len(manifest_missing_entry),
         "orphan_records": len(orphan_records),

--- a/app/core/schema.py
+++ b/app/core/schema.py
@@ -57,13 +57,20 @@ def assert_schema_at_head() -> None:
             current = set(MigrationContext.configure(conn).get_current_heads())
     except Exception as e:
         # An unreachable database is a distinct failure; surface it rather than mask it.
-        raise SchemaOutOfDateError(f"Could not read the database schema revision: {e}") from e
+        msg = (
+            f"Cannot start: the database is unreachable, so its schema revision could not be read ({e}). "
+            "Check that the database service is running and DATABASE_* settings are correct, then restart the backend."
+        )
+        logger.error(f"[ERROR] {msg}")
+        raise SchemaOutOfDateError(msg) from e
 
     if current == heads:
         logger.info(f"[OK] Database schema at head ({', '.join(sorted(heads)) or 'none'})")
         return
 
-    raise SchemaOutOfDateError(
-        f"Database schema is out of date: database at {sorted(current) or 'no revision'}, "
+    msg = (
+        f"Cannot start: database schema is out of date - database at {sorted(current) or 'no revision'}, "
         f"code expects head {sorted(heads)}. Run 'alembic upgrade head' (or update.sh) before starting the backend."
     )
+    logger.error(f"[ERROR] {msg}")
+    raise SchemaOutOfDateError(msg)

--- a/tests/integration/test_capture_integration.py
+++ b/tests/integration/test_capture_integration.py
@@ -2,8 +2,7 @@
 Integration tests for capture API endpoints wired to database.
 
 Tests the full flow: capture image -> save to microSD -> create database record.
-These need real camera hardware (Linux/Raspberry Pi); they skip on other
-platforms and when no camera is connected.
+These need camera hardware (Linux/Raspberry Pi); they skip on other platforms and when no camera is connected.
 Run with: python -m pytest tests/integration/test_capture_integration.py
 """
 import pytest

--- a/tests/unit/test_integrity_hash_sampling.py
+++ b/tests/unit/test_integrity_hash_sampling.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""The integrity check's hash verification must be bounded by default.
+
+A full sweep re-hashes every stored image, which is I/O-punishing on a unit
+holding tens of thousands of captures. run_integrity_check must hash only a
+bounded (random) sample when max_hash_checks is set, and everything eligible
+only when it is None (the explicit full-sweep opt-in).
+"""
+import hashlib
+import json
+
+import pytest
+
+from app.core.integrity import run_integrity_check
+from app.models.project import Project
+from app.models.record import Record, RecordImage
+
+
+def _seed_captures(db_session, projects_dir, n):
+    proj_dir = projects_dir / "proj"
+    (proj_dir / "images").mkdir(parents=True, exist_ok=True)
+    (proj_dir / "metadata").mkdir(parents=True, exist_ok=True)
+
+    project = Project(name="proj")
+    db_session.add(project)
+    db_session.commit()
+    record = Record(title="r", project_id=project.id, status="in_review", capture_mode="single")
+    db_session.add(record)
+    db_session.commit()
+
+    manifest_lines = []
+    for i in range(n):
+        rel = f"images/img_{i}.jpg"
+        fpath = proj_dir / rel
+        fpath.write_bytes(f"data-{i}".encode())
+        sha = hashlib.sha256(fpath.read_bytes()).hexdigest()
+        manifest_lines.append(json.dumps({
+            "capture_id": f"c{i}",
+            "files": [{"sha256": sha, "relative_path": rel}],
+        }))
+        db_session.add(RecordImage(
+            record_id=record.id,
+            filename=f"img_{i}.jpg",
+            file_path=str(fpath),
+            capture_id=f"c{i}",
+            format="jpg",
+            file_size=1,
+        ))
+    (proj_dir / "metadata" / "manifest.jsonl").write_text("\n".join(manifest_lines), encoding="utf-8")
+    db_session.commit()
+
+
+@pytest.mark.unit
+def test_hash_check_is_bounded_and_sampled(db_session, override_projects_root):
+    _seed_captures(db_session, override_projects_root, n=8)
+
+    report = run_integrity_check(db_session, verify_hashes=True, max_hash_checks=3)
+    summary = report["summary"]
+
+    assert summary["hashes_eligible"] == 8
+    assert summary["hashes_checked"] == 3
+    assert summary["hash_sampled"] is True
+
+
+@pytest.mark.unit
+def test_full_sweep_hashes_everything(db_session, override_projects_root):
+    _seed_captures(db_session, override_projects_root, n=8)
+
+    report = run_integrity_check(db_session, verify_hashes=True, max_hash_checks=None)
+    summary = report["summary"]
+
+    assert summary["hashes_eligible"] == 8
+    assert summary["hashes_checked"] == 8
+    assert summary["hash_sampled"] is False


### PR DESCRIPTION
Default the integrity check to a bounded random hash sample (max_hash_checks, default 1000) with an explicit full=true opt-in for the exhaustive sweep, so a default run no longer re-hashes every capture on a full SD. Log a clear, actionable message before aborting startup when the DB is unreachable or the schema is behind head.